### PR TITLE
Refresh web chat UI design

### DIFF
--- a/src/OpenClaw.Gateway/wwwroot/webchat.html
+++ b/src/OpenClaw.Gateway/wwwroot/webchat.html
@@ -677,6 +677,10 @@
                 animation-iteration-count: 1 !important;
                 transition-duration: 0.01ms !important;
             }
+
+            #chat-wrapper {
+                scroll-behavior: auto;
+            }
         }
     </style>
 </head>

--- a/src/OpenClaw.Gateway/wwwroot/webchat.html
+++ b/src/OpenClaw.Gateway/wwwroot/webchat.html
@@ -5,30 +5,43 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OpenClaw.NET WebChat</title>
-    <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
-        rel="stylesheet">
+    <!-- System fonts only; no web font fetch. -->
     <!-- Highlight.js for Code Blocks -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
 
     <style>
         :root {
-            --bg: #050505;
-            --surface-glass: rgba(15, 15, 17, 0.7);
-            --surface: rgba(24, 24, 27, 0.6);
-            --surface-hover: rgba(39, 39, 42, 0.8);
-            --primary: #6366f1;
-            --primary-gradient: linear-gradient(135deg, #6366f1, #d946ef);
-            --secondary: #14b8a6;
-            --error: #ef4444;
-            --text: #fafafa;
-            --text-secondary: #a1a1aa;
-            --border: rgba(255, 255, 255, 0.08);
-            --radius-lg: 16px;
-            --radius-message: 20px;
+            color-scheme: dark;
+            --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", "Inter", "Helvetica Neue", Arial, sans-serif;
+            --font-mono: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+
+            --bg: #000000;
+            --bg-elevated: #1c1c1e;
+            --bg-elevated-2: #2c2c2e;
+            --bg-field: rgba(118, 118, 128, 0.24);
+            --bg-field-hover: rgba(118, 118, 128, 0.36);
+
+            --text: #f5f5f7;
+            --text-secondary: rgba(235, 235, 245, 0.60);
+            --text-tertiary: rgba(235, 235, 245, 0.30);
+
+            --separator: rgba(255, 255, 255, 0.08);
+            --separator-strong: rgba(255, 255, 255, 0.14);
+
+            --accent: #0a84ff;
+            --accent-hover: #409cff;
+            --accent-pressed: #0060d4;
+            --success: #30d158;
+            --warning: #ff9f0a;
+            --error: #ff453a;
+
+            --radius-chip: 980px;
+            --radius-bubble: 18px;
+            --radius-input: 22px;
+            --radius-card: 14px;
+
+            --ease: cubic-bezier(0.4, 0.0, 0.2, 1);
+            --ease-bounce: cubic-bezier(0.175, 0.885, 0.32, 1.275);
         }
 
         * {
@@ -37,106 +50,71 @@
             padding: 0;
         }
 
+        html, body {
+            height: 100%;
+        }
+
         body {
-            font-family: 'Outfit', system-ui, -apple-system, sans-serif;
-            background-color: var(--bg);
-            background-image:
-                radial-gradient(circle at 15% 50%, rgba(99, 102, 241, 0.08) 0%, transparent 50%),
-                radial-gradient(circle at 85% 30%, rgba(217, 70, 239, 0.08) 0%, transparent 50%),
-                radial-gradient(circle at 50% 100%, rgba(20, 184, 166, 0.05) 0%, transparent 50%);
-            background-attachment: fixed;
+            font-family: var(--font-sans);
+            font-feature-settings: "ss01", "cv11";
+            background: var(--bg);
             color: var(--text);
             height: 100vh;
             display: flex;
             flex-direction: column;
             overflow: hidden;
             -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            letter-spacing: -0.01em;
         }
 
-        /* Ambient animated blobs */
-        .ambient-blob {
-            position: absolute;
-            border-radius: 50%;
-            filter: blur(80px);
-            opacity: 0.5;
-            z-index: -1;
-            animation: float 20s infinite alternate cubic-bezier(0.45, 0.05, 0.55, 0.95);
-            pointer-events: none;
+        button {
+            font-family: inherit;
         }
 
-        .blob-1 {
-            background: rgba(99, 102, 241, 0.2);
-            width: 400px;
-            height: 400px;
-            top: -100px;
-            left: -100px;
-        }
+        /* ============================== Header ============================== */
 
-        .blob-2 {
-            background: rgba(217, 70, 239, 0.15);
-            width: 300px;
-            height: 300px;
-            bottom: -50px;
-            right: -50px;
-            animation-delay: -5s;
-        }
-
-        @keyframes float {
-            0% {
-                transform: translate(0, 0) scale(1);
-            }
-
-            100% {
-                transform: translate(50px, 30px) scale(1.1);
-            }
-        }
-
-        /* Glass Header */
         #header {
-            background-color: var(--surface-glass);
-            backdrop-filter: blur(24px);
-            -webkit-backdrop-filter: blur(24px);
-            padding: 1rem 2rem;
+            background: rgba(28, 28, 30, 0.72);
+            backdrop-filter: saturate(180%) blur(28px);
+            -webkit-backdrop-filter: saturate(180%) blur(28px);
+            padding: 0.75rem 1.5rem;
             display: flex;
             justify-content: space-between;
             align-items: center;
-            border-bottom: 1px solid var(--border);
+            border-bottom: 1px solid var(--separator);
             z-index: 10;
-            box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+            flex-shrink: 0;
         }
 
         .header-brand {
             display: flex;
             align-items: center;
-            gap: 1rem;
+            gap: 0.75rem;
         }
 
         .header-brand img {
-            width: 38px;
-            height: 38px;
+            width: 28px;
+            height: 28px;
             object-fit: contain;
-            filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.1));
-            transition: transform 0.3s ease;
-        }
-
-        .header-brand:hover img {
-            transform: scale(1.05) rotate(5deg);
         }
 
         #header h2 {
-            font-size: 1.6rem;
-            font-weight: 700;
-            letter-spacing: -0.5px;
-            background: var(--primary-gradient);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            font-size: 1.0625rem;
+            font-weight: 600;
+            letter-spacing: -0.02em;
+            color: var(--text);
         }
 
         #header .header-right {
             display: flex;
             align-items: center;
-            gap: 1rem;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+            justify-content: flex-end;
         }
+
+        /* ============================== Controls ============================== */
 
         #token-input,
         #doctor-button,
@@ -148,83 +126,116 @@
         #live-mic-button,
         #live-interrupt-button,
         .live-status-badge {
-            background: rgba(255, 255, 255, 0.03);
-            border: 1px solid var(--border);
+            background: var(--bg-field);
+            border: 1px solid transparent;
             color: var(--text);
-            padding: 0.6rem 1.2rem;
-            border-radius: 99px;
-            font-family: 'Outfit', sans-serif;
-            font-size: 0.95rem;
-            transition: all 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
+            padding: 0.4rem 0.9rem;
+            height: 32px;
+            border-radius: var(--radius-chip);
+            font-family: var(--font-sans);
+            font-size: 0.8125rem;
+            font-weight: 500;
+            transition: background-color 150ms var(--ease), border-color 150ms var(--ease), color 150ms var(--ease), transform 90ms var(--ease);
+            line-height: 1;
         }
 
         #token-input,
         #voice-id-input {
-            width: 240px;
-            font-family: 'JetBrains Mono', monospace;
-            font-size: 0.9rem;
+            width: 220px;
+            font-family: var(--font-mono);
+            font-size: 0.78rem;
+            font-weight: 400;
+            letter-spacing: 0;
+        }
+
+        #token-input::placeholder,
+        #voice-id-input::placeholder,
+        #message-input::placeholder {
+            color: var(--text-tertiary);
         }
 
         #token-input:focus,
-        #voice-id-input:focus,
+        #voice-id-input:focus {
+            outline: none;
+            background: var(--bg-elevated-2);
+            border-color: var(--accent);
+        }
+
         #doctor-button:hover,
         #mode-select:hover,
         #live-provider-select:hover,
         #speech-provider-select:hover,
         #live-connect-button:hover,
-        #live-mic-button:hover,
-        #live-interrupt-button:hover,
-        .live-status-badge:hover {
-            outline: none;
-            border-color: rgba(168, 85, 247, 0.5);
-            background: rgba(255, 255, 255, 0.08);
-            box-shadow: 0 0 15px rgba(168, 85, 247, 0.15);
+        #live-mic-button:hover:not(:disabled),
+        #live-interrupt-button:hover:not(:disabled) {
+            background: var(--bg-field-hover);
+        }
+
+        #doctor-button:active:not(:disabled),
+        #live-connect-button:active:not(:disabled),
+        #live-mic-button:active:not(:disabled),
+        #live-interrupt-button:active:not(:disabled) {
+            transform: scale(0.97);
+        }
+
+        #doctor-button,
+        #live-connect-button,
+        #live-mic-button,
+        #live-interrupt-button,
+        #mode-select,
+        #live-provider-select,
+        #speech-provider-select {
+            cursor: pointer;
         }
 
         #mode-select,
         #live-provider-select,
         #speech-provider-select {
-            width: auto;
-            min-width: 120px;
+            appearance: none;
+            -webkit-appearance: none;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%23999' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: right 0.75rem center;
+            padding-right: 2rem;
+            min-width: 0;
         }
 
-        #live-connect-button,
-        #live-mic-button,
-        #live-interrupt-button {
-            cursor: pointer;
-            font-weight: 500;
+        #live-mic-button[disabled],
+        #live-interrupt-button[disabled] {
+            opacity: 0.4;
+            cursor: not-allowed;
         }
 
         #live-mic-button.active {
-            border-color: rgba(20, 184, 166, 0.5);
-            color: #ccfbf1;
-            box-shadow: 0 0 15px rgba(20, 184, 166, 0.2);
+            background: rgba(48, 209, 88, 0.18);
+            color: #a7f0be;
         }
 
         .live-status-badge {
             display: inline-flex;
             align-items: center;
-            gap: 0.5rem;
+            gap: 0.4rem;
             color: var(--text-secondary);
-            padding-inline: 0.95rem;
+            padding: 0.4rem 0.8rem 0.4rem 0.75rem;
+            cursor: default;
         }
 
         .live-status-badge::before {
             content: '';
-            width: 9px;
-            height: 9px;
+            width: 7px;
+            height: 7px;
             border-radius: 50%;
-            background: #71717a;
+            background: var(--text-tertiary);
+            transition: background 150ms var(--ease), box-shadow 150ms var(--ease);
         }
 
         .live-status-badge.online {
-            color: #ccfbf1;
-            border-color: rgba(20, 184, 166, 0.4);
+            color: var(--text);
         }
 
         .live-status-badge.online::before {
-            background: var(--secondary);
-            box-shadow: 0 0 10px rgba(20, 184, 166, 0.7);
+            background: var(--success);
+            box-shadow: 0 0 0 3px rgba(48, 209, 88, 0.18);
         }
 
         #remember-token-wrap {
@@ -232,57 +243,51 @@
             align-items: center;
             gap: 0.35rem;
             color: var(--text-secondary);
-            font-size: 0.78rem;
+            font-size: 0.75rem;
             white-space: nowrap;
             user-select: none;
         }
 
         #remember-token {
-            accent-color: #a855f7;
+            accent-color: var(--accent);
             width: 14px;
             height: 14px;
             cursor: pointer;
         }
 
-        #doctor-button {
-            cursor: pointer;
-            font-weight: 500;
-        }
+        /* ============================== Chat Stream ============================== */
 
-        #doctor-button:active {
-            transform: scale(0.95);
-        }
-
-        /* Chat Stream Container */
         #chat-wrapper {
             flex-grow: 1;
             overflow-y: auto;
             display: flex;
             justify-content: center;
             scroll-behavior: smooth;
+            background: var(--bg);
         }
 
         #chat-container {
             width: 100%;
-            max-width: 900px;
-            padding: 2rem 1.5rem;
+            max-width: 780px;
+            padding: 2rem 1.5rem 1rem;
             display: flex;
             flex-direction: column;
-            gap: 1.5rem;
+            gap: 0.5rem;
         }
 
-        /* Message Bubbles */
+        /* ============================== Message rows ============================== */
+
         .message-row {
             display: flex;
             width: 100%;
-            gap: 1rem;
+            gap: 0.625rem;
             align-items: flex-end;
-            animation: slideUp 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+            animation: fadeSlide 280ms var(--ease) forwards;
             opacity: 0;
-            transform: translateY(20px);
+            transform: translateY(8px);
         }
 
-        @keyframes slideUp {
+        @keyframes fadeSlide {
             to {
                 opacity: 1;
                 transform: translateY(0);
@@ -302,227 +307,208 @@
             justify-content: center;
         }
 
-        .agent-avatar {
-            width: 44px;
-            height: 44px;
-            border-radius: 12px;
-            background: rgba(255, 255, 255, 0.05);
-            border: 1px solid var(--border);
+        .agent-avatar,
+        .user-avatar {
+            width: 28px;
+            height: 28px;
+            border-radius: 50%;
             display: flex;
             align-items: center;
             justify-content: center;
             flex-shrink: 0;
+            margin-bottom: 2px;
+        }
+
+        .agent-avatar {
+            background: var(--bg-elevated);
+            border: 1px solid var(--separator);
             overflow: hidden;
-            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
-            margin-bottom: 0.2rem;
         }
 
         .agent-avatar img {
-            width: 26px;
-            height: 26px;
+            width: 18px;
+            height: 18px;
             object-fit: contain;
         }
 
         .user-avatar {
-            width: 44px;
-            height: 44px;
-            border-radius: 12px;
-            background: var(--primary-gradient);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            flex-shrink: 0;
+            background: var(--bg-elevated-2);
+            color: var(--text);
             font-weight: 600;
-            font-size: 1.2rem;
-            color: #fff;
-            box-shadow: 0 4px 15px rgba(168, 85, 247, 0.3);
-            margin-bottom: 0.2rem;
+            font-size: 0.7rem;
+            letter-spacing: 0.02em;
         }
 
+        /* ============================== Message bubbles ============================== */
+
         .message {
-            max-width: 80%;
-            padding: 1.2rem 1.6rem;
-            border-radius: var(--radius-message);
-            line-height: 1.6;
+            max-width: 68%;
+            padding: 0.5rem 0.875rem;
+            border-radius: var(--radius-bubble);
+            line-height: 1.4;
             word-wrap: break-word;
-            font-size: 1.05rem;
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+            font-size: 0.9375rem;
         }
 
         .message.user {
-            background: var(--primary-gradient);
+            background: var(--accent);
             color: #ffffff;
             border-bottom-right-radius: 6px;
         }
 
         .message.assistant {
-            background-color: var(--surface);
-            border: 1px solid var(--border);
-            border-bottom-left-radius: 6px;
+            background: var(--bg-elevated);
             color: var(--text);
-            backdrop-filter: blur(12px);
+            border-bottom-left-radius: 6px;
         }
 
         .message.system {
-            background-color: transparent;
-            box-shadow: none;
+            background: transparent;
             color: var(--text-secondary);
-            font-size: 0.9rem;
+            font-size: 0.8125rem;
             text-align: center;
-            padding: 0.5rem 1rem;
+            padding: 0.25rem 0.75rem;
             display: flex;
             align-items: center;
             gap: 0.5rem;
+            max-width: 100%;
         }
 
         .message.system.error {
             color: var(--error);
-            background: rgba(239, 68, 68, 0.1);
-            border: 1px solid rgba(239, 68, 68, 0.2);
-            border-radius: 99px;
-            padding: 0.4rem 1rem;
+            background: rgba(255, 69, 58, 0.12);
+            border-radius: var(--radius-chip);
+            padding: 0.25rem 0.75rem;
         }
 
-        /* Tool Pills */
+        /* ============================== Tool pills ============================== */
+
         .tool-pill {
-            background: rgba(20, 184, 166, 0.1);
-            border: 1px solid rgba(20, 184, 166, 0.25);
-            color: var(--secondary);
-            padding: 0.4rem 1.2rem;
-            border-radius: 999px;
-            font-size: 0.85rem;
+            background: var(--bg-elevated);
+            border: 1px solid var(--separator);
+            color: var(--text-secondary);
+            padding: 0.25rem 0.75rem;
+            border-radius: var(--radius-chip);
+            font-size: 0.75rem;
             font-weight: 500;
+            letter-spacing: 0;
             display: inline-flex;
             align-items: center;
-            gap: 0.6rem;
-            margin: 0.5rem auto;
+            gap: 0.45rem;
+            margin: 0.125rem auto;
             align-self: center;
-            backdrop-filter: blur(8px);
-            transition: all 0.3s ease;
-        }
-
-        .tool-pill:hover {
-            background: rgba(20, 184, 166, 0.2);
-            transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(20, 184, 166, 0.2);
         }
 
         .tool-pill::before {
             content: '';
-            display: inline-block;
-            width: 8px;
-            height: 8px;
+            width: 6px;
+            height: 6px;
             border-radius: 50%;
-            background-color: var(--secondary);
-            box-shadow: 0 0 8px var(--secondary);
-            animation: pulse-dot 2s infinite cubic-bezier(0.4, 0, 0.6, 1);
+            background: var(--accent);
+            animation: pulse-dot 1.8s infinite var(--ease);
         }
 
-        /* Markdown Styles */
+        /* ============================== Markdown in assistant bubble ============================== */
+
         .message.assistant p:not(:last-child) {
-            margin-bottom: 1rem;
+            margin-bottom: 0.75rem;
         }
 
         .message.assistant a {
-            color: #a5b4fc;
+            color: var(--accent);
             text-decoration: none;
-            border-bottom: 1px solid transparent;
-            transition: border-color 0.2s;
         }
 
         .message.assistant a:hover {
-            border-color: #a5b4fc;
+            text-decoration: underline;
         }
 
         .message.assistant code:not(pre code) {
-            background: rgba(255, 255, 255, 0.1);
-            padding: 0.2em 0.5em;
-            border-radius: 6px;
-            font-family: 'JetBrains Mono', monospace;
-            font-size: 0.9em;
-            color: #d8b4fe;
+            background: var(--bg-elevated-2);
+            padding: 0.1em 0.4em;
+            border-radius: 5px;
+            font-family: var(--font-mono);
+            font-size: 0.86em;
+            color: #ff9f8a;
         }
 
         .message.assistant pre {
-            background: rgba(0, 0, 0, 0.5);
-            border-radius: 12px;
-            padding: 1.2rem;
-            margin: 1.2rem 0;
+            background: var(--bg);
+            border: 1px solid var(--separator);
+            border-radius: 10px;
+            padding: 0.875rem 1rem;
+            margin: 0.75rem 0;
             overflow-x: auto;
-            border: 1px solid var(--border);
-            box-shadow: inset 0 2px 10px rgba(0, 0, 0, 0.3);
         }
 
         .message.assistant pre code {
-            font-family: 'JetBrains Mono', monospace;
-            font-size: 0.9rem;
-            line-height: 1.5;
+            font-family: var(--font-mono);
+            font-size: 0.8125rem;
+            line-height: 1.55;
             padding: 0;
             background: transparent;
-            color: #e4e4e7;
+            color: #d4d4d4;
         }
 
         .message.assistant ul,
         .message.assistant ol {
-            padding-left: 1.5rem;
-            margin-bottom: 1rem;
+            padding-left: 1.25rem;
+            margin-bottom: 0.75rem;
         }
 
         .message.assistant li {
-            margin-bottom: 0.3rem;
+            margin-bottom: 0.2rem;
         }
 
-        /* Typing Indicator */
+        .message.assistant h1,
+        .message.assistant h2,
+        .message.assistant h3 {
+            font-weight: 600;
+            letter-spacing: -0.01em;
+            margin: 0.75rem 0 0.4rem;
+        }
+
+        .message.assistant h1 { font-size: 1.1rem; }
+        .message.assistant h2 { font-size: 1.0rem; }
+        .message.assistant h3 { font-size: 0.95rem; }
+
+        /* ============================== Typing indicator ============================== */
+
         .typing-row {
             display: none;
             justify-content: flex-start;
             width: 100%;
-            margin-bottom: 0.5rem;
+            gap: 0.625rem;
+            align-items: flex-end;
+            margin: 0.125rem 0;
         }
 
         .typing-indicator {
-            background-color: var(--surface);
-            border: 1px solid var(--border);
-            padding: 1.2rem 1.6rem;
-            border-radius: var(--radius-message);
+            background: var(--bg-elevated);
+            padding: 0.75rem 1rem;
+            border-radius: var(--radius-bubble);
             border-bottom-left-radius: 6px;
             display: flex;
-            gap: 0.5rem;
+            gap: 0.3rem;
             align-items: center;
-            backdrop-filter: blur(12px);
         }
 
         .dot {
-            width: 8px;
-            height: 8px;
-            background-color: var(--text-secondary);
+            width: 6px;
+            height: 6px;
+            background: var(--text-tertiary);
             border-radius: 50%;
-            animation: bounce 1.4s infinite ease-in-out both;
+            animation: bounce 1.3s infinite ease-in-out both;
         }
 
-        .dot:nth-child(1) {
-            animation-delay: -0.32s;
-            background: #6366f1;
-        }
-
-        .dot:nth-child(2) {
-            animation-delay: -0.16s;
-            background: #a855f7;
-        }
-
-        .dot:nth-child(3) {
-            background: #ec4899;
-        }
+        .dot:nth-child(1) { animation-delay: -0.32s; }
+        .dot:nth-child(2) { animation-delay: -0.16s; }
 
         @keyframes bounce {
-
-            0%,
-            80%,
-            100% {
-                transform: scale(0);
-                opacity: 0.5;
+            0%, 80%, 100% {
+                transform: scale(0.6);
+                opacity: 0.4;
             }
-
             40% {
                 transform: scale(1);
                 opacity: 1;
@@ -530,79 +516,67 @@
         }
 
         @keyframes pulse-dot {
-
-            0%,
-            100% {
-                opacity: 1;
-                transform: scale(1);
-            }
-
-            50% {
-                opacity: .5;
-                transform: scale(0.8);
-            }
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.4; }
         }
 
-        /* Glass Input Container */
+        /* ============================== Composer ============================== */
+
         #input-wrapper {
-            background-color: rgba(15, 15, 17, 0.85);
-            backdrop-filter: blur(24px);
-            -webkit-backdrop-filter: blur(24px);
-            border-top: 1px solid var(--border);
-            padding: 1.5rem 0;
+            background: rgba(28, 28, 30, 0.80);
+            backdrop-filter: saturate(180%) blur(28px);
+            -webkit-backdrop-filter: saturate(180%) blur(28px);
+            border-top: 1px solid var(--separator);
+            padding: 1rem 0 1.25rem;
             display: flex;
             justify-content: center;
             z-index: 10;
+            flex-shrink: 0;
         }
 
         #composer-shell {
             width: 100%;
-            max-width: 900px;
+            max-width: 780px;
             padding: 0 1.5rem;
             display: flex;
             flex-direction: column;
-            gap: 0.9rem;
+            gap: 0.75rem;
         }
 
         #live-toolbar {
             display: flex;
             flex-wrap: wrap;
-            gap: 0.75rem;
+            gap: 0.4rem;
             align-items: center;
         }
 
         #input-container {
             width: 100%;
             display: flex;
-            gap: 1rem;
+            gap: 0.625rem;
             align-items: flex-end;
         }
 
         #message-input {
             flex-grow: 1;
-            background: rgba(255, 255, 255, 0.04);
-            border: 1px solid var(--border);
+            background: var(--bg-elevated);
+            border: 1px solid var(--separator);
             color: var(--text);
-            padding: 1rem 1.4rem;
-            border-radius: var(--radius-message);
-            font-family: 'Outfit', sans-serif;
-            font-size: 1.05rem;
+            padding: 0.75rem 1rem;
+            border-radius: var(--radius-input);
+            font-family: var(--font-sans);
+            font-size: 0.9375rem;
+            line-height: 1.4;
             resize: none;
-            min-height: 56px;
+            min-height: 44px;
             max-height: 200px;
-            transition: all 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
-            box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+            transition: border-color 150ms var(--ease), background-color 150ms var(--ease);
         }
 
         #message-input:focus {
             outline: none;
-            border-color: rgba(168, 85, 247, 0.5);
-            background: rgba(255, 255, 255, 0.08);
-            box-shadow: 0 0 0 4px rgba(168, 85, 247, 0.1), inset 0 2px 4px rgba(0, 0, 0, 0.1);
-        }
-
-        #message-input::placeholder {
-            color: rgba(255, 255, 255, 0.4);
+            border-color: var(--accent);
+            background: var(--bg-elevated-2);
         }
 
         #message-input:disabled {
@@ -611,49 +585,46 @@
         }
 
         #send-button {
-            background: var(--primary-gradient);
+            background: var(--accent);
             color: #ffffff;
             border: none;
-            width: 56px;
-            height: 56px;
+            width: 32px;
+            height: 32px;
             border-radius: 50%;
             display: flex;
             align-items: center;
             justify-content: center;
             cursor: pointer;
-            transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-            box-shadow: 0 4px 15px rgba(168, 85, 247, 0.3);
+            transition: background-color 150ms var(--ease), transform 90ms var(--ease);
             flex-shrink: 0;
+            margin-bottom: 6px;
         }
 
         #send-button svg {
-            transition: transform 0.3s ease;
+            width: 16px;
+            height: 16px;
         }
 
         #send-button:hover:not(:disabled) {
-            transform: scale(1.08) translateY(-2px);
-            box-shadow: 0 8px 25px rgba(168, 85, 247, 0.5);
-        }
-
-        #send-button:hover:not(:disabled) svg {
-            transform: translate(2px, -2px);
+            background: var(--accent-hover);
         }
 
         #send-button:active:not(:disabled) {
-            transform: scale(0.95);
+            transform: scale(0.92);
+            background: var(--accent-pressed);
         }
 
         #send-button:disabled {
-            background: rgba(255, 255, 255, 0.08);
-            color: rgba(255, 255, 255, 0.3);
-            box-shadow: none;
+            background: var(--bg-field);
+            color: var(--text-tertiary);
             cursor: not-allowed;
-            transform: none;
         }
 
-        /* Scrollbar Styling */
+        /* ============================== Scrollbars ============================== */
+
         ::-webkit-scrollbar {
-            width: 8px;
+            width: 10px;
+            height: 10px;
         }
 
         ::-webkit-scrollbar-track {
@@ -661,45 +632,56 @@
         }
 
         ::-webkit-scrollbar-thumb {
-            background: rgba(255, 255, 255, 0.15);
+            background: rgba(255, 255, 255, 0.10);
             border-radius: 10px;
+            border: 2px solid transparent;
+            background-clip: padding-box;
         }
 
         ::-webkit-scrollbar-thumb:hover {
-            background: rgba(255, 255, 255, 0.25);
+            background: rgba(255, 255, 255, 0.20);
+            background-clip: padding-box;
+            border: 2px solid transparent;
         }
 
-        /* Media Queries for responsiveness */
+        /* ============================== Responsive ============================== */
+
         @media (max-width: 768px) {
             #header {
-                padding: 1rem;
-                flex-direction: column;
-                gap: 1rem;
+                padding: 0.75rem 1rem;
+                flex-wrap: wrap;
+                gap: 0.5rem;
             }
 
             #composer-shell {
                 padding: 0 1rem;
             }
 
-            #header h2 {
-                font-size: 1.4rem;
-            }
-
             #chat-container {
-                padding: 1.5rem 1rem;
+                padding: 1.25rem 1rem 0.75rem;
             }
 
             .message {
-                max-width: 90%;
+                max-width: 82%;
+            }
+
+            #token-input,
+            #voice-id-input {
+                width: 160px;
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            * {
+                animation-duration: 0.01ms !important;
+                animation-iteration-count: 1 !important;
+                transition-duration: 0.01ms !important;
             }
         }
     </style>
 </head>
 
 <body>
-    <div class="ambient-blob blob-1"></div>
-    <div class="ambient-blob blob-2"></div>
-
     <div id="header">
         <div class="header-brand">
             <img src="image.png" alt="OpenClaw.NET Logo">


### PR DESCRIPTION
## Summary

Rewrites the `<style>` block in [webchat.html](src/OpenClaw.Gateway/wwwroot/webchat.html) with a cleaner, more restrained design system. No JS, no behavior, no endpoints change — this is a visual pass only.

**Before:** purple/pink gradient, Outfit web font, animated background blobs, big 56px gradient send button, heavy glows on hover.

**After:**
- System fonts (`-apple-system`, `SF Mono` for code) — no web font fetch.
- Neutral dark palette: true black, `#1c1c1e` / `#2c2c2e` surfaces, a single blue accent (`#0a84ff`).
- iMessage-style bubbles (solid blue user right, neutral grey assistant left, 18px radius with corner notch).
- Pill-shaped 32px controls with translucent fill; custom SVG chevron on selects.
- Circular 32px send button (was 56px).
- Translucent vibrancy headers/footers (`saturate(180%) blur(28px)`).
- Removed animated blob divs; added `prefers-reduced-motion` support (including `scroll-behavior` override).
- highlight.js theme swapped from `github-dark` to `atom-one-dark` for a warmer fit.

## Scope preserved

- All DOM IDs referenced by JS (22 total) intact: `#message-input`, `#send-button`, `#live-mic-button`, `#typing-row`, `#live-status-badge`, etc.
- All class names the JS toggles/assigns preserved: `.message`/`.message.user`/`.message.assistant`/`.message.system`, `.message-row`/`.user-row`/`.assistant-row`/`.system-row`, `.agent-avatar`, `.user-avatar`, `.tool-pill`, `.typing-row`, `.live-status-badge.online`, `#live-mic-button.active`.
- Only HTML change: removed the two `<div class="ambient-blob ...">` decorative divs.

## Test plan

- [x] `dotnet test src/OpenClaw.Tests -c Release` — 821/821 passing, including `WebChat_ToolFailures_AreRenderedInTranscript` which asserts specific JS symbols still exist in the file
- [ ] Manual: load `/chat`, send a user message, confirm bubble rendering
- [ ] Manual: trigger a tool call (e.g. `web_search`), confirm `.tool-pill` renders
- [ ] Manual: toggle Live mode → Start Live → Mic toggle, confirm status badge online state and mic-active state colors
- [ ] Manual: paste a code block in an assistant reply, confirm syntax highlighting reads well against the new background
- [ ] Manual: check at narrow viewport (< 768px) that the header wraps and composer stays usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)