### PR TITLE
Tickerq refactor cronscheduler

### DIFF
--- a/src/OpenClaw.Core/OpenClaw.Core.csproj
+++ b/src/OpenClaw.Core/OpenClaw.Core.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.11" />
     <PackageReference Include="Spectre.Console" Version="0.54.0" />
+    <PackageReference Include="TickerQ" Version="10.3.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="../../compat/public-smoke.json" LogicalName="OpenClaw.Core.Compatibility.public-smoke.json" />

--- a/src/OpenClaw.Core/Pipeline/CronScheduler.cs
+++ b/src/OpenClaw.Core/Pipeline/CronScheduler.cs
@@ -1,17 +1,15 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Channels;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using NCrontab;
 using OpenClaw.Core.Models;
+using TickerQ.Utilities;
 
 namespace OpenClaw.Core.Pipeline;
 
 /// <summary>
-/// A simple background service that checks registered cron jobs every minute
-/// and publishes an InboundMessage to the pipeline.
+/// Dispatches configured cron jobs when invoked by the host scheduler.
 /// </summary>
-public sealed class CronScheduler : BackgroundService
+public sealed class CronScheduler
 {
     private static readonly TimeSpan MaxRunningDuration = TimeSpan.FromHours(6);
 
@@ -27,7 +25,7 @@ public sealed class CronScheduler : BackgroundService
         _pipelineChannel = pipelineChannel;
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    public async Task RunStartupJobsAsync(CancellationToken stoppingToken)
     {
         var initialJobs = _jobSource.GetJobs();
         if (initialJobs.Count == 0)
@@ -35,10 +33,8 @@ public sealed class CronScheduler : BackgroundService
             _logger.LogInformation("Cron Scheduler started with no jobs. Waiting for live cron registrations.");
         }
 
-        using var timer = new PeriodicTimer(TimeSpan.FromMinutes(1));
         _logger.LogInformation("Cron Scheduler started. Monitoring {Count} initial jobs.", initialJobs.Count);
 
-        // Optional: run selected jobs immediately once on startup (useful for testing / boot-time reports)
         foreach (var job in initialJobs)
         {
             if (!job.RunOnStartup)
@@ -55,41 +51,39 @@ public sealed class CronScheduler : BackgroundService
                 _logger.LogWarning(ex, "Failed to run cron job '{JobName}' on startup", job.Name);
             }
         }
+    }
 
-        while (await timer.WaitForNextTickAsync(stoppingToken))
+    public async Task RunTickAsync(CancellationToken stoppingToken)
+    {
+        CleanupStaleRunningJobs(DateTimeOffset.UtcNow);
+        var jobs = _jobSource.GetJobs();
+        if (jobs.Count == 0)
+            return;
+
+        var utcNow = DateTimeOffset.UtcNow;
+
+        foreach (var job in jobs)
         {
-            CleanupStaleRunningJobs(DateTimeOffset.UtcNow);
-            var jobs = _jobSource.GetJobs();
-            if (jobs.Count == 0)
-                continue;
-
-            var utcNow = DateTimeOffset.UtcNow;
-
-            // Re-evaluate jobs at the top of the minute
-            foreach (var job in jobs)
+            var now = utcNow;
+            if (!string.IsNullOrWhiteSpace(job.Timezone))
             {
-                // Convert to job-specific timezone if configured, otherwise use UTC
-                var now = utcNow;
-                if (!string.IsNullOrWhiteSpace(job.Timezone))
+                try
                 {
-                    try
-                    {
-                        var tz = TimeZoneInfo.FindSystemTimeZoneById(job.Timezone);
-                        now = TimeZoneInfo.ConvertTime(utcNow, tz);
-                    }
-                    catch (TimeZoneNotFoundException)
-                    {
-                        _logger.LogWarning("Cron job '{JobName}' has invalid timezone '{Timezone}', falling back to UTC.",
-                            job.Name, job.Timezone);
-                    }
+                    var tz = TimeZoneInfo.FindSystemTimeZoneById(job.Timezone);
+                    now = TimeZoneInfo.ConvertTime(utcNow, tz);
                 }
-
-                if (IsTime(job.CronExpression, now))
+                catch (TimeZoneNotFoundException)
                 {
-                    _logger.LogInformation("Triggering cron job '{JobName}' at {Time}", job.Name, now);
-                    await EnqueueJobIfNotRunningAsync(job, stoppingToken);
+                    _logger.LogWarning("Cron job '{JobName}' has invalid timezone '{Timezone}', falling back to UTC.",
+                        job.Name, job.Timezone);
                 }
             }
+
+            if (!IsTime(job.CronExpression, now))
+                continue;
+
+            _logger.LogInformation("Triggering cron job '{JobName}' at {Time}", job.Name, now);
+            await EnqueueJobIfNotRunningAsync(job, stoppingToken);
         }
     }
 
@@ -158,30 +152,32 @@ public sealed class CronScheduler : BackgroundService
     }
 
     /// <summary>
-    /// Evaluates a standard 5-field cron expression against a given time.
-    /// (Minutes, Hours, Day of Month, Month, Day of Week)
+    /// Evaluates a cron expression against a given time using TickerQ parsing semantics.
     /// </summary>
     public static bool IsTime(string expression, DateTimeOffset time)
     {
-        if (string.IsNullOrWhiteSpace(expression)) return false;
+        if (string.IsNullOrWhiteSpace(expression))
+            return false;
 
-        expression = NormalizeExpression(expression);
+        var normalizedExpression = NormalizeExpression(expression, time);
+        if (!CronExpression.TryParse(normalizedExpression, out var cronExpression))
+            return false;
 
-        var parts = expression.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length != 5) return false;
+        var schedule = CrontabSchedule.Parse(cronExpression.Value, new CrontabSchedule.ParseOptions
+        {
+            IncludingSeconds = true
+        });
 
-        var minMatch = MatchField(parts[0], time.Minute, 0, 59, time);
-        var hourMatch = MatchField(parts[1], time.Hour, 0, 23, time);
-        var domMatch = MatchField(parts[2], time.Day, 1, 31, time);
-        var monthMatch = MatchField(parts[3], time.Month, 1, 12, time);
-        var dowMatch = MatchField(parts[4], (int)time.DayOfWeek, 0, 6, time);
+        var localTime = DateTime.SpecifyKind(time.DateTime, DateTimeKind.Unspecified);
+        var previousSecond = localTime.AddSeconds(-1);
+        var nextOccurrence = schedule.GetNextOccurrence(previousSecond);
 
-        return minMatch && hourMatch && domMatch && monthMatch && dowMatch;
+        return nextOccurrence == localTime;
     }
 
-    private static string NormalizeExpression(string expression)
+    private static string NormalizeExpression(string expression, DateTimeOffset time)
     {
-        return expression.Trim().ToLowerInvariant() switch
+        var normalized = expression.Trim().ToLowerInvariant() switch
         {
             "@hourly" => "0 * * * *",
             "@daily" => "0 0 * * *",
@@ -189,56 +185,19 @@ public sealed class CronScheduler : BackgroundService
             "@monthly" => "0 0 1 * *",
             _ => expression
         };
-    }
 
-    private static bool MatchField(string field, int value, int minValue, int maxValue, DateTimeOffset time)
-    {
-        if (field == "*") return true;
-
-        if (field == "L")
-            return value == DateTime.DaysInMonth(time.Year, time.Month);
-
-        if (int.TryParse(field, out var exact))
-            return exact == value;
-
-        if (field.Contains(','))
-            return field.Split(',').Any(option => MatchField(option, value, minValue, maxValue, time));
-
-        if (field.Contains('/'))
+        var parts = normalized.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var dayOfMonthIndex = parts.Length switch
         {
-            var stepParts = field.Split('/');
-            if (stepParts.Length == 2 && int.TryParse(stepParts[1], out var step) && step > 0)
-            {
-                var range = stepParts[0];
-                if (range == "*")
-                    return (value - minValue) % step == 0;
+            5 => 2,
+            6 => 3,
+            _ => -1
+        };
 
-                if (TryParseRange(range, out var start, out var end))
-                {
-                    if (!IsValueInRange(value, start, end))
-                        return false;
+        if (dayOfMonthIndex >= 0 && string.Equals(parts[dayOfMonthIndex], "l", StringComparison.OrdinalIgnoreCase))
+            parts[dayOfMonthIndex] = DateTime.DaysInMonth(time.Year, time.Month).ToString();
 
-                    return (value - start) % step == 0;
-                }
-            }
-        }
-
-        if (TryParseRange(field, out var rangeStart, out var rangeEnd))
-            return IsValueInRange(value, rangeStart, rangeEnd);
-
-        return false;
-    }
-
-    private static bool TryParseRange(string field, out int start, out int end)
-    {
-        start = 0;
-        end = 0;
-        var rangeParts = field.Split('-');
-        if (rangeParts.Length != 2)
-            return false;
-
-        return int.TryParse(rangeParts[0], out start)
-            && int.TryParse(rangeParts[1], out end);
+        return string.Join(' ', parts);
     }
 
     private void CleanupStaleRunningJobs(DateTimeOffset nowUtc)
@@ -256,13 +215,5 @@ public sealed class CronScheduler : BackgroundService
                     nowUtc - kvp.Value);
             }
         }
-    }
-
-    private static bool IsValueInRange(int value, int start, int end)
-    {
-        if (start <= end)
-            return value >= start && value <= end;
-
-        return value >= start || value <= end;
     }
 }

--- a/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
 using OpenClaw.Channels;
 using OpenClaw.Agent;
 using OpenClaw.Agent.Execution;
@@ -13,7 +14,10 @@ using OpenClaw.Core.Sessions;
 using OpenClaw.Gateway.Bootstrap;
 using OpenClaw.Gateway.Extensions;
 using OpenClaw.Gateway.Models;
+using OpenClaw.Gateway.Pipeline;
 using OpenClaw.Gateway.PromptCaching;
+using TickerQ.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace OpenClaw.Gateway.Composition;
 
@@ -23,6 +27,7 @@ internal static class CoreServicesExtensions
     {
         var config = startup.Config;
 
+        services.TryAddSingleton<IConfiguration>(_ => new ConfigurationBuilder().Build());
         services.AddSingleton(config);
         services.AddSingleton(config.Learning);
         services.AddSingleton(typeof(AllowlistSemantics), AllowlistPolicy.ParseSemantics(config.Channels.AllowlistSemantics));
@@ -98,6 +103,8 @@ internal static class CoreServicesExtensions
             return svc;
         });
         services.AddSingleton<HeartbeatService>();
+        services.AddTickerQ();
+        services.AddSingleton<CronSchedulerTickerFunction>();
         services.AddSingleton<GatewayAutomationService>();
         services.AddSingleton<LearningService>();
         services.AddSingleton<ICronJobSource, GatewayCronJobSource>();
@@ -121,6 +128,13 @@ internal static class CoreServicesExtensions
         services.AddSingleton<IMemoryRetentionCoordinator>(sp => sp.GetRequiredService<MemoryRetentionSweeperService>());
         services.AddHostedService(sp => sp.GetRequiredService<MemoryRetentionSweeperService>());
         services.AddSingleton<MessagePipeline>();
+        services.AddSingleton(sp =>
+            new CronScheduler(
+                sp.GetRequiredService<ICronJobSource>(),
+                sp.GetRequiredService<ILogger<CronScheduler>>(),
+                sp.GetRequiredService<MessagePipeline>().InboundWriter));
+        services.AddSingleton<CronSchedulerStartupService>();
+        services.AddHostedService(sp => sp.GetRequiredService<CronSchedulerStartupService>());
         services.AddSingleton(new WebSocketChannel(config.WebSocket));
         services.AddSingleton<ChatCommandProcessor>();
         services.AddSingleton<GatewayLlmExecutionService>();

--- a/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs
@@ -154,7 +154,7 @@ internal static class RuntimeInitializationExtensions
         skillWatcher.Start(app.Lifetime.ApplicationStopping);
 
         await services.AutomationService.RefreshCacheAsync(app.Lifetime.ApplicationStopping);
-        var cronTask = StartCronIfEnabled(loggerFactory, services.Pipeline, services.CronJobSource, app.Lifetime.ApplicationStopping);
+        var cronTask = app.Services.GetRequiredService<CronScheduler>();
         StartNativeEventBridges(config, loggerFactory, services.Pipeline, app.Lifetime.ApplicationStopping);
 
         var profile = app.Services.GetRequiredService<IRuntimeProfile>();
@@ -693,20 +693,6 @@ internal static class RuntimeInitializationExtensions
             costChecker: costChecker));
 
         return new MiddlewarePipeline(middlewareList);
-    }
-
-    private static CronScheduler? StartCronIfEnabled(
-        ILoggerFactory loggerFactory,
-        MessagePipeline pipeline,
-        ICronJobSource jobSource,
-        CancellationToken stoppingToken)
-    {
-        var logger = loggerFactory.CreateLogger<CronScheduler>();
-        var cronTask = new CronScheduler(jobSource, logger, pipeline.InboundWriter);
-        _ = cronTask.StartAsync(stoppingToken).ContinueWith(
-            t => logger.LogError(t.Exception!.InnerException, "CronScheduler failed to start"),
-            TaskContinuationOptions.OnlyOnFaulted);
-        return cronTask;
     }
 
     private static void StartNativeEventBridges(

--- a/src/OpenClaw.Gateway/LearningService.cs
+++ b/src/OpenClaw.Gateway/LearningService.cs
@@ -93,7 +93,7 @@ internal sealed class LearningService
             return;
 
         var lastUser = session.History.LastOrDefault(static turn => string.Equals(turn.Role, "user", StringComparison.OrdinalIgnoreCase));
-        var lastAssistant = session.History.LastOrDefault(static turn => string.Equals(turn.Role, "assistant", StringComparison.OrdinalIgnoreCase));
+        var lastAssistant = session.History.LastOrDefault(static turn => string.Equals(turn.Role, "assistant", StringComparison.OrdinalIgnoreCase) && turn.ToolCalls is { Count: > 1 });
         if (lastUser is null)
             return;
 

--- a/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
+++ b/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
@@ -51,6 +51,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
     <PackageReference Include="QRCoder" Version="1.6.0" />
+    <PackageReference Include="TickerQ" Version="10.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenClaw.Gateway/Pipeline/CronSchedulerStartupService.cs
+++ b/src/OpenClaw.Gateway/Pipeline/CronSchedulerStartupService.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Hosting;
+using OpenClaw.Core.Pipeline;
+
+namespace OpenClaw.Gateway.Pipeline;
+
+internal sealed class CronSchedulerStartupService : IHostedService
+{
+    private readonly CronScheduler _scheduler;
+
+    public CronSchedulerStartupService(CronScheduler scheduler)
+        => _scheduler = scheduler;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+        => _scheduler.RunStartupJobsAsync(cancellationToken);
+
+    public Task StopAsync(CancellationToken cancellationToken)
+        => Task.CompletedTask;
+}

--- a/src/OpenClaw.Gateway/Pipeline/CronSchedulerTickerFunction.cs
+++ b/src/OpenClaw.Gateway/Pipeline/CronSchedulerTickerFunction.cs
@@ -1,0 +1,16 @@
+using OpenClaw.Core.Pipeline;
+using TickerQ.Utilities.Base;
+
+namespace OpenClaw.Gateway.Pipeline;
+
+internal sealed class CronSchedulerTickerFunction
+{
+    private readonly CronScheduler _scheduler;
+
+    public CronSchedulerTickerFunction(CronScheduler scheduler)
+        => _scheduler = scheduler;
+
+    [TickerFunction("openclaw-cron-scan", cronExpression: "* * * * *")]
+    public Task ExecuteAsync(TickerFunctionContext context, CancellationToken cancellationToken)
+        => _scheduler.RunTickAsync(cancellationToken);
+}

--- a/src/OpenClaw.Gateway/Program.cs
+++ b/src/OpenClaw.Gateway/Program.cs
@@ -5,6 +5,7 @@ using OpenClaw.Gateway.Endpoints;
 using OpenClaw.Gateway.Mcp;
 using OpenClaw.Gateway.Pipeline;
 using OpenClaw.Gateway.Profiles;
+using TickerQ.DependencyInjection;
 #if OPENCLAW_ENABLE_MAF_EXPERIMENT
 using OpenClaw.Gateway.A2A;
 using OpenClaw.MicrosoftAgentFrameworkAdapter;
@@ -43,6 +44,7 @@ builder.Services.AddOpenSandboxIntegration(builder.Configuration);
 #endif
 
 var app = builder.Build();
+app.UseTickerQ();
 var runtime = await app.InitializeOpenClawRuntimeAsync(startup);
 
 app.InitializeMcpRuntime(runtime);

--- a/src/OpenClaw.Gateway/appsettings.json
+++ b/src/OpenClaw.Gateway/appsettings.json
@@ -263,7 +263,7 @@
   },
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Information"
     }
   }
 }


### PR DESCRIPTION
## Description
Changes:
•	Use TickerQ to take over cron scheduling:
•	Add TickerQ 10.3.0 to OpenClaw.Gateway.csproj
•	Add app.UseTickerQ() to Program.cs
•	Add AddTickerQ() registration in CoreServicesExtensions.cs
•	Keep CronScheduler’s enqueueing and matching logic, but stop running it via BackgroundService + PeriodicTimer
•	CronScheduler.cs
•	It is now invoked by external scheduling through RunStartupJobsAsync(CancellationToken) / RunTickAsync(CancellationToken)
•	Remove the original custom cron field-matching implementation
•	Change IsTime(string, DateTimeOffset) to:
•	First use TickerQ’s CronExpression.TryParse
•	Then compute the next occurrence using TickerQ-aligned 6-field cron semantics and determine whether it matches the current time
•	Only retain a very thin compatibility layer:
•	Add a new TickerQ job function:
•	CronSchedulerTickerFunction.cs
•	Use [TickerFunction("openclaw-cron-scan", cronExpression: "* * * * *")]
•	Add a new startup service:
•	CronSchedulerStartupService.cs
•	Execute RunOnStartup jobs during startup
•	RuntimeInitializationExtensions no longer starts CronScheduler manually
Compatibility:
•	AOT: Uses TickerQ’s attribute/source-generator approach, avoiding continued execution of the original polling logic as a background timer, which aligns with the repository’s AOT direction.
•	JIT: Behavior remains compatible as well, with no additional requirements.
## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the code style implementation of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed locally (`dotnet test`)
- [ ] I have updated the documentation (README.md, comments) if required
- [ ] I have checked for security implications (input validation, authorization)

## Screenshots (if applicable)

[Add screenshots for UI/UX changes]

## Benchmarks (if applicable)

[Did this change affect performance? Provide benchmark results.]
