### PR TITLE
Resilient WebSocketChannel during disconnection

### DIFF
--- a/src/OpenClaw.Channels/WebSocketChannel.cs
+++ b/src/OpenClaw.Channels/WebSocketChannel.cs
@@ -334,7 +334,23 @@ public sealed class WebSocketChannel : IChannelAdapter
                 }
 
                 var memory = buffer.AsMemory(total, buffer.Length - total);
-                var result = await ws.ReceiveAsync(memory, ct);
+                ValueWebSocketReceiveResult result;
+                try
+                {
+                    result = await ws.ReceiveAsync(memory, ct);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    return null;
+                }
+                catch (ObjectDisposedException)
+                {
+                    return null;
+                }
+                catch (WebSocketException)
+                {
+                    return null;
+                }
 
                 if (result.MessageType == WebSocketMessageType.Close)
                     return null;

--- a/src/OpenClaw.Tests/TestWebSocket.cs
+++ b/src/OpenClaw.Tests/TestWebSocket.cs
@@ -7,6 +7,7 @@ internal sealed class TestWebSocket : WebSocket
 {
     private readonly ConcurrentQueue<(byte[] Data, WebSocketMessageType Type, bool End)> _receive = new();
     private readonly ConcurrentQueue<byte[]> _sent = new();
+    private readonly ConcurrentQueue<Exception> _receiveExceptions = new();
 
     private WebSocketState _state = WebSocketState.Open;
 
@@ -20,6 +21,9 @@ internal sealed class TestWebSocket : WebSocket
 
     public void QueueClose()
         => _receive.Enqueue((Array.Empty<byte>(), WebSocketMessageType.Close, true));
+
+    public void QueueReceiveException(Exception exception)
+        => _receiveExceptions.Enqueue(exception);
 
     public override WebSocketCloseStatus? CloseStatus { get; }
     public override string? CloseStatusDescription { get; }
@@ -44,6 +48,9 @@ internal sealed class TestWebSocket : WebSocket
 
     public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
     {
+        if (_receiveExceptions.TryDequeue(out var exception))
+            return Task.FromException<WebSocketReceiveResult>(exception);
+
         if (!_receive.TryDequeue(out var next))
             return Task.FromResult(new WebSocketReceiveResult(0, WebSocketMessageType.Close, true));
 

--- a/src/OpenClaw.Tests/WebSocketChannelTests.cs
+++ b/src/OpenClaw.Tests/WebSocketChannelTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.WebSockets;
 using System.Text.Json;
 using OpenClaw.Channels;
 using OpenClaw.Core.Models;
@@ -74,6 +75,26 @@ public sealed class WebSocketChannelTests
 
         Assert.NotNull(received);
         Assert.Equal("legacy", received!.Text);
+    }
+
+    [Fact]
+    public async Task HandleConnectionAsync_IgnoresPrematureRemoteCloseDuringReceive()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig { MaxMessageBytes = 1024 });
+        var ws = new TestWebSocket();
+
+        ws.QueueReceiveException(new WebSocketException(WebSocketError.ConnectionClosedPrematurely));
+
+        var observed = false;
+        channel.OnMessageReceived += (_, _) =>
+        {
+            observed = true;
+            return ValueTask.CompletedTask;
+        };
+
+        await channel.HandleConnectionAsync(ws, "client", IPAddress.Loopback, CancellationToken.None);
+
+        Assert.False(observed);
     }
 
     [Fact]


### PR DESCRIPTION
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style implementation of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed locally (`dotnet test`)
- [ ] I have updated the documentation (README.md, comments) if required
- [ ] I have checked for security implications (input validation, authorization)
