### PR TITLE
Integrate TickerQ cron scheduler (by @geffzhang, addresses #57 review)

### DIFF
--- a/src/OpenClaw.Channels/EmailChannel.cs
+++ b/src/OpenClaw.Channels/EmailChannel.cs
@@ -161,7 +161,8 @@ public sealed class EmailChannel : IChannelAdapter
     private async Task<IMailFolder> GetInboundFolderAsync(ImapClient client, CancellationToken ct)
     {
         if (string.Equals(_config.InboundFolder, "INBOX", StringComparison.OrdinalIgnoreCase))
-            return client.Inbox;
+            return client.Inbox
+                ?? throw new InvalidOperationException("IMAP server did not expose an INBOX folder.");
 
         return await client.GetFolderAsync(_config.InboundFolder, ct);
     }

--- a/src/OpenClaw.Channels/OpenClaw.Channels.csproj
+++ b/src/OpenClaw.Channels/OpenClaw.Channels.csproj
@@ -7,7 +7,7 @@
     <ProjectReference Include="..\OpenClaw.Core\OpenClaw.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.15.1" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/src/OpenClaw.Core/OpenClaw.Core.csproj
+++ b/src/OpenClaw.Core/OpenClaw.Core.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.11" />
     <PackageReference Include="Spectre.Console" Version="0.54.0" />
+    <PackageReference Include="TickerQ" Version="10.3.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="../../compat/public-smoke.json" LogicalName="OpenClaw.Core.Compatibility.public-smoke.json" />

--- a/src/OpenClaw.Core/OpenClaw.Core.csproj
+++ b/src/OpenClaw.Core/OpenClaw.Core.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.11" />
     <PackageReference Include="Spectre.Console" Version="0.54.0" />
+    <PackageReference Include="NCrontab" Version="3.3.0" />
     <PackageReference Include="TickerQ" Version="10.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenClaw.Core/Pipeline/CronScheduler.cs
+++ b/src/OpenClaw.Core/Pipeline/CronScheduler.cs
@@ -1,17 +1,15 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Channels;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using NCrontab;
 using OpenClaw.Core.Models;
+using TickerQ.Utilities;
 
 namespace OpenClaw.Core.Pipeline;
 
 /// <summary>
-/// A simple background service that checks registered cron jobs every minute
-/// and publishes an InboundMessage to the pipeline.
+/// Dispatches configured cron jobs when invoked by the host scheduler.
 /// </summary>
-public sealed class CronScheduler : BackgroundService
+public sealed class CronScheduler
 {
     private static readonly TimeSpan MaxRunningDuration = TimeSpan.FromHours(6);
 
@@ -27,7 +25,7 @@ public sealed class CronScheduler : BackgroundService
         _pipelineChannel = pipelineChannel;
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    public async Task RunStartupJobsAsync(CancellationToken stoppingToken)
     {
         var initialJobs = _jobSource.GetJobs();
         if (initialJobs.Count == 0)
@@ -35,10 +33,8 @@ public sealed class CronScheduler : BackgroundService
             _logger.LogInformation("Cron Scheduler started with no jobs. Waiting for live cron registrations.");
         }
 
-        using var timer = new PeriodicTimer(TimeSpan.FromMinutes(1));
         _logger.LogInformation("Cron Scheduler started. Monitoring {Count} initial jobs.", initialJobs.Count);
 
-        // Optional: run selected jobs immediately once on startup (useful for testing / boot-time reports)
         foreach (var job in initialJobs)
         {
             if (!job.RunOnStartup)
@@ -55,41 +51,39 @@ public sealed class CronScheduler : BackgroundService
                 _logger.LogWarning(ex, "Failed to run cron job '{JobName}' on startup", job.Name);
             }
         }
+    }
 
-        while (await timer.WaitForNextTickAsync(stoppingToken))
+    public async Task RunTickAsync(CancellationToken stoppingToken)
+    {
+        CleanupStaleRunningJobs(DateTimeOffset.UtcNow);
+        var jobs = _jobSource.GetJobs();
+        if (jobs.Count == 0)
+            return;
+
+        var utcNow = DateTimeOffset.UtcNow;
+
+        foreach (var job in jobs)
         {
-            CleanupStaleRunningJobs(DateTimeOffset.UtcNow);
-            var jobs = _jobSource.GetJobs();
-            if (jobs.Count == 0)
-                continue;
-
-            var utcNow = DateTimeOffset.UtcNow;
-
-            // Re-evaluate jobs at the top of the minute
-            foreach (var job in jobs)
+            var now = utcNow;
+            if (!string.IsNullOrWhiteSpace(job.Timezone))
             {
-                // Convert to job-specific timezone if configured, otherwise use UTC
-                var now = utcNow;
-                if (!string.IsNullOrWhiteSpace(job.Timezone))
+                try
                 {
-                    try
-                    {
-                        var tz = TimeZoneInfo.FindSystemTimeZoneById(job.Timezone);
-                        now = TimeZoneInfo.ConvertTime(utcNow, tz);
-                    }
-                    catch (TimeZoneNotFoundException)
-                    {
-                        _logger.LogWarning("Cron job '{JobName}' has invalid timezone '{Timezone}', falling back to UTC.",
-                            job.Name, job.Timezone);
-                    }
+                    var tz = TimeZoneInfo.FindSystemTimeZoneById(job.Timezone);
+                    now = TimeZoneInfo.ConvertTime(utcNow, tz);
                 }
-
-                if (IsTime(job.CronExpression, now))
+                catch (TimeZoneNotFoundException)
                 {
-                    _logger.LogInformation("Triggering cron job '{JobName}' at {Time}", job.Name, now);
-                    await EnqueueJobIfNotRunningAsync(job, stoppingToken);
+                    _logger.LogWarning("Cron job '{JobName}' has invalid timezone '{Timezone}', falling back to UTC.",
+                        job.Name, job.Timezone);
                 }
             }
+
+            if (!IsTime(job.CronExpression, now))
+                continue;
+
+            _logger.LogInformation("Triggering cron job '{JobName}' at {Time}", job.Name, now);
+            await EnqueueJobIfNotRunningAsync(job, stoppingToken);
         }
     }
 
@@ -158,30 +152,32 @@ public sealed class CronScheduler : BackgroundService
     }
 
     /// <summary>
-    /// Evaluates a standard 5-field cron expression against a given time.
-    /// (Minutes, Hours, Day of Month, Month, Day of Week)
+    /// Evaluates a cron expression against a given time using TickerQ parsing semantics.
     /// </summary>
     public static bool IsTime(string expression, DateTimeOffset time)
     {
-        if (string.IsNullOrWhiteSpace(expression)) return false;
+        if (string.IsNullOrWhiteSpace(expression))
+            return false;
 
-        expression = NormalizeExpression(expression);
+        var normalizedExpression = NormalizeExpression(expression, time);
+        if (!CronExpression.TryParse(normalizedExpression, out var cronExpression))
+            return false;
 
-        var parts = expression.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length != 5) return false;
+        var schedule = CrontabSchedule.Parse(cronExpression.Value, new CrontabSchedule.ParseOptions
+        {
+            IncludingSeconds = true
+        });
 
-        var minMatch = MatchField(parts[0], time.Minute, 0, 59, time);
-        var hourMatch = MatchField(parts[1], time.Hour, 0, 23, time);
-        var domMatch = MatchField(parts[2], time.Day, 1, 31, time);
-        var monthMatch = MatchField(parts[3], time.Month, 1, 12, time);
-        var dowMatch = MatchField(parts[4], (int)time.DayOfWeek, 0, 6, time);
+        var localTime = DateTime.SpecifyKind(time.DateTime, DateTimeKind.Unspecified);
+        var previousSecond = localTime.AddSeconds(-1);
+        var nextOccurrence = schedule.GetNextOccurrence(previousSecond);
 
-        return minMatch && hourMatch && domMatch && monthMatch && dowMatch;
+        return nextOccurrence == localTime;
     }
 
-    private static string NormalizeExpression(string expression)
+    private static string NormalizeExpression(string expression, DateTimeOffset time)
     {
-        return expression.Trim().ToLowerInvariant() switch
+        var normalized = expression.Trim().ToLowerInvariant() switch
         {
             "@hourly" => "0 * * * *",
             "@daily" => "0 0 * * *",
@@ -189,56 +185,19 @@ public sealed class CronScheduler : BackgroundService
             "@monthly" => "0 0 1 * *",
             _ => expression
         };
-    }
 
-    private static bool MatchField(string field, int value, int minValue, int maxValue, DateTimeOffset time)
-    {
-        if (field == "*") return true;
-
-        if (field == "L")
-            return value == DateTime.DaysInMonth(time.Year, time.Month);
-
-        if (int.TryParse(field, out var exact))
-            return exact == value;
-
-        if (field.Contains(','))
-            return field.Split(',').Any(option => MatchField(option, value, minValue, maxValue, time));
-
-        if (field.Contains('/'))
+        var parts = normalized.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var dayOfMonthIndex = parts.Length switch
         {
-            var stepParts = field.Split('/');
-            if (stepParts.Length == 2 && int.TryParse(stepParts[1], out var step) && step > 0)
-            {
-                var range = stepParts[0];
-                if (range == "*")
-                    return (value - minValue) % step == 0;
+            5 => 2,
+            6 => 3,
+            _ => -1
+        };
 
-                if (TryParseRange(range, out var start, out var end))
-                {
-                    if (!IsValueInRange(value, start, end))
-                        return false;
+        if (dayOfMonthIndex >= 0 && string.Equals(parts[dayOfMonthIndex], "l", StringComparison.OrdinalIgnoreCase))
+            parts[dayOfMonthIndex] = DateTime.DaysInMonth(time.Year, time.Month).ToString();
 
-                    return (value - start) % step == 0;
-                }
-            }
-        }
-
-        if (TryParseRange(field, out var rangeStart, out var rangeEnd))
-            return IsValueInRange(value, rangeStart, rangeEnd);
-
-        return false;
-    }
-
-    private static bool TryParseRange(string field, out int start, out int end)
-    {
-        start = 0;
-        end = 0;
-        var rangeParts = field.Split('-');
-        if (rangeParts.Length != 2)
-            return false;
-
-        return int.TryParse(rangeParts[0], out start)
-            && int.TryParse(rangeParts[1], out end);
+        return string.Join(' ', parts);
     }
 
     private void CleanupStaleRunningJobs(DateTimeOffset nowUtc)
@@ -256,13 +215,5 @@ public sealed class CronScheduler : BackgroundService
                     nowUtc - kvp.Value);
             }
         }
-    }
-
-    private static bool IsValueInRange(int value, int start, int end)
-    {
-        if (start <= end)
-            return value >= start && value <= end;
-
-        return value >= start || value <= end;
     }
 }

--- a/src/OpenClaw.Core/Pipeline/CronScheduler.cs
+++ b/src/OpenClaw.Core/Pipeline/CronScheduler.cs
@@ -30,10 +30,13 @@ public sealed class CronScheduler
         var initialJobs = _jobSource.GetJobs();
         if (initialJobs.Count == 0)
         {
-            _logger.LogInformation("Cron Scheduler started with no jobs. Waiting for live cron registrations.");
+            _logger.LogInformation("Cron scheduler startup dispatch found no initial jobs.");
+            return;
         }
 
-        _logger.LogInformation("Cron Scheduler started. Monitoring {Count} initial jobs.", initialJobs.Count);
+        _logger.LogInformation(
+            "Cron scheduler startup dispatch inspecting {Count} initial jobs for RunOnStartup execution.",
+            initialJobs.Count);
 
         foreach (var job in initialJobs)
         {
@@ -168,7 +171,8 @@ public sealed class CronScheduler
             IncludingSeconds = true
         });
 
-        var localTime = DateTime.SpecifyKind(time.DateTime, DateTimeKind.Unspecified);
+        var truncatedTime = time.AddTicks(-(time.Ticks % TimeSpan.TicksPerSecond));
+        var localTime = DateTime.SpecifyKind(truncatedTime.DateTime, DateTimeKind.Unspecified);
         var previousSecond = localTime.AddSeconds(-1);
         var nextOccurrence = schedule.GetNextOccurrence(previousSecond);
 

--- a/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
 using OpenClaw.Channels;
 using OpenClaw.Agent;
 using OpenClaw.Agent.Execution;
@@ -13,7 +14,10 @@ using OpenClaw.Core.Sessions;
 using OpenClaw.Gateway.Bootstrap;
 using OpenClaw.Gateway.Extensions;
 using OpenClaw.Gateway.Models;
+using OpenClaw.Gateway.Pipeline;
 using OpenClaw.Gateway.PromptCaching;
+using TickerQ.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace OpenClaw.Gateway.Composition;
 
@@ -23,6 +27,7 @@ internal static class CoreServicesExtensions
     {
         var config = startup.Config;
 
+        services.TryAddSingleton<IConfiguration>(_ => new ConfigurationBuilder().Build());
         services.AddSingleton(config);
         services.AddSingleton(config.Learning);
         services.AddSingleton(typeof(AllowlistSemantics), AllowlistPolicy.ParseSemantics(config.Channels.AllowlistSemantics));
@@ -101,6 +106,8 @@ internal static class CoreServicesExtensions
             return svc;
         });
         services.AddSingleton<HeartbeatService>();
+        services.AddTickerQ();
+        services.AddSingleton<CronSchedulerTickerFunction>();
         services.AddSingleton<GatewayAutomationService>();
         services.AddSingleton<LearningService>();
         services.AddSingleton<ICronJobSource, GatewayCronJobSource>();
@@ -124,6 +131,13 @@ internal static class CoreServicesExtensions
         services.AddSingleton<IMemoryRetentionCoordinator>(sp => sp.GetRequiredService<MemoryRetentionSweeperService>());
         services.AddHostedService(sp => sp.GetRequiredService<MemoryRetentionSweeperService>());
         services.AddSingleton<MessagePipeline>();
+        services.AddSingleton(sp =>
+            new CronScheduler(
+                sp.GetRequiredService<ICronJobSource>(),
+                sp.GetRequiredService<ILogger<CronScheduler>>(),
+                sp.GetRequiredService<MessagePipeline>().InboundWriter));
+        services.AddSingleton<CronSchedulerStartupService>();
+        services.AddHostedService(sp => sp.GetRequiredService<CronSchedulerStartupService>());
         services.AddSingleton(new WebSocketChannel(config.WebSocket));
         services.AddSingleton<ChatCommandProcessor>();
         services.AddSingleton<GatewayLlmExecutionService>();

--- a/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenClaw.Channels;
 using OpenClaw.Agent;
 using OpenClaw.Agent.Execution;
@@ -17,7 +18,6 @@ using OpenClaw.Gateway.Models;
 using OpenClaw.Gateway.Pipeline;
 using OpenClaw.Gateway.PromptCaching;
 using TickerQ.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace OpenClaw.Gateway.Composition;
 
@@ -27,6 +27,9 @@ internal static class CoreServicesExtensions
     {
         var config = startup.Config;
 
+        // TickerQ requires IConfiguration. WebApplicationBuilder already registers one,
+        // so this is a no-op in production (TryAddSingleton respects existing registrations).
+        // Tests that compose services from a bare ServiceCollection rely on this fallback.
         services.TryAddSingleton<IConfiguration>(_ => new ConfigurationBuilder().Build());
         services.AddSingleton(config);
         services.AddSingleton(config.Learning);

--- a/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs
@@ -159,7 +159,7 @@ internal static class RuntimeInitializationExtensions
         skillWatcher.Start(app.Lifetime.ApplicationStopping);
 
         await services.AutomationService.RefreshCacheAsync(app.Lifetime.ApplicationStopping);
-        var cronTask = StartCronIfEnabled(loggerFactory, services.Pipeline, services.CronJobSource, app.Lifetime.ApplicationStopping);
+        var cronTask = app.Services.GetRequiredService<CronScheduler>();
         StartNativeEventBridges(config, loggerFactory, services.Pipeline, app.Lifetime.ApplicationStopping);
 
         var profile = app.Services.GetRequiredService<IRuntimeProfile>();
@@ -699,20 +699,6 @@ internal static class RuntimeInitializationExtensions
             costChecker: costChecker));
 
         return new MiddlewarePipeline(middlewareList);
-    }
-
-    private static CronScheduler? StartCronIfEnabled(
-        ILoggerFactory loggerFactory,
-        MessagePipeline pipeline,
-        ICronJobSource jobSource,
-        CancellationToken stoppingToken)
-    {
-        var logger = loggerFactory.CreateLogger<CronScheduler>();
-        var cronTask = new CronScheduler(jobSource, logger, pipeline.InboundWriter);
-        _ = cronTask.StartAsync(stoppingToken).ContinueWith(
-            t => logger.LogError(t.Exception!.InnerException, "CronScheduler failed to start"),
-            TaskContinuationOptions.OnlyOnFaulted);
-        return cronTask;
     }
 
     private static void StartNativeEventBridges(

--- a/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs
@@ -159,7 +159,7 @@ internal static class RuntimeInitializationExtensions
         skillWatcher.Start(app.Lifetime.ApplicationStopping);
 
         await services.AutomationService.RefreshCacheAsync(app.Lifetime.ApplicationStopping);
-        var cronTask = app.Services.GetRequiredService<CronScheduler>();
+        var cronScheduler = app.Services.GetRequiredService<CronScheduler>();
         StartNativeEventBridges(config, loggerFactory, services.Pipeline, app.Lifetime.ApplicationStopping);
 
         var profile = app.Services.GetRequiredService<IRuntimeProfile>();
@@ -176,7 +176,7 @@ internal static class RuntimeInitializationExtensions
             orchestratorId,
             tools,
             skills,
-            cronTask);
+            cronScheduler);
 
         services.PluginHealth.SetRuntimeReports(
             runtime.PluginReports,
@@ -430,7 +430,7 @@ internal static class RuntimeInitializationExtensions
         string orchestratorId,
         IReadOnlyList<ITool> tools,
         IReadOnlyList<SkillDefinition> skills,
-        CronScheduler? cronTask)
+        CronScheduler? cronScheduler)
     {
         var operations = new RuntimeOperationsState
         {
@@ -484,7 +484,7 @@ internal static class RuntimeInitializationExtensions
                 : null,
             DynamicProviderOwners = pluginComposition.DynamicProviderOwners,
             EstimatedSkillPromptChars = SkillPromptBuilder.EstimateCharacterCost(skills),
-            CronTask = cronTask,
+            CronTask = cronScheduler,
             TwilioSmsWebhookHandler = channelComposition.TwilioSmsWebhookHandler,
             PluginHost = pluginComposition.PluginHost,
             NativeDynamicPluginHost = pluginComposition.NativeDynamicPluginHost,

--- a/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
+++ b/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
@@ -51,6 +51,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
     <PackageReference Include="QRCoder" Version="1.6.0" />
+    <PackageReference Include="TickerQ" Version="10.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenClaw.Gateway/Pipeline/CronSchedulerStartupService.cs
+++ b/src/OpenClaw.Gateway/Pipeline/CronSchedulerStartupService.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Hosting;
+using OpenClaw.Core.Pipeline;
+
+namespace OpenClaw.Gateway.Pipeline;
+
+internal sealed class CronSchedulerStartupService : IHostedService
+{
+    private readonly CronScheduler _scheduler;
+
+    public CronSchedulerStartupService(CronScheduler scheduler)
+        => _scheduler = scheduler;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+        => _scheduler.RunStartupJobsAsync(cancellationToken);
+
+    public Task StopAsync(CancellationToken cancellationToken)
+        => Task.CompletedTask;
+}

--- a/src/OpenClaw.Gateway/Pipeline/CronSchedulerTickerFunction.cs
+++ b/src/OpenClaw.Gateway/Pipeline/CronSchedulerTickerFunction.cs
@@ -1,0 +1,16 @@
+using OpenClaw.Core.Pipeline;
+using TickerQ.Utilities.Base;
+
+namespace OpenClaw.Gateway.Pipeline;
+
+internal sealed class CronSchedulerTickerFunction
+{
+    private readonly CronScheduler _scheduler;
+
+    public CronSchedulerTickerFunction(CronScheduler scheduler)
+        => _scheduler = scheduler;
+
+    [TickerFunction("openclaw-cron-scan", cronExpression: "* * * * *")]
+    public Task ExecuteAsync(TickerFunctionContext context, CancellationToken cancellationToken)
+        => _scheduler.RunTickAsync(cancellationToken);
+}

--- a/src/OpenClaw.Gateway/Program.cs
+++ b/src/OpenClaw.Gateway/Program.cs
@@ -5,6 +5,7 @@ using OpenClaw.Gateway.Endpoints;
 using OpenClaw.Gateway.Mcp;
 using OpenClaw.Gateway.Pipeline;
 using OpenClaw.Gateway.Profiles;
+using TickerQ.DependencyInjection;
 #if OPENCLAW_ENABLE_MAF_EXPERIMENT
 using OpenClaw.Gateway.A2A;
 using OpenClaw.MicrosoftAgentFrameworkAdapter;
@@ -43,6 +44,7 @@ builder.Services.AddOpenSandboxIntegration(builder.Configuration);
 #endif
 
 var app = builder.Build();
+app.UseTickerQ();
 var runtime = await app.InitializeOpenClawRuntimeAsync(startup);
 
 app.InitializeMcpRuntime(runtime);

--- a/src/OpenClaw.Gateway/appsettings.json
+++ b/src/OpenClaw.Gateway/appsettings.json
@@ -263,7 +263,7 @@
   },
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Information"
     }
   }
 }

--- a/src/OpenClaw.Gateway/appsettings.json
+++ b/src/OpenClaw.Gateway/appsettings.json
@@ -263,7 +263,7 @@
   },
   "Logging": {
     "LogLevel": {
-      "Default": "Information"
+      "Default": "Warning"
     }
   }
 }

--- a/src/OpenClaw.Tests/ResilienceTests.cs
+++ b/src/OpenClaw.Tests/ResilienceTests.cs
@@ -169,6 +169,13 @@ public sealed class ResilienceTests
         Assert.Equal(expected, CronScheduler.IsTime(expression, time));
     }
 
+    [Fact]
+    public void CronScheduler_IsTime_IgnoresSubSecondPrecision()
+    {
+        var time = new DateTimeOffset(2026, 1, 1, 12, 30, 0, 250, TimeSpan.Zero);
+        Assert.True(CronScheduler.IsTime("30 12 * * *", time));
+    }
+
     [Theory]
     [InlineData("0 9-17 * * 1-5", 0, 10, DayOfWeek.Monday, true)]
     [InlineData("0 9-17 * * 1-5", 0, 8, DayOfWeek.Monday, false)]

--- a/src/OpenClaw.Tests/ResilienceTests.cs
+++ b/src/OpenClaw.Tests/ResilienceTests.cs
@@ -157,6 +157,48 @@ public sealed class ResilienceTests
         Assert.False(CronScheduler.IsTime("0 0 L * *", notMatching));
     }
 
+    [Theory]
+    [InlineData("0,15,30,45 * * * *", 15, true)]
+    [InlineData("0,15,30,45 * * * *", 14, false)]
+    [InlineData("*/10 * * * *", 0, true)]
+    [InlineData("*/10 * * * *", 20, true)]
+    [InlineData("*/10 * * * *", 5, false)]
+    public void CronScheduler_IsTime_SupportsListsAndStepWildcards(string expression, int minute, bool expected)
+    {
+        var time = new DateTimeOffset(2026, 1, 1, 12, minute, 0, TimeSpan.Zero);
+        Assert.Equal(expected, CronScheduler.IsTime(expression, time));
+    }
+
+    [Theory]
+    [InlineData("0 9-17 * * 1-5", 0, 10, DayOfWeek.Monday, true)]
+    [InlineData("0 9-17 * * 1-5", 0, 8, DayOfWeek.Monday, false)]
+    [InlineData("0 9-17 * * 1-5", 0, 10, DayOfWeek.Saturday, false)]
+    public void CronScheduler_IsTime_SupportsDayOfWeekRanges(string expression, int minute, int hour, DayOfWeek dow, bool expected)
+    {
+        // Find a date in 2026 matching the given day of week
+        var baseDate = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        while (baseDate.DayOfWeek != dow)
+            baseDate = baseDate.AddDays(1);
+        var time = new DateTimeOffset(baseDate.Year, baseDate.Month, baseDate.Day, hour, minute, 0, TimeSpan.Zero);
+        Assert.Equal(expected, CronScheduler.IsTime(expression, time));
+    }
+
+    [Fact]
+    public void CronScheduler_IsTime_EmptyExpression_ReturnsFalse()
+    {
+        var time = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        Assert.False(CronScheduler.IsTime("", time));
+        Assert.False(CronScheduler.IsTime("   ", time));
+    }
+
+    [Fact]
+    public void CronScheduler_IsTime_InvalidExpression_ReturnsFalse()
+    {
+        var time = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        Assert.False(CronScheduler.IsTime("not a cron", time));
+        Assert.False(CronScheduler.IsTime("60 * * * *", time)); // minute out of range
+    }
+
     [Fact]
     public async Task CircuitBreaker_ThreadSafety_ConcurrentCalls()
     {


### PR DESCRIPTION
## Credit

This PR carries forward **@geffzhang**'s work from #57 — the TickerQ integration, `CronScheduler` refactor, `CronSchedulerStartupService`, and `CronSchedulerTickerFunction` are all authored by them (commit authorship preserved). This branch exists to address the review concerns on that PR so it can land cleanly; no original design decisions were changed.

## Summary

- Replaces the in-repo 5-field cron matcher with TickerQ 10.3.0 driving `CronScheduler.RunTickAsync` from a TickerQ function. Keeps the existing enqueueing, stale-run cleanup, and timezone logic intact.
- Adds `CronSchedulerStartupService` that runs `RunOnStartup` jobs at app start.
- Adds `CronSchedulerTickerFunction` registered with `[TickerFunction("openclaw-cron-scan", cronExpression: "* * * * *")]`.
- Uses `NCrontab` inside `CronScheduler.IsTime` for actual schedule math (TickerQ provides the parser).

## Review feedback addressed (vs #57)

- **Revert unrelated log-level change**: `appsettings.json` `Logging:LogLevel:Default` stays at `Warning`.
- **Declare `NCrontab` explicitly**: Added `NCrontab 3.3.0` to `OpenClaw.Core.csproj` (was only pulled in transitively via TickerQ).
- **Drop PR #55's LearningService hunk**: Already on main; this branch rebases cleanly.
- **Justify `TryAddSingleton<IConfiguration>`**: Added a comment explaining it's a no-op when `WebApplicationBuilder` registers `IConfiguration`; the fallback exists for bare-`ServiceCollection` tests. `TryAdd` semantics ensure it never shadows a real config.
- **Add cron edge-case tests**: `ResilienceTests.cs` now covers lists (`0,15,30,45 * * * *`), step wildcards (`*/10 * * * *`), day-of-week ranges (`0 9-17 * * 1-5`), empty expressions, and invalid expressions.

## NativeAOT

- `IsAotCompatible=true` is preserved on `OpenClaw.Core`.
- Local AOT publish on macOS Apple Silicon hits a pre-existing `ld: Assertion failed: (_addend < largeAddends.size())` linker bug that also fails on unmodified `main`; CI's Linux AOT job is the authoritative check.

## Validation

- `dotnet build src/OpenClaw.Tests/OpenClaw.Tests.csproj -c Release` — 0 warnings, 0 errors
- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj -c Release` — **805 / 805 pass** (includes 10 new cron tests)

## Test plan
- [ ] CI build-and-test passes
- [ ] CI publish-aot passes
- [ ] Smoke test: boot gateway, confirm cron jobs with `RunOnStartup=true` fire at startup
- [ ] Smoke test: confirm a `* * * * *` job fires each minute

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: geffzhang <geffzhang@qq.com>