### PR TITLE
fix gateway LLM DI constructor ambiguity

### DIFF
--- a/src/OpenClaw.Gateway/GatewayLlmExecutionService.cs
+++ b/src/OpenClaw.Gateway/GatewayLlmExecutionService.cs
@@ -89,7 +89,7 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
         _logger = logger;
     }
 
-    public GatewayLlmExecutionService(
+    internal GatewayLlmExecutionService(
         GatewayConfig config,
         LlmProviderRegistry registry,
         ProviderPolicyService policyService,
@@ -110,7 +110,7 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
     {
     }
 
-    public GatewayLlmExecutionService(
+    internal GatewayLlmExecutionService(
         GatewayConfig config,
         LlmProviderRegistry registry,
         ProviderPolicyService policyService,

--- a/src/OpenClaw.Tests/CoreServicesExtensionsTests.cs
+++ b/src/OpenClaw.Tests/CoreServicesExtensionsTests.cs
@@ -46,4 +46,44 @@ public sealed class CoreServicesExtensionsTests
         Assert.NotNull(provider.GetRequiredService<LearningService>());
         Assert.NotNull(provider.GetRequiredService<ISessionAdminStore>());
     }
+
+    [Fact]
+    public void AddOpenClawCoreServices_WithSecurityServices_AllowsGatewayLlmExecutionServiceToResolveDuringValidation()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), "openclaw-core-services-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempPath);
+
+        var config = new GatewayConfig
+        {
+            Memory = new MemoryConfig
+            {
+                StoragePath = tempPath
+            }
+        };
+        var startup = new GatewayStartupContext
+        {
+            Config = config,
+            RuntimeState = new GatewayRuntimeState
+            {
+                RequestedMode = "jit",
+                EffectiveMode = GatewayRuntimeMode.Jit,
+                DynamicCodeSupported = true
+            },
+            IsNonLoopbackBind = false
+        };
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddOpenClawCoreServices(startup);
+        services.AddOpenClawSecurityServices(startup);
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        Assert.NotNull(provider.GetRequiredService<GatewayLlmExecutionService>());
+    }
 }

--- a/src/OpenClaw.Tests/CoreServicesExtensionsTests.cs
+++ b/src/OpenClaw.Tests/CoreServicesExtensionsTests.cs
@@ -15,36 +15,42 @@ public sealed class CoreServicesExtensionsTests
     {
         var tempPath = Path.Combine(Path.GetTempPath(), "openclaw-core-services-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempPath);
-
-        var config = new GatewayConfig
+        try
         {
-            Memory = new MemoryConfig
+            var config = new GatewayConfig
             {
-                StoragePath = tempPath
-            }
-        };
-        var startup = new GatewayStartupContext
+                Memory = new MemoryConfig
+                {
+                    StoragePath = tempPath
+                }
+            };
+            var startup = new GatewayStartupContext
+            {
+                Config = config,
+                RuntimeState = new GatewayRuntimeState
+                {
+                    RequestedMode = "jit",
+                    EffectiveMode = GatewayRuntimeMode.Jit,
+                    DynamicCodeSupported = true
+                },
+                IsNonLoopbackBind = false
+            };
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOptions();
+            services.AddOpenClawCoreServices(startup);
+
+            using var provider = services.BuildServiceProvider();
+
+            Assert.Same(config.Learning, provider.GetRequiredService<LearningConfig>());
+            Assert.NotNull(provider.GetRequiredService<LearningService>());
+            Assert.NotNull(provider.GetRequiredService<ISessionAdminStore>());
+        }
+        finally
         {
-            Config = config,
-            RuntimeState = new GatewayRuntimeState
-            {
-                RequestedMode = "jit",
-                EffectiveMode = GatewayRuntimeMode.Jit,
-                DynamicCodeSupported = true
-            },
-            IsNonLoopbackBind = false
-        };
-
-        var services = new ServiceCollection();
-        services.AddLogging();
-        services.AddOptions();
-        services.AddOpenClawCoreServices(startup);
-
-        using var provider = services.BuildServiceProvider();
-
-        Assert.Same(config.Learning, provider.GetRequiredService<LearningConfig>());
-        Assert.NotNull(provider.GetRequiredService<LearningService>());
-        Assert.NotNull(provider.GetRequiredService<ISessionAdminStore>());
+            DeleteDirectoryIfPresent(tempPath);
+        }
     }
 
     [Fact]
@@ -52,38 +58,59 @@ public sealed class CoreServicesExtensionsTests
     {
         var tempPath = Path.Combine(Path.GetTempPath(), "openclaw-core-services-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempPath);
-
-        var config = new GatewayConfig
+        try
         {
-            Memory = new MemoryConfig
+            var config = new GatewayConfig
             {
-                StoragePath = tempPath
-            }
-        };
-        var startup = new GatewayStartupContext
-        {
-            Config = config,
-            RuntimeState = new GatewayRuntimeState
+                Memory = new MemoryConfig
+                {
+                    StoragePath = tempPath
+                }
+            };
+            var startup = new GatewayStartupContext
             {
-                RequestedMode = "jit",
-                EffectiveMode = GatewayRuntimeMode.Jit,
-                DynamicCodeSupported = true
-            },
-            IsNonLoopbackBind = false
-        };
+                Config = config,
+                RuntimeState = new GatewayRuntimeState
+                {
+                    RequestedMode = "jit",
+                    EffectiveMode = GatewayRuntimeMode.Jit,
+                    DynamicCodeSupported = true
+                },
+                IsNonLoopbackBind = false
+            };
 
-        var services = new ServiceCollection();
-        services.AddLogging();
-        services.AddOptions();
-        services.AddOpenClawCoreServices(startup);
-        services.AddOpenClawSecurityServices(startup);
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOptions();
+            services.AddOpenClawCoreServices(startup);
+            services.AddOpenClawSecurityServices(startup);
 
-        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+            using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+            {
+                ValidateOnBuild = true,
+                ValidateScopes = true
+            });
+
+            Assert.NotNull(provider.GetRequiredService<GatewayLlmExecutionService>());
+        }
+        finally
         {
-            ValidateOnBuild = true,
-            ValidateScopes = true
-        });
+            DeleteDirectoryIfPresent(tempPath);
+        }
+    }
 
-        Assert.NotNull(provider.GetRequiredService<GatewayLlmExecutionService>());
+    private static void DeleteDirectoryIfPresent(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
     }
 }


### PR DESCRIPTION
## Summary
- make the `LlmProviderRegistry` compatibility constructors on `GatewayLlmExecutionService` non-public so DI only sees the model-profile constructor path
- keep the compatibility overloads available to internal call sites and tests via `InternalsVisibleTo`
- add a regression test that builds the validated service provider and resolves `GatewayLlmExecutionService`

## Why
`main` currently fails during gateway startup because `AddSingleton<GatewayLlmExecutionService>()` can match both the model-profile constructor and the provider-registry compatibility constructor. With `PromptCacheCoordinator` and `PromptCacheWarmRegistry` registered, the container reports an `AmbiguousConstructorException` during `builder.Build()`.

## Validation
- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj`
- `ASPNETCORE_ENVIRONMENT=Development dotnet run --project src/OpenClaw.Gateway/OpenClaw.Gateway.csproj` (startup remains healthy until the timeout instead of failing in DI validation)

## Notes
This replaces the intent of #46 on top of current `main`, without carrying over the unrelated Companion and admin SSE changes from that branch.