### PR TITLE
[codex] Harden runtime edge cases, add observability and audit endpoints

### DIFF
--- a/src/OpenClaw.Agent/AgentRuntime.cs
+++ b/src/OpenClaw.Agent/AgentRuntime.cs
@@ -105,7 +105,8 @@ public sealed class AgentRuntime : IAgentRuntime
         Func<Session, bool>? isContractTokenBudgetExceeded = null,
         Func<Session, bool>? isContractRuntimeBudgetExceeded = null,
         Action<Session, string, string, long, long>? recordContractTurnUsage = null,
-        Action<Session, string>? appendContractSnapshot = null)
+        Action<Session, string>? appendContractSnapshot = null,
+        ToolAuditLog? toolAuditLog = null)
     {
         _chatClient = chatClient;
         _tools = tools;
@@ -149,7 +150,8 @@ public sealed class AgentRuntime : IAgentRuntime
             toolSandbox: toolSandbox,
             toolUsageTracker: toolUsageTracker,
             executionRouter: executionRouter,
-            toolPresetResolver: toolPresetResolver);
+            toolPresetResolver: toolPresetResolver,
+            auditLog: toolAuditLog);
         _sessionTokenBudget = sessionTokenBudget;
         _estimateTokenBudgetAdmission = gatewayConfig?.EnableEstimatedTokenAdmissionControl ?? false;
         _recall = recall;

--- a/src/OpenClaw.Agent/IAgentRuntimeFactory.cs
+++ b/src/OpenClaw.Agent/IAgentRuntimeFactory.cs
@@ -28,6 +28,7 @@ public sealed class AgentRuntimeFactoryContext
     public required IReadOnlyList<string> ApprovalRequiredTools { get; init; }
     public IToolSandbox? ToolSandbox { get; init; }
     public ToolUsageTracker? ToolUsageTracker { get; init; }
+    public ToolAuditLog? ToolAuditLog { get; init; }
     public Func<Session, bool>? IsContractTokenBudgetExceeded { get; init; }
     public Func<Session, bool>? IsContractRuntimeBudgetExceeded { get; init; }
     public Action<Session, string, string, long, long>? RecordContractTurnUsage { get; init; }

--- a/src/OpenClaw.Agent/NativeAgentRuntimeFactory.cs
+++ b/src/OpenClaw.Agent/NativeAgentRuntimeFactory.cs
@@ -46,7 +46,8 @@ public sealed class NativeAgentRuntimeFactory : IAgentRuntimeFactory
             isContractTokenBudgetExceeded: context.IsContractTokenBudgetExceeded,
             isContractRuntimeBudgetExceeded: context.IsContractRuntimeBudgetExceeded,
             recordContractTurnUsage: context.RecordContractTurnUsage,
-            appendContractSnapshot: context.AppendContractSnapshot);
+            appendContractSnapshot: context.AppendContractSnapshot,
+            toolAuditLog: context.ToolAuditLog);
 
     public IAgentRuntime Create(AgentRuntimeFactoryContext context)
     {

--- a/src/OpenClaw.Agent/OpenClawToolExecutor.cs
+++ b/src/OpenClaw.Agent/OpenClawToolExecutor.cs
@@ -272,8 +272,8 @@ public sealed class OpenClawToolExecutor
             DurationMs = sw.Elapsed.TotalMilliseconds,
             Failed = toolFailed,
             TimedOut = toolTimedOut,
-            ArgumentsBytes = argsJson.Length,
-            ResultBytes = result.Length
+            ArgumentsBytes = Encoding.UTF8.GetByteCount(argsJson),
+            ResultBytes = Encoding.UTF8.GetByteCount(result)
         });
         _logger?.LogDebug("[{CorrelationId}] Tool {Tool} completed in {Duration}ms ok={Ok}",
             turnCtx.CorrelationId,

--- a/src/OpenClaw.Agent/OpenClawToolExecutor.cs
+++ b/src/OpenClaw.Agent/OpenClawToolExecutor.cs
@@ -35,6 +35,7 @@ public sealed class OpenClawToolExecutor
     private readonly ToolUsageTracker? _toolUsageTracker;
     private readonly ToolExecutionRouter _executionRouter;
     private readonly IToolPresetResolver? _toolPresetResolver;
+    private readonly ToolAuditLog? _auditLog;
 
     public OpenClawToolExecutor(
         IReadOnlyList<ITool> tools,
@@ -48,7 +49,8 @@ public sealed class OpenClawToolExecutor
         IToolSandbox? toolSandbox = null,
         ToolUsageTracker? toolUsageTracker = null,
         ToolExecutionRouter? executionRouter = null,
-        IToolPresetResolver? toolPresetResolver = null)
+        IToolPresetResolver? toolPresetResolver = null,
+        ToolAuditLog? auditLog = null)
     {
         _toolsByName = tools.ToDictionary(t => t.Name, StringComparer.Ordinal);
         _toolDeclarations = tools.Select(CreateDeclaration).Cast<AITool>().ToArray();
@@ -74,6 +76,7 @@ public sealed class OpenClawToolExecutor
         _toolUsageTracker = toolUsageTracker;
         _executionRouter = executionRouter ?? new ToolExecutionRouter(_config, _toolSandbox, logger);
         _toolPresetResolver = toolPresetResolver;
+        _auditLog = auditLog;
     }
 
     public IList<AITool> ToolDeclarations => _toolDeclarations;
@@ -252,8 +255,26 @@ public sealed class OpenClawToolExecutor
         sw.Stop();
 
         _metrics?.IncrementToolCalls();
+        Telemetry.ToolExecutionDuration.Record(
+            sw.Elapsed.TotalMilliseconds,
+            new KeyValuePair<string, object?>("tool.name", tool.Name),
+            new KeyValuePair<string, object?>("tool.success", !toolFailed));
         turnCtx.RecordToolCall(sw.Elapsed, toolFailed, toolTimedOut);
         _toolUsageTracker?.RecordToolCall(tool.Name, sw.Elapsed, toolFailed, toolTimedOut);
+        _auditLog?.Record(new ToolAuditEntry
+        {
+            TimestampUtc = DateTimeOffset.UtcNow,
+            ToolName = tool.Name,
+            SessionId = session.Id,
+            ChannelId = session.ChannelId,
+            SenderId = session.SenderId,
+            CorrelationId = turnCtx.CorrelationId,
+            DurationMs = sw.Elapsed.TotalMilliseconds,
+            Failed = toolFailed,
+            TimedOut = toolTimedOut,
+            ArgumentsBytes = argsJson.Length,
+            ResultBytes = result.Length
+        });
         _logger?.LogDebug("[{CorrelationId}] Tool {Tool} completed in {Duration}ms ok={Ok}",
             turnCtx.CorrelationId,
             tool.Name,

--- a/src/OpenClaw.Agent/Plugins/NativeDynamicPluginHost.cs
+++ b/src/OpenClaw.Agent/Plugins/NativeDynamicPluginHost.cs
@@ -159,7 +159,28 @@ public sealed class NativeDynamicPluginHost : IAsyncDisposable
             await LoadPluginAsync(plugin, ct);
         }
 
+        EmitDiagnosticsAsStructuredLogs();
+
         return _tools;
+    }
+
+    private void EmitDiagnosticsAsStructuredLogs()
+    {
+        foreach (var report in _reports)
+        {
+            foreach (var diag in report.Diagnostics)
+            {
+                var level = diag.Severity switch
+                {
+                    "error" => LogLevel.Error,
+                    "warning" => LogLevel.Warning,
+                    _ => LogLevel.Information
+                };
+                _logger.Log(level,
+                    "Plugin {PluginId} diagnostic [{Code}] on surface {Surface}: {Message} (path={Path})",
+                    report.PluginId, diag.Code, diag.Surface, diag.Message, diag.Path);
+            }
+        }
     }
 
     public void RegisterCommandsWith(ChatCommandProcessor processor)

--- a/src/OpenClaw.Agent/Plugins/SocketBridgeTransport.cs
+++ b/src/OpenClaw.Agent/Plugins/SocketBridgeTransport.cs
@@ -116,6 +116,7 @@ public sealed class SocketBridgeTransport : BridgeTransportBase
                 var authenticated = await TryAuthenticateStreamAsync(stream, connectCts.Token);
                 if (authenticated.Reader is null || authenticated.Writer is null)
                 {
+                    await stream.DisposeAsync();
                     acceptedSocket.Dispose();
                     continue;
                 }

--- a/src/OpenClaw.Agent/Tools/ToolPathPolicy.cs
+++ b/src/OpenClaw.Agent/Tools/ToolPathPolicy.cs
@@ -41,16 +41,15 @@ internal static class ToolPathPolicy
     {
         var full = Path.GetFullPath(path);
 
-        // If the path exists, resolve symlinks based on actual entry type
-        if (File.Exists(full))
-        {
-            return ResolveFileLinkOrSelf(full);
-        }
+        // Try resolving as a symlink first, without checking existence.
+        // This eliminates the TOCTOU window between File.Exists and ResolveLinkTarget.
+        var resolved = TryResolveLinkTarget(full);
+        if (resolved is not null)
+            return resolved;
 
-        if (Directory.Exists(full))
-        {
-            return ResolveDirectoryLinkOrSelf(full);
-        }
+        // Not a symlink — if the path exists as-is, return it directly
+        if (File.Exists(full) || Directory.Exists(full))
+            return full;
 
         // Path doesn't exist yet — resolve the deepest existing ancestor
         // and append the remaining tail. This prevents writing through a
@@ -69,45 +68,36 @@ internal static class ToolPathPolicy
             if (IsPathRoot(dir))
                 return Path.Combine(dir, tail);
 
-            var realDir = ResolveDirectoryLinkOrSelf(dir);
+            var realDir = TryResolveLinkTarget(dir) ?? dir;
             return Path.Combine(realDir, tail);
         }
 
         return full;
     }
 
-    private static string ResolveFileLinkOrSelf(string path)
+    /// <summary>
+    /// Attempts to resolve a symlink target for the given path.
+    /// Returns null if the path is not a symlink, does not exist, or cannot be accessed.
+    /// </summary>
+    private static string? TryResolveLinkTarget(string path)
     {
         try
         {
-            var resolved = File.ResolveLinkTarget(path, returnFinalTarget: true);
-            return resolved?.FullName ?? path;
+            var target = File.ResolveLinkTarget(path, returnFinalTarget: true);
+            if (target is not null) return target.FullName;
         }
-        catch (IOException)
-        {
-            return path;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return path;
-        }
-    }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
 
-    private static string ResolveDirectoryLinkOrSelf(string path)
-    {
         try
         {
-            var resolved = Directory.ResolveLinkTarget(path, returnFinalTarget: true);
-            return resolved?.FullName ?? path;
+            var target = Directory.ResolveLinkTarget(path, returnFinalTarget: true);
+            if (target is not null) return target.FullName;
         }
-        catch (IOException)
-        {
-            return path;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return path;
-        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+
+        return null;
     }
 
     private static bool IsPathRoot(string path)

--- a/src/OpenClaw.Core/Models/Session.cs
+++ b/src/OpenClaw.Core/Models/Session.cs
@@ -702,6 +702,8 @@ public sealed class SessionDelegationChildSummary
 [JsonSerializable(typeof(Dictionary<string, decimal>))]
 [JsonSerializable(typeof(ToolUsageSnapshot))]
 [JsonSerializable(typeof(List<ToolUsageSnapshot>))]
+[JsonSerializable(typeof(OpenClaw.Core.Observability.ToolAuditEntry))]
+[JsonSerializable(typeof(IReadOnlyList<OpenClaw.Core.Observability.ToolAuditEntry>))]
 [JsonSerializable(typeof(OpenClaw.Core.Plugins.BridgeMediaAttachment))]
 [JsonSerializable(typeof(OpenClaw.Core.Plugins.BridgeMediaAttachment[]))]
 [JsonSerializable(typeof(OpenClaw.Core.Plugins.BridgeChannelTypingRequest))]

--- a/src/OpenClaw.Core/Observability/Telemetry.cs
+++ b/src/OpenClaw.Core/Observability/Telemetry.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 
 namespace OpenClaw.Core.Observability;
 
@@ -14,4 +15,39 @@ public static class Telemetry
     /// The primary ActivitySource for distributed tracing within OpenClaw.
     /// </summary>
     public static readonly ActivitySource ActivitySource = new(ServiceName, Version);
+
+    /// <summary>
+    /// The primary Meter for OpenClaw metrics. Registered with the OTLP exporter via
+    /// GatewayTelemetryExtensions.AddGatewayTelemetry (meter name "OpenClaw.Gateway").
+    /// </summary>
+    public static readonly Meter Meter = new(ServiceName, Version);
+
+    /// <summary>
+    /// Histogram recording the duration (ms) of each tool execution, tagged by tool name and success.
+    /// </summary>
+    public static readonly Histogram<double> ToolExecutionDuration =
+        Meter.CreateHistogram<double>(
+            "openclaw.tool.execution.duration",
+            unit: "ms",
+            description: "Duration of tool executions in milliseconds");
+
+    /// <summary>
+    /// Counter incremented when a request is blocked by rate limiting, tagged by actor type and policy.
+    /// </summary>
+    public static readonly Counter<long> RateLimitExceeded =
+        Meter.CreateCounter<long>(
+            "openclaw.ratelimit.exceeded",
+            description: "Number of requests blocked by rate limiting");
+
+    /// <summary>
+    /// Registers an observable gauge that reports the current pending approval queue depth.
+    /// Call once during startup after the ToolApprovalService is constructed.
+    /// </summary>
+    public static void RegisterApprovalQueueGauge(Func<int> observeFunc)
+    {
+        Meter.CreateObservableGauge(
+            "openclaw.approval.queue.depth",
+            observeFunc,
+            description: "Number of pending tool approval requests");
+    }
 }

--- a/src/OpenClaw.Core/Observability/ToolAuditLog.cs
+++ b/src/OpenClaw.Core/Observability/ToolAuditLog.cs
@@ -38,43 +38,51 @@ public sealed class ToolAuditLog : IDisposable
 
     public ToolAuditLog(string? filePath, ILogger<ToolAuditLog>? logger = null)
     {
-        _filePath = string.IsNullOrWhiteSpace(filePath) ? null : filePath;
         _logger = logger;
 
-        if (_filePath is not null)
+        var configuredFilePath = string.IsNullOrWhiteSpace(filePath) ? null : filePath;
+        if (configuredFilePath is not null)
         {
             try
             {
-                var dir = Path.GetDirectoryName(_filePath);
+                var dir = Path.GetDirectoryName(configuredFilePath);
                 if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
                     Directory.CreateDirectory(dir);
             }
-            catch (IOException ex)
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
             {
-                _logger?.LogWarning(ex, "Failed to create audit log directory for {Path}", _filePath);
+                _logger?.LogWarning(ex,
+                    "Failed to initialize audit log directory for {Path}; file logging will be disabled",
+                    configuredFilePath);
+                configuredFilePath = null;
             }
         }
+
+        _filePath = configuredFilePath;
     }
 
     public void Record(ToolAuditEntry entry)
     {
+        string? filePath;
         lock (_gate)
         {
             if (_recent.Count >= RecentBufferCapacity)
                 _recent.RemoveAt(0);
             _recent.Add(entry);
 
-            if (_filePath is null) return;
+            filePath = _filePath;
+        }
 
-            try
-            {
-                var json = JsonSerializer.Serialize(entry, ToolAuditJsonContext.Default.ToolAuditEntry);
-                File.AppendAllText(_filePath, json + "\n");
-            }
-            catch (IOException ex)
-            {
-                _logger?.LogWarning(ex, "Failed to append tool audit entry to {Path}", _filePath);
-            }
+        if (filePath is null) return;
+
+        try
+        {
+            var json = JsonSerializer.Serialize(entry, ToolAuditJsonContext.Default.ToolAuditEntry);
+            File.AppendAllText(filePath, json + "\n");
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        {
+            _logger?.LogWarning(ex, "Failed to append tool audit entry to {Path}", filePath);
         }
     }
 

--- a/src/OpenClaw.Core/Observability/ToolAuditLog.cs
+++ b/src/OpenClaw.Core/Observability/ToolAuditLog.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace OpenClaw.Core.Observability;
+
+/// <summary>
+/// A single audit record for a tool execution. Append-only, written to a JSON-lines file.
+/// </summary>
+public sealed record ToolAuditEntry
+{
+    public required DateTimeOffset TimestampUtc { get; init; }
+    public required string ToolName { get; init; }
+    public required string SessionId { get; init; }
+    public required string ChannelId { get; init; }
+    public required string SenderId { get; init; }
+    public required string CorrelationId { get; init; }
+    public required double DurationMs { get; init; }
+    public required bool Failed { get; init; }
+    public required bool TimedOut { get; init; }
+    public string? ApprovalId { get; init; }
+    public int ArgumentsBytes { get; init; }
+    public int ResultBytes { get; init; }
+}
+
+/// <summary>
+/// Thread-safe, append-only JSON-lines writer for tool execution audit entries.
+/// Intentionally omits raw arguments and result payloads by default to avoid leaking secrets;
+/// only byte counts are recorded. Callers can log redacted summaries via the logger separately.
+/// </summary>
+public sealed class ToolAuditLog : IDisposable
+{
+    private readonly string? _filePath;
+    private readonly ILogger<ToolAuditLog>? _logger;
+    private readonly Lock _gate = new();
+    private readonly List<ToolAuditEntry> _recent = new(capacity: 256);
+    private const int RecentBufferCapacity = 256;
+
+    public ToolAuditLog(string? filePath, ILogger<ToolAuditLog>? logger = null)
+    {
+        _filePath = string.IsNullOrWhiteSpace(filePath) ? null : filePath;
+        _logger = logger;
+
+        if (_filePath is not null)
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(_filePath);
+                if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+            }
+            catch (IOException ex)
+            {
+                _logger?.LogWarning(ex, "Failed to create audit log directory for {Path}", _filePath);
+            }
+        }
+    }
+
+    public void Record(ToolAuditEntry entry)
+    {
+        lock (_gate)
+        {
+            if (_recent.Count >= RecentBufferCapacity)
+                _recent.RemoveAt(0);
+            _recent.Add(entry);
+
+            if (_filePath is null) return;
+
+            try
+            {
+                var json = JsonSerializer.Serialize(entry, ToolAuditJsonContext.Default.ToolAuditEntry);
+                File.AppendAllText(_filePath, json + "\n");
+            }
+            catch (IOException ex)
+            {
+                _logger?.LogWarning(ex, "Failed to append tool audit entry to {Path}", _filePath);
+            }
+        }
+    }
+
+    public IReadOnlyList<ToolAuditEntry> SnapshotRecent(int limit = 100)
+    {
+        lock (_gate)
+        {
+            var count = Math.Min(limit, _recent.Count);
+            if (count <= 0) return [];
+            var result = new ToolAuditEntry[count];
+            for (var i = 0; i < count; i++)
+                result[i] = _recent[_recent.Count - count + i];
+            return result;
+        }
+    }
+
+    public void Dispose()
+    {
+        // No resources to release - file is opened/closed per Record call.
+    }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(ToolAuditEntry))]
+[JsonSerializable(typeof(IReadOnlyList<ToolAuditEntry>))]
+[JsonSerializable(typeof(List<ToolAuditEntry>))]
+[JsonSerializable(typeof(ToolAuditEntry[]))]
+internal sealed partial class ToolAuditJsonContext : JsonSerializerContext;

--- a/src/OpenClaw.Core/Pipeline/ToolApprovalService.cs
+++ b/src/OpenClaw.Core/Pipeline/ToolApprovalService.cs
@@ -57,6 +57,11 @@ public sealed class ToolApprovalService
 
     private readonly ConcurrentDictionary<string, Pending> _pending = new(StringComparer.Ordinal);
 
+    /// <summary>
+    /// Current number of pending approval requests. Used by observability (openclaw.approval.queue.depth gauge).
+    /// </summary>
+    public int PendingCount => _pending.Count;
+
     public ToolApprovalRequest Create(
         string sessionId,
         string channelId,

--- a/src/OpenClaw.Core/Pipeline/ToolApprovalService.cs
+++ b/src/OpenClaw.Core/Pipeline/ToolApprovalService.cs
@@ -184,6 +184,18 @@ public sealed class ToolApprovalService
 
             // Timeout => deny by default and drain the pending request.
             _pending.TryRemove(approvalId, out _);
+            p.Tcs.TrySetCanceled();
+
+            // Re-check: TrySetDecision may have won the race before TrySetCanceled
+            if (p.Tcs.Task.IsCompletedSuccessfully)
+            {
+                return new ToolApprovalWaitOutcome
+                {
+                    Result = p.Tcs.Task.Result ? ToolApprovalWaitResult.Approved : ToolApprovalWaitResult.Denied,
+                    Request = p.Request
+                };
+            }
+
             return new ToolApprovalWaitOutcome
             {
                 Result = ToolApprovalWaitResult.TimedOut,

--- a/src/OpenClaw.Core/Security/BindAddressClassifier.cs
+++ b/src/OpenClaw.Core/Security/BindAddressClassifier.cs
@@ -6,6 +6,10 @@ public static class BindAddressClassifier
 {
     public static bool IsLoopbackBind(string bindAddress)
     {
+        // ASP.NET Core wildcard bind addresses mean "all interfaces" — not loopback
+        if (bindAddress is "*" or "+" or "[::]")
+            return false;
+
         if (IPAddress.TryParse(bindAddress, out var ip))
             return IPAddress.IsLoopback(ip);
 

--- a/src/OpenClaw.Core/Security/SecretResolver.cs
+++ b/src/OpenClaw.Core/Security/SecretResolver.cs
@@ -46,9 +46,9 @@ public static class SecretResolver
 
         if (logger is not null && LooksLikeEnvVarName(secretRef))
             logger.LogWarning(
-                "Secret ref '{SecretRef}' looks like an environment variable name but no such variable is set. " +
-                "Using the literal value. Prefix with 'env:' for strict resolution.",
-                secretRef);
+                "A secret ref with {Length} chars looks like an environment variable name but no such variable is set. " +
+                "Falling back to the literal value. Prefix with 'env:' for strict resolution.",
+                secretRef.Length);
 
         return secretRef;
     }

--- a/src/OpenClaw.Core/Security/SecretResolver.cs
+++ b/src/OpenClaw.Core/Security/SecretResolver.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace OpenClaw.Core.Security;
 
 /// <summary>
@@ -20,6 +22,13 @@ public static class SecretResolver
     /// referenced environment variable is unset.
     /// </summary>
     public static string? Resolve(string? secretRef)
+        => Resolve(secretRef, logger: null);
+
+    /// <summary>
+    /// Resolve a secret reference to its actual value, logging a warning when a bare
+    /// string that looks like an environment variable name falls back to a literal.
+    /// </summary>
+    public static string? Resolve(string? secretRef, ILogger? logger)
     {
         if (string.IsNullOrWhiteSpace(secretRef))
             return null;
@@ -31,7 +40,17 @@ public static class SecretResolver
             return secretRef[RawPrefix.Length..];
 
         // Default: treat as env var name, fall back to literal
-        return Environment.GetEnvironmentVariable(secretRef) ?? secretRef;
+        var envValue = Environment.GetEnvironmentVariable(secretRef);
+        if (envValue is not null)
+            return envValue;
+
+        if (logger is not null && LooksLikeEnvVarName(secretRef))
+            logger.LogWarning(
+                "Secret ref '{SecretRef}' looks like an environment variable name but no such variable is set. " +
+                "Using the literal value. Prefix with 'env:' for strict resolution.",
+                secretRef);
+
+        return secretRef;
     }
 
     /// <summary>
@@ -40,4 +59,7 @@ public static class SecretResolver
     /// </summary>
     public static bool IsRawRef(string? secretRef)
         => secretRef is not null && secretRef.StartsWith(RawPrefix, StringComparison.OrdinalIgnoreCase);
+
+    private static bool LooksLikeEnvVarName(string value)
+        => value.Length >= 3 && value.All(c => c is (>= 'A' and <= 'Z') or (>= '0' and <= '9') or '_');
 }

--- a/src/OpenClaw.Core/Sessions/SessionManager.cs
+++ b/src/OpenClaw.Core/Sessions/SessionManager.cs
@@ -66,9 +66,12 @@ public sealed class SessionManager : IAsyncDisposable, IDisposable
             return session;
         }
 
-        await _admissionGate.WaitAsync(ct);
+        var gateAcquired = false;
         try
         {
+            await _admissionGate.WaitAsync(ct);
+            gateAcquired = true;
+
             if (_active.TryGetValue(key, out var activeSession))
             {
                 activeSession.LastActiveAt = now;
@@ -122,7 +125,7 @@ public sealed class SessionManager : IAsyncDisposable, IDisposable
         }
         finally
         {
-            _admissionGate.Release();
+            if (gateAcquired) _admissionGate.Release();
         }
     }
 

--- a/src/OpenClaw.Gateway/ActorRateLimitService.cs
+++ b/src/OpenClaw.Gateway/ActorRateLimitService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using OpenClaw.Core.Models;
+using OpenClaw.Core.Observability;
 
 namespace OpenClaw.Gateway;
 
@@ -130,6 +131,10 @@ internal sealed class ActorRateLimitService
                 if (window.BurstCount >= policy.BurstLimit || window.SustainedCount >= policy.SustainedLimit)
                 {
                     blockedByPolicyId = policy.Id;
+                    Telemetry.RateLimitExceeded.Add(1,
+                        new KeyValuePair<string, object?>("actor.type", policy.ActorType),
+                        new KeyValuePair<string, object?>("policy.id", policy.Id),
+                        new KeyValuePair<string, object?>("endpoint.scope", policy.EndpointScope));
                     return false;
                 }
 

--- a/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
@@ -43,6 +43,9 @@ internal static class CoreServicesExtensions
         AddFeatureStores(services, config);
         services.AddSingleton<ProviderUsageTracker>();
         services.AddSingleton<ToolUsageTracker>();
+        services.AddSingleton(sp => new ToolAuditLog(
+            Path.Combine(config.Memory.StoragePath, "audit", "tool-audit.jsonl"),
+            sp.GetRequiredService<ILogger<ToolAuditLog>>()));
         services.AddSingleton<LlmProviderRegistry>();
         services.AddSingleton<ConfiguredModelProfileRegistry>();
         services.AddSingleton<IModelProfileRegistry>(sp => sp.GetRequiredService<ConfiguredModelProfileRegistry>());

--- a/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
@@ -44,7 +44,7 @@ internal static class CoreServicesExtensions
         services.AddSingleton<ProviderUsageTracker>();
         services.AddSingleton<ToolUsageTracker>();
         services.AddSingleton(sp => new ToolAuditLog(
-            Path.Combine(config.Memory.StoragePath, "audit", "tool-audit.jsonl"),
+            Path.Combine(Path.GetFullPath(config.Memory.StoragePath), "audit", "tool-audit.jsonl"),
             sp.GetRequiredService<ILogger<ToolAuditLog>>()));
         services.AddSingleton<LlmProviderRegistry>();
         services.AddSingleton<ConfiguredModelProfileRegistry>();

--- a/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs
@@ -48,6 +48,11 @@ internal static class RuntimeInitializationExtensions
                 "Requester-matched HTTP tool approvals are disabled on a non-loopback bind. Enable OpenClaw:Security:RequireRequesterMatchForHttpToolApproval for safer public deployments.");
         }
         var services = ResolveRuntimeServices(app);
+
+        // Register observability gauge for pending tool approvals
+        var approvalService = app.Services.GetRequiredService<ToolApprovalService>();
+        Telemetry.RegisterApprovalQueueGauge(() => approvalService.PendingCount);
+
         var blockedPluginIds = services.PluginHealth.GetBlockedPluginIds();
         var channelComposition = await BuildChannelCompositionAsync(app, startup, services, loggerFactory);
         var builtInTools = CreateBuiltInTools(
@@ -667,6 +672,7 @@ internal static class RuntimeInitializationExtensions
             ApprovalRequiredTools = approvalRequiredTools,
             ToolSandbox = toolSandbox,
             ToolUsageTracker = services.GetRequiredService<ToolUsageTracker>(),
+            ToolAuditLog = services.GetRequiredService<ToolAuditLog>(),
             IsContractTokenBudgetExceeded = contractGovernance.IsTokenBudgetExceeded,
             IsContractRuntimeBudgetExceeded = contractGovernance.IsRuntimeBudgetExceeded,
             RecordContractTurnUsage = contractGovernance.RecordTurnUsage,

--- a/src/OpenClaw.Gateway/Endpoints/DiagnosticsEndpoints.cs
+++ b/src/OpenClaw.Gateway/Endpoints/DiagnosticsEndpoints.cs
@@ -26,6 +26,32 @@ internal static class DiagnosticsEndpoints
                 CoreJsonContext.Default.HealthResponse);
         });
 
+        // Unauthenticated liveness probe: the process is up. Intended for load balancer / K8s probes.
+        app.MapGet("/health/live", () =>
+            Results.Json(
+                new HealthResponse { Status = "ok", Uptime = Environment.TickCount64 },
+                CoreJsonContext.Default.HealthResponse));
+
+        // Unauthenticated readiness probe: the runtime is initialized and can serve traffic.
+        // Does not leak config. Returns 503 if the session manager is missing or an internal error occurs.
+        app.MapGet("/health/ready", () =>
+        {
+            try
+            {
+                _ = runtime.SessionManager.ActiveCount;
+                return Results.Json(
+                    new HealthResponse { Status = "ready", Uptime = Environment.TickCount64 },
+                    CoreJsonContext.Default.HealthResponse);
+            }
+            catch
+            {
+                return Results.Json(
+                    new HealthResponse { Status = "not_ready", Uptime = Environment.TickCount64 },
+                    CoreJsonContext.Default.HealthResponse,
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+        });
+
         app.MapGet("/metrics", (HttpContext ctx) =>
         {
             if (!EndpointHelpers.AuthorizeOperatorRequest(ctx, startup, browserSessions, requireCsrf: false).IsAuthorized)
@@ -51,6 +77,17 @@ internal static class DiagnosticsEndpoints
 
             var toolTracker = app.Services.GetRequiredService<OpenClaw.Core.Observability.ToolUsageTracker>();
             return Results.Json(toolTracker.Snapshot(), CoreJsonContext.Default.ListToolUsageSnapshot);
+        });
+
+        app.MapGet("/admin/audit/tools", (HttpContext ctx, int? limit) =>
+        {
+            if (!EndpointHelpers.AuthorizeOperatorRequest(ctx, startup, browserSessions, requireCsrf: false).IsAuthorized)
+                return Results.Unauthorized();
+
+            var auditLog = app.Services.GetRequiredService<OpenClaw.Core.Observability.ToolAuditLog>();
+            var effectiveLimit = limit is > 0 and <= 1000 ? limit.Value : 100;
+            var recent = auditLog.SnapshotRecent(effectiveLimit);
+            return Results.Json(recent, CoreJsonContext.Default.IReadOnlyListToolAuditEntry);
         });
 
         app.MapGet("/memory/retention/status", async (HttpContext ctx) =>

--- a/src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs
+++ b/src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs
@@ -69,7 +69,8 @@ public sealed class MafAgentRuntime : IAgentRuntime
             context.RuntimeMetrics,
             logger,
             config: context.Config,
-            toolSandbox: context.ToolSandbox);
+            toolSandbox: context.ToolSandbox,
+            auditLog: context.ToolAuditLog);
         _options = options;
         _agentFactory = agentFactory;
         _sessionStateStore = sessionStateStore;

--- a/src/OpenClaw.Tests/ActorRateLimitServiceTests.cs
+++ b/src/OpenClaw.Tests/ActorRateLimitServiceTests.cs
@@ -1,0 +1,141 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenClaw.Core.Models;
+using OpenClaw.Gateway;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class ActorRateLimitServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly ActorRateLimitService _service;
+
+    public ActorRateLimitServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(_tempDir);
+        _service = new ActorRateLimitService(_tempDir, NullLogger<ActorRateLimitService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void TryConsume_BurstLimit_BlocksAfterExhausted()
+    {
+        _service.AddOrUpdate(new ActorRateLimitPolicy
+        {
+            Id = "burst-test",
+            ActorType = "ip",
+            EndpointScope = "chat",
+            BurstLimit = 3,
+            BurstWindowSeconds = 60,
+            SustainedLimit = 100,
+            SustainedWindowSeconds = 300,
+            Enabled = true
+        });
+
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.True(_service.TryConsume("ip", "10.0.0.1", "chat", out _));
+        }
+
+        Assert.False(_service.TryConsume("ip", "10.0.0.1", "chat", out var blockedBy));
+        Assert.Equal("burst-test", blockedBy);
+    }
+
+    [Fact]
+    public void TryConsume_SustainedLimit_BlocksAfterExhausted()
+    {
+        _service.AddOrUpdate(new ActorRateLimitPolicy
+        {
+            Id = "sustained-test",
+            ActorType = "ip",
+            EndpointScope = "chat",
+            BurstLimit = 100,
+            BurstWindowSeconds = 10,
+            SustainedLimit = 5,
+            SustainedWindowSeconds = 300,
+            Enabled = true
+        });
+
+        for (var i = 0; i < 5; i++)
+        {
+            Assert.True(_service.TryConsume("ip", "10.0.0.1", "chat", out _));
+        }
+
+        Assert.False(_service.TryConsume("ip", "10.0.0.1", "chat", out var blockedBy));
+        Assert.Equal("sustained-test", blockedBy);
+    }
+
+    [Fact]
+    public void TryConsume_PerActorIsolation_IndependentLimits()
+    {
+        _service.AddOrUpdate(new ActorRateLimitPolicy
+        {
+            Id = "isolation-test",
+            ActorType = "ip",
+            EndpointScope = "chat",
+            BurstLimit = 2,
+            BurstWindowSeconds = 60,
+            SustainedLimit = 100,
+            SustainedWindowSeconds = 300,
+            Enabled = true
+        });
+
+        // Actor A uses 2 requests
+        Assert.True(_service.TryConsume("ip", "actor-a", "chat", out _));
+        Assert.True(_service.TryConsume("ip", "actor-a", "chat", out _));
+        Assert.False(_service.TryConsume("ip", "actor-a", "chat", out _));
+
+        // Actor B is unaffected
+        Assert.True(_service.TryConsume("ip", "actor-b", "chat", out _));
+        Assert.True(_service.TryConsume("ip", "actor-b", "chat", out _));
+    }
+
+    [Fact]
+    public void TryConsume_DisabledPolicy_DoesNotBlock()
+    {
+        _service.AddOrUpdate(new ActorRateLimitPolicy
+        {
+            Id = "disabled-test",
+            ActorType = "ip",
+            EndpointScope = "chat",
+            BurstLimit = 1,
+            BurstWindowSeconds = 60,
+            SustainedLimit = 1,
+            SustainedWindowSeconds = 300,
+            Enabled = false
+        });
+
+        Assert.True(_service.TryConsume("ip", "10.0.0.1", "chat", out _));
+        Assert.True(_service.TryConsume("ip", "10.0.0.1", "chat", out _));
+    }
+
+    [Fact]
+    public void PruneStaleWindows_RemovesExpiredWindows()
+    {
+        _service.AddOrUpdate(new ActorRateLimitPolicy
+        {
+            Id = "prune-test",
+            ActorType = "ip",
+            EndpointScope = "chat",
+            BurstLimit = 100,
+            BurstWindowSeconds = 10,
+            SustainedLimit = 100,
+            SustainedWindowSeconds = 30,
+            Enabled = true
+        });
+
+        _service.TryConsume("ip", "10.0.0.1", "chat", out _);
+        Assert.True(_service.ActiveWindowCount > 0);
+
+        // Prune with a far-future timestamp (2x sustained window = 60s, so 120s in the future is safe)
+        var farFuture = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + 120;
+        _service.PruneStaleWindows(farFuture);
+
+        Assert.Equal(0, _service.ActiveWindowCount);
+    }
+}

--- a/src/OpenClaw.Tests/BindAddressClassifierTests.cs
+++ b/src/OpenClaw.Tests/BindAddressClassifierTests.cs
@@ -1,0 +1,24 @@
+using OpenClaw.Core.Security;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class BindAddressClassifierTests
+{
+    [Theory]
+    [InlineData("127.0.0.1", true)]
+    [InlineData("::1", true)]
+    [InlineData("localhost", true)]
+    [InlineData("LOCALHOST", true)]
+    [InlineData("0.0.0.0", false)]
+    [InlineData("*", false)]
+    [InlineData("+", false)]
+    [InlineData("[::]", false)]
+    [InlineData("192.168.1.1", false)]
+    [InlineData("10.0.0.1", false)]
+    [InlineData("172.16.0.1", false)]
+    public void IsLoopbackBind_ClassifiesCorrectly(string bindAddress, bool expectedIsLoopback)
+    {
+        Assert.Equal(expectedIsLoopback, BindAddressClassifier.IsLoopbackBind(bindAddress));
+    }
+}

--- a/src/OpenClaw.Tests/SecurityTests.cs
+++ b/src/OpenClaw.Tests/SecurityTests.cs
@@ -58,6 +58,8 @@ public class SecurityTests
         Assert.Equal("OPENCLAW_NONEXISTENT_VAR_XYZ", result);
         Assert.Single(logger.Warnings);
         Assert.Contains("environment variable name", logger.Warnings[0]);
+        // Warning must not leak the actual secret ref value
+        Assert.DoesNotContain("OPENCLAW_NONEXISTENT_VAR_XYZ", logger.Warnings[0]);
     }
 
     [Fact]

--- a/src/OpenClaw.Tests/SecurityTests.cs
+++ b/src/OpenClaw.Tests/SecurityTests.cs
@@ -49,6 +49,50 @@ public class SecurityTests
     public void IsRawRef_Null_False()
         => Assert.False(SecretResolver.IsRawRef(null));
 
+    [Fact]
+    public void Resolve_WithLogger_BareEnvVarLikeName_LogsWarning()
+    {
+        var logger = new TestLogger();
+        var result = SecretResolver.Resolve("OPENCLAW_NONEXISTENT_VAR_XYZ", logger);
+
+        Assert.Equal("OPENCLAW_NONEXISTENT_VAR_XYZ", result);
+        Assert.Single(logger.Warnings);
+        Assert.Contains("environment variable name", logger.Warnings[0]);
+    }
+
+    [Fact]
+    public void Resolve_WithLogger_LowercaseBareString_NoWarning()
+    {
+        var logger = new TestLogger();
+        var result = SecretResolver.Resolve("some-value", logger);
+
+        Assert.Equal("some-value", result);
+        Assert.Empty(logger.Warnings);
+    }
+
+    [Fact]
+    public void Resolve_WithLogger_EnvPrefix_NoWarning()
+    {
+        var logger = new TestLogger();
+        var result = SecretResolver.Resolve("env:OPENCLAW_NONEXISTENT_VAR_XYZ", logger);
+
+        Assert.Null(result);
+        Assert.Empty(logger.Warnings);
+    }
+
+    private sealed class TestLogger : Microsoft.Extensions.Logging.ILogger
+    {
+        public List<string> Warnings { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+        public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId,
+            TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == Microsoft.Extensions.Logging.LogLevel.Warning)
+                Warnings.Add(formatter(state, exception));
+        }
+    }
+
     // ── InputSanitizer ─────────────────────────────────────────────
 
     [Theory]

--- a/src/OpenClaw.Tests/SessionManagerTests.cs
+++ b/src/OpenClaw.Tests/SessionManagerTests.cs
@@ -178,6 +178,27 @@ public sealed class SessionManagerTests
         }
     }
 
+    [Fact]
+    public async Task GetOrCreateAsync_CancelledToken_DoesNotCorruptSemaphore()
+    {
+        var store = new InMemoryStore();
+        var manager = new SessionManager(store, new GatewayConfig
+        {
+            MaxConcurrentSessions = 8,
+            SessionTimeoutMinutes = 30
+        });
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => manager.GetOrCreateAsync("websocket", "alice", cts.Token).AsTask());
+
+        // Semaphore must not be corrupted — subsequent call should succeed
+        var session = await manager.GetOrCreateAsync("websocket", "alice", CancellationToken.None);
+        Assert.NotNull(session);
+    }
+
     private sealed class DelayedMemoryStore : IMemoryStore
     {
         public async ValueTask<Session?> GetSessionAsync(string sessionId, CancellationToken ct)

--- a/src/OpenClaw.Tests/ToolApprovalServiceTests.cs
+++ b/src/OpenClaw.Tests/ToolApprovalServiceTests.cs
@@ -53,4 +53,63 @@ public sealed class ToolApprovalServiceTests
 
         Assert.Equal(ToolApprovalDecisionResult.Recorded, result);
     }
+
+    [Fact]
+    public void TrySetDecision_DoubleApprove_SecondReturnsNotFound()
+    {
+        var service = new ToolApprovalService();
+        var request = service.Create("sess-1", "telegram", "user-1", "shell", "{}", TimeSpan.FromMinutes(1));
+
+        var first = service.TrySetDecision(
+            request.ApprovalId, approved: true,
+            requesterChannelId: "telegram", requesterSenderId: "user-1");
+
+        var second = service.TrySetDecision(
+            request.ApprovalId, approved: true,
+            requesterChannelId: "telegram", requesterSenderId: "user-1");
+
+        Assert.Equal(ToolApprovalDecisionResult.Recorded, first);
+        Assert.Equal(ToolApprovalDecisionResult.NotFound, second);
+    }
+
+    [Fact]
+    public async Task ListPending_ExpiredEntry_IsCleaned()
+    {
+        var service = new ToolApprovalService();
+        service.Create("sess-1", "telegram", "user-1", "shell", "{}", TimeSpan.FromMilliseconds(1));
+
+        await Task.Delay(50);
+
+        var pending = service.ListPending("telegram", "user-1");
+        Assert.Empty(pending);
+    }
+
+    [Fact]
+    public async Task WaitForDecisionOutcomeAsync_ApprovedBeforeTimeout_ReturnsApproved()
+    {
+        var service = new ToolApprovalService();
+        var request = service.Create("sess-1", "telegram", "user-1", "shell", "{}", TimeSpan.FromSeconds(2));
+
+        var waitTask = service.WaitForDecisionOutcomeAsync(request.ApprovalId, TimeSpan.FromSeconds(2), CancellationToken.None);
+
+        // Approve after a short delay
+        await Task.Delay(50);
+        service.TrySetDecision(request.ApprovalId, approved: true,
+            requesterChannelId: "telegram", requesterSenderId: "user-1");
+
+        var outcome = await waitTask;
+        Assert.Equal(ToolApprovalWaitResult.Approved, outcome.Result);
+    }
+
+    [Fact]
+    public async Task WaitForDecisionOutcomeAsync_Timeout_ReturnsTimedOut()
+    {
+        var service = new ToolApprovalService();
+        var request = service.Create("sess-1", "telegram", "user-1", "shell", "{}", TimeSpan.FromSeconds(5));
+
+        var outcome = await service.WaitForDecisionOutcomeAsync(
+            request.ApprovalId, TimeSpan.FromMilliseconds(100), CancellationToken.None);
+
+        Assert.Equal(ToolApprovalWaitResult.TimedOut, outcome.Result);
+    }
 }

--- a/src/OpenClaw.Tests/ToolPathPolicyTests.cs
+++ b/src/OpenClaw.Tests/ToolPathPolicyTests.cs
@@ -121,6 +121,22 @@ public sealed class ToolPathPolicyTests
         Assert.StartsWith(outsideDir, resolved, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ResolveRealPath_NonExistentFileUnderExistingDir_ResolvesUnderRealParent()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = CreateTempDir();
+        var nonExistentFile = Path.Combine(root, "does-not-exist.txt");
+
+        var resolved = ToolPathPolicy.ResolveRealPath(nonExistentFile);
+
+        // Should resolve under the real root directory with the correct filename
+        Assert.StartsWith(root, resolved, StringComparison.Ordinal);
+        Assert.EndsWith("does-not-exist.txt", resolved, StringComparison.Ordinal);
+    }
+
     private static string CreateTempDir()
     {
         var path = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("n"));


### PR DESCRIPTION
## What changed

This PR covers two tranches of work addressing findings from a comprehensive code audit.

### Tranche 1 — Runtime hardening (commit c47be37)

Key fixes:
- dispose unauthenticated socket streams in `SocketBridgeTransport`
- tighten symlink and non-existent path resolution in `ToolPathPolicy`
- handle approval timeout vs. decision races more safely in `ToolApprovalService`
- classify ASP.NET wildcard bind addresses (`*`, `+`, `[::]`) as non-loopback in `BindAddressClassifier`
- add warning-capable secret resolution for bare env-var-like literals in `SecretResolver`
- avoid semaphore corruption on cancelled admission in `SessionManager`

Test coverage added or expanded for:
- actor rate limits (new `ActorRateLimitServiceTests`)
- bind address classification (new `BindAddressClassifierTests`)
- secret resolver warning behavior
- session cancellation behavior
- tool approval timeout and pending cleanup behavior
- tool path resolution for non-existent files under existing directories

### Tranche 2 — Observability and audit (commit becb5dd)

- **Metrics**: new `Meter` in `Telemetry` with three instruments — `openclaw.tool.execution.duration` (histogram), `openclaw.ratelimit.exceeded` (counter), `openclaw.approval.queue.depth` (observable gauge). Meter name matches the existing OTLP registration.
- **Structured plugin diagnostics**: `NativeDynamicPluginHost` now emits each `PluginCompatibilityDiagnostic` as an OTLP-eligible log event with severity-appropriate level and structured fields (`PluginId`, `Code`, `Surface`, `Path`).
- **ToolAuditLog**: append-only JSON-lines writer at `{StoragePath}/audit/tool-audit.jsonl` that records tool name, session/channel/sender, correlation id, duration, success, and payload byte counts (no raw arguments or results, to avoid leaking secrets). Keeps a 256-entry in-memory ring for fast admin reads.
- **Liveness/readiness probes**: unauthenticated `GET /health/live` and `GET /health/ready` for load balancer and K8s probes. Existing authenticated `/health` is untouched.
- **Audit endpoint**: admin-gated `GET /admin/audit/tools?limit=N` returns recent audit entries.

Wiring threads `ToolAuditLog` through `AgentRuntimeFactoryContext`, `NativeAgentRuntimeFactory`, `MafAgentRuntime`, and `OpenClawToolExecutor`. `ToolAuditEntry` is registered in `CoreJsonContext` for source-gen serialization.

## Why it changed

Tranche 1 closes edge cases in security-sensitive and concurrency-sensitive paths: resource cleanup during failed bridge auth, TOCTOU-style symlink handling, approval decision timeout races, public-bind detection, cancellation safety around session admission.

Tranche 2 adds operational visibility and compliance-friendly audit that operators deploying the runtime have asked for, without mandatory dependencies or JIT requirements.

## Impact

- Safer runtime behavior around failed auth, path handling, and session admission
- More accurate public-bind hardening decisions
- First-class metrics for tool performance, rate limiting, and approval backlog
- Tool execution audit trail suitable for incident review
- Standard K8s/load-balancer probe endpoints that don't leak configuration

## NativeAOT compatibility

All changes are AOT-compatible:
- No reflection or dynamic code generation introduced
- `ToolAuditEntry` uses source-gen JSON via `CoreJsonContext`
- `System.Diagnostics.Metrics` primitives are AOT-safe

## Validation

- `dotnet build src/OpenClaw.Tests/OpenClaw.Tests.csproj -c Release` — 0 warnings, 0 errors
- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj -c Release` — **795 / 795 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)