### PR TITLE
Replace StringContent with Stream-based Utf8JsonContent.

### DIFF
--- a/src/OpenClaw.Agent/Tools/CalendarTool.cs
+++ b/src/OpenClaw.Agent/Tools/CalendarTool.cs
@@ -1,8 +1,8 @@
-using System.Text;
-using System.Text.Json;
 using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Http;
 using OpenClaw.Core.Plugins;
+using System.Text;
+using System.Text.Json;
 
 namespace OpenClaw.Agent.Tools;
 
@@ -166,13 +166,13 @@ public sealed class CalendarTool : ITool, IDisposable
         // Default end = start + 1 hour
         end ??= DateTimeOffset.Parse(start).AddHours(1).ToString("o");
 
-        var body = BuildEventJson(title, start, end,
+        using var content = BuildEventJsonContent(title, start, end,
             args.TryGetProperty("description", out var desc) ? desc.GetString() : null,
             args.TryGetProperty("location", out var loc) ? loc.GetString() : null);
 
         var url = $"{CalendarApiBase}/calendars/{Uri.EscapeDataString(_config.CalendarId)}/events";
         using var request = CreateAuthRequest(HttpMethod.Post, url);
-        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        request.Content = content;
 
         using var response = await _http.SendAsync(request, ct);
         if (!response.IsSuccessStatusCode)
@@ -200,11 +200,11 @@ public sealed class CalendarTool : ITool, IDisposable
         var description = args.TryGetProperty("description", out var desc) ? desc.GetString() : null;
         var location = args.TryGetProperty("location", out var loc) ? loc.GetString() : null;
 
-        var body = BuildPartialEventJson(title, start, end, description, location);
+        using var content = BuildPartialEventJsonContent(title, start, end, description, location);
 
         var url = $"{CalendarApiBase}/calendars/{Uri.EscapeDataString(_config.CalendarId)}/events/{Uri.EscapeDataString(eventId)}";
         using var request = CreateAuthRequest(HttpMethod.Patch, url);
-        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        request.Content = content;
 
         using var response = await _http.SendAsync(request, ct);
         if (!response.IsSuccessStatusCode)
@@ -356,9 +356,9 @@ public sealed class CalendarTool : ITool, IDisposable
         return Encoding.UTF8.GetString(ms.ToArray());
     }
 
-    private static string BuildEventJson(string title, string start, string end, string? description, string? location)
+    private static Utf8JsonContent BuildEventJsonContent(string title, string start, string end, string? description, string? location)
     {
-        using var ms = new System.IO.MemoryStream();
+        var ms = new System.IO.MemoryStream();
         using (var w = new Utf8JsonWriter(ms))
         {
             w.WriteStartObject();
@@ -373,12 +373,14 @@ public sealed class CalendarTool : ITool, IDisposable
             if (location is not null) w.WriteString("location", location);
             w.WriteEndObject();
         }
-        return Encoding.UTF8.GetString(ms.ToArray());
+
+        ms.Position = 0L;
+        return new Utf8JsonContent(ms);
     }
 
-    private static string BuildPartialEventJson(string? title, string? start, string? end, string? description, string? location)
+    private static Utf8JsonContent BuildPartialEventJsonContent(string? title, string? start, string? end, string? description, string? location)
     {
-        using var ms = new System.IO.MemoryStream();
+        var ms = new System.IO.MemoryStream();
         using (var w = new Utf8JsonWriter(ms))
         {
             w.WriteStartObject();
@@ -389,7 +391,8 @@ public sealed class CalendarTool : ITool, IDisposable
             if (location is not null) w.WriteString("location", location);
             w.WriteEndObject();
         }
-        return Encoding.UTF8.GetString(ms.ToArray());
+        ms.Position = 0L;
+        return new Utf8JsonContent(ms);
     }
 
     private static string Base64UrlEncode(byte[] data)

--- a/src/OpenClaw.Agent/Tools/ImageGenTool.cs
+++ b/src/OpenClaw.Agent/Tools/ImageGenTool.cs
@@ -74,9 +74,8 @@ public sealed class ImageGenTool : ITool, IDisposable
 
         using var request = new HttpRequestMessage(HttpMethod.Post, url);
         request.Headers.Add("Authorization", $"Bearer {apiKey}");
-
-        var body = BuildRequestJson(prompt, size, quality);
-        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        using var content = BuildRequestJsonContent(prompt, size, quality);
+        request.Content = content;
 
         try
         {
@@ -119,9 +118,9 @@ public sealed class ImageGenTool : ITool, IDisposable
     }
 
     /// <summary>AOT-safe JSON builder for the image gen request.</summary>
-    private string BuildRequestJson(string prompt, string size, string quality)
+    private Utf8JsonContent BuildRequestJsonContent(string prompt, string size, string quality)
     {
-        using var ms = new System.IO.MemoryStream();
+        var ms = new System.IO.MemoryStream();
         using (var writer = new Utf8JsonWriter(ms))
         {
             writer.WriteStartObject();
@@ -133,7 +132,8 @@ public sealed class ImageGenTool : ITool, IDisposable
             writer.WriteString("response_format", "url");
             writer.WriteEndObject();
         }
-        return Encoding.UTF8.GetString(ms.ToArray());
+        ms.Position = 0L;
+        return new Utf8JsonContent(ms);
     }
 
     private string? ResolveKey() => SecretResolver.Resolve(_config.ApiKey);

--- a/src/OpenClaw.Agent/Tools/Utf8JsonContent.cs
+++ b/src/OpenClaw.Agent/Tools/Utf8JsonContent.cs
@@ -1,0 +1,24 @@
+﻿using System.Net.Http.Headers;
+using System.Text;
+
+namespace OpenClaw.Agent.Tools
+{
+    sealed class Utf8JsonContent : StreamContent
+    {
+        private readonly long _length;
+        private static readonly MediaTypeHeaderValue _uft8_contentType = new("application/json", Encoding.UTF8.WebName);
+
+        public Utf8JsonContent(MemoryStream content)
+            : base(content)
+        {
+            _length = content.Length;
+            Headers.ContentType = _uft8_contentType;
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _length;
+            return true;
+        }
+    }
+}

--- a/src/OpenClaw.Agent/Tools/WebSearchTool.cs
+++ b/src/OpenClaw.Agent/Tools/WebSearchTool.cs
@@ -82,10 +82,8 @@ public sealed class WebSearchTool : ITool, IDisposable
         };
 
         // Build JSON manually for AOT safety
-        request.Content = new StringContent(
-            BuildSearchJson(body),
-            Encoding.UTF8,
-            "application/json");
+        using var content = BuildSearchJsonContent(body);
+        request.Content = content;
 
         using var response = await _http.SendAsync(request, ct);
         response.EnsureSuccessStatusCode();
@@ -182,9 +180,9 @@ public sealed class WebSearchTool : ITool, IDisposable
     public void Dispose() => _http.Dispose();
 
     /// <summary>AOT-safe JSON builder for simple search request bodies.</summary>
-    private static string BuildSearchJson(Dictionary<string, object?> data)
+    private static Utf8JsonContent BuildSearchJsonContent(Dictionary<string, object?> data)
     {
-        using var ms = new System.IO.MemoryStream();
+        var ms = new System.IO.MemoryStream();
         using (var writer = new System.Text.Json.Utf8JsonWriter(ms))
         {
             writer.WriteStartObject();
@@ -202,6 +200,7 @@ public sealed class WebSearchTool : ITool, IDisposable
             }
             writer.WriteEndObject();
         }
-        return Encoding.UTF8.GetString(ms.ToArray());
+        ms.Position = 0L;
+        return new Utf8JsonContent(ms);
     }
 }

--- a/src/OpenClaw.Tests/Utf8JsonContentTest.cs
+++ b/src/OpenClaw.Tests/Utf8JsonContentTest.cs
@@ -1,0 +1,27 @@
+﻿using System.Text;
+using Xunit;
+
+namespace OpenClaw.Tests
+{
+    public sealed class Utf8JsonContentTest
+    {
+        [Fact]
+        public async Task CopyToAsyncTest()
+        {
+            var jsonString = """
+                {"key":"value"}
+                """;
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(jsonString))
+            {
+                Position = 0L
+            };
+
+            using var jsonContent = new Agent.Tools.Utf8JsonContent(stream);
+            var actualStream = new MemoryStream();
+            await jsonContent.CopyToAsync(actualStream);
+            var actual = Encoding.UTF8.GetString(actualStream.ToArray());
+
+            Assert.Equal(jsonString, actual);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Converting UTF-8 JSON content generated by Utf8JsonWriter to a string incurs overhead, and converting the string to StringContent incurs additional overhead. We can eliminate the intermediate string to avoid these two unnecessary overheads.

 
## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style implementation of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed locally (`dotnet test`)
- [ ] I have updated the documentation (README.md, comments) if required
- [ ] I have checked for security implications (input validation, authorization)

## Screenshots (if applicable)

[Add screenshots for UI/UX changes]

## Benchmarks (if applicable)

[Did this change affect performance? Provide benchmark results.]
