### PR TITLE
Companion: tool-approval queue tab

### DIFF
--- a/src/OpenClaw.Client/OpenClawHttpClient.cs
+++ b/src/OpenClaw.Client/OpenClawHttpClient.cs
@@ -47,6 +47,7 @@ public sealed class OpenClawHttpClient : IDisposable
     private readonly Uri _adminModelsDoctorUri;
     private readonly Uri _adminModelEvaluationsUri;
     private readonly Uri _adminApprovalSimulationUri;
+    private readonly Uri _toolsApproveUri;
     private readonly Uri _adminAccountResolutionUri;
     private readonly Uri _adminBackendsUri;
     private readonly Uri _adminIncidentExportUri;
@@ -107,6 +108,7 @@ public sealed class OpenClawHttpClient : IDisposable
         _adminModelsDoctorUri = new Uri(baseUri, "/admin/models/doctor");
         _adminModelEvaluationsUri = new Uri(baseUri, "/admin/models/evaluations");
         _adminApprovalSimulationUri = new Uri(baseUri, "/admin/approvals/simulate");
+        _toolsApproveUri = new Uri(baseUri, "/tools/approve");
         _adminAccountResolutionUri = new Uri(baseUri, "/admin/accounts/test-resolution");
         _adminBackendsUri = new Uri(baseUri, "/admin/backends");
         _adminIncidentExportUri = new Uri(baseUri, "/admin/incident/export");
@@ -282,6 +284,24 @@ public sealed class OpenClawHttpClient : IDisposable
         ApprovalHistoryQuery query,
         CancellationToken cancellationToken)
         => GetAsync(BuildApprovalHistoryUri(query), CoreJsonContext.Default.IntegrationApprovalHistoryResponse, cancellationToken);
+
+    public Task<OperationStatusResponse> ApproveToolRequestAsync(string approvalId, CancellationToken cancellationToken)
+        => PostApprovalDecisionAsync(approvalId, approved: true, cancellationToken);
+
+    public Task<OperationStatusResponse> DenyToolRequestAsync(string approvalId, CancellationToken cancellationToken)
+        => PostApprovalDecisionAsync(approvalId, approved: false, cancellationToken);
+
+    private async Task<OperationStatusResponse> PostApprovalDecisionAsync(string approvalId, bool approved, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(approvalId))
+            throw new ArgumentException("approvalId is required.", nameof(approvalId));
+
+        var uri = new Uri(
+            $"{_toolsApproveUri}?approvalId={Uri.EscapeDataString(approvalId)}&approved={(approved ? "true" : "false")}",
+            UriKind.RelativeOrAbsolute);
+        using var req = new HttpRequestMessage(HttpMethod.Post, uri);
+        return await SendAsync(req, CoreJsonContext.Default.OperationStatusResponse, cancellationToken);
+    }
 
     public Task<IntegrationProvidersResponse> GetIntegrationProvidersAsync(int recentTurnsLimit, CancellationToken cancellationToken)
         => GetAsync(new Uri($"{_integrationProvidersUri}?recentTurnsLimit={Math.Clamp(recentTurnsLimit, 1, 256)}", UriKind.RelativeOrAbsolute), CoreJsonContext.Default.IntegrationProvidersResponse, cancellationToken);

--- a/src/OpenClaw.Companion/App.axaml.cs
+++ b/src/OpenClaw.Companion/App.axaml.cs
@@ -29,13 +29,17 @@ public partial class App : Application
 
             _client = new GatewayWebSocketClient();
             var settings = new SettingsStore();
+            var viewModel = new MainWindowViewModel(settings, _client);
             desktop.MainWindow = new MainWindow
             {
-                DataContext = new MainWindowViewModel(settings, _client),
+                DataContext = viewModel,
             };
+
+            viewModel.StartApprovalsPolling(TimeSpan.FromSeconds(5));
 
             desktop.Exit += async (_, _) =>
             {
+                viewModel.StopApprovalsPolling();
                 if (_client is not null)
                     await _client.DisposeAsync();
             };

--- a/src/OpenClaw.Companion/OpenClaw.Companion.csproj
+++ b/src/OpenClaw.Companion/OpenClaw.Companion.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="OpenClaw.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\OpenClaw.Client\OpenClaw.Client.csproj" />
     <PackageReference Include="Avalonia" Version="11.3.12" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Approvals.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Approvals.cs
@@ -10,6 +10,7 @@ namespace OpenClaw.Companion.ViewModels;
 public sealed partial class MainWindowViewModel
 {
     private CancellationTokenSource? _approvalsPollCts;
+    private readonly SemaphoreSlim _approvalsRefreshLock = new(1, 1);
 
     [ObservableProperty]
     private bool _isApprovalsBusy;
@@ -24,7 +25,15 @@ public sealed partial class MainWindowViewModel
 
     public int PendingApprovalsCount => PendingApprovals.Count;
 
+    public bool HasPendingApprovals => PendingApprovals.Count > 0;
+
     partial void OnIsApprovalsBusyChanged(bool value) => RefreshApprovalsCommand.NotifyCanExecuteChanged();
+
+    private void NotifyPendingApprovalsChanged()
+    {
+        OnPropertyChanged(nameof(PendingApprovalsCount));
+        OnPropertyChanged(nameof(HasPendingApprovals));
+    }
 
     [RelayCommand(CanExecute = nameof(CanInteractWithApprovals))]
     private async Task RefreshApprovalsAsync()
@@ -90,6 +99,12 @@ public sealed partial class MainWindowViewModel
 
     private async Task RefreshApprovalsInternalAsync(CancellationToken ct)
     {
+        // Skip if another refresh (poll tick or manual click) is already in flight.
+        // Pass CancellationToken.None because TimeSpan.Zero never blocks; we just want
+        // a non-throwing try-acquire.
+        if (!await _approvalsRefreshLock.WaitAsync(TimeSpan.Zero, CancellationToken.None))
+            return;
+
         Dispatcher.UIThread.Post(() => IsApprovalsBusy = true);
         try
         {
@@ -100,7 +115,7 @@ public sealed partial class MainWindowViewModel
                 {
                     ApprovalsStatus = error ?? "Invalid gateway URL.";
                     PendingApprovals.Clear();
-                    OnPropertyChanged(nameof(PendingApprovalsCount));
+                    NotifyPendingApprovalsChanged();
                 });
                 return;
             }
@@ -111,7 +126,7 @@ public sealed partial class MainWindowViewModel
                 {
                     ApprovalsStatus = "Operator token required to load approvals.";
                     PendingApprovals.Clear();
-                    OnPropertyChanged(nameof(PendingApprovalsCount));
+                    NotifyPendingApprovalsChanged();
                 });
                 return;
             }
@@ -128,7 +143,7 @@ public sealed partial class MainWindowViewModel
                 ApprovalsStatus = items.Count == 0
                     ? "No pending approvals."
                     : $"{items.Count} pending approval{(items.Count == 1 ? "" : "s")}.";
-                OnPropertyChanged(nameof(PendingApprovalsCount));
+                NotifyPendingApprovalsChanged();
             });
         }
         catch (OperationCanceledException)
@@ -145,6 +160,7 @@ public sealed partial class MainWindowViewModel
         finally
         {
             Dispatcher.UIThread.Post(() => IsApprovalsBusy = false);
+            _approvalsRefreshLock.Release();
         }
     }
 
@@ -184,7 +200,7 @@ public sealed partial class MainWindowViewModel
         var index = PendingApprovals.IndexOf(item);
         if (index >= 0)
             PendingApprovals.RemoveAt(index);
-        OnPropertyChanged(nameof(PendingApprovalsCount));
+        NotifyPendingApprovalsChanged();
 
         try
         {
@@ -203,7 +219,7 @@ public sealed partial class MainWindowViewModel
                 ApprovalsStatus = $"Decision failed: {response.Error ?? "server rejected the request"}.";
                 if (index >= 0 && index <= PendingApprovals.Count)
                     PendingApprovals.Insert(index, item);
-                OnPropertyChanged(nameof(PendingApprovalsCount));
+                NotifyPendingApprovalsChanged();
             }
         }
         catch (Exception ex)
@@ -211,7 +227,7 @@ public sealed partial class MainWindowViewModel
             ApprovalsStatus = $"Decision failed: {ex.Message}";
             if (index >= 0 && index <= PendingApprovals.Count)
                 PendingApprovals.Insert(index, item);
-            OnPropertyChanged(nameof(PendingApprovalsCount));
+            NotifyPendingApprovalsChanged();
         }
     }
 }

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Approvals.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Approvals.cs
@@ -1,0 +1,267 @@
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using OpenClaw.Core.Pipeline;
+
+namespace OpenClaw.Companion.ViewModels;
+
+public sealed partial class MainWindowViewModel
+{
+    private CancellationTokenSource? _approvalsPollCts;
+
+    [ObservableProperty]
+    private bool _isApprovalsBusy;
+
+    [ObservableProperty]
+    private string _approvalsStatus = "Approvals queue not loaded.";
+
+    [ObservableProperty]
+    private DateTimeOffset? _approvalsLastPolled;
+
+    public ObservableCollection<PendingApprovalItem> PendingApprovals { get; } = [];
+
+    public int PendingApprovalsCount => PendingApprovals.Count;
+
+    partial void OnIsApprovalsBusyChanged(bool value) => RefreshApprovalsCommand.NotifyCanExecuteChanged();
+
+    [RelayCommand(CanExecute = nameof(CanInteractWithApprovals))]
+    private async Task RefreshApprovalsAsync()
+    {
+        await RefreshApprovalsInternalAsync(CancellationToken.None);
+    }
+
+    [RelayCommand]
+    private async Task ApproveApprovalAsync(PendingApprovalItem? item)
+    {
+        if (item is null)
+            return;
+        await SubmitApprovalDecisionAsync(item, approved: true);
+    }
+
+    [RelayCommand]
+    private async Task DenyApprovalAsync(PendingApprovalItem? item)
+    {
+        if (item is null)
+            return;
+        await SubmitApprovalDecisionAsync(item, approved: false);
+    }
+
+    public void StartApprovalsPolling(TimeSpan interval)
+    {
+        StopApprovalsPolling();
+        if (interval <= TimeSpan.Zero)
+            return;
+
+        _approvalsPollCts = new CancellationTokenSource();
+        var token = _approvalsPollCts.Token;
+
+        _ = Task.Run(async () =>
+        {
+            await RefreshApprovalsInternalAsync(token);
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(interval, token);
+                }
+                catch (TaskCanceledException)
+                {
+                    return;
+                }
+
+                if (token.IsCancellationRequested)
+                    return;
+
+                await RefreshApprovalsInternalAsync(token);
+            }
+        }, token);
+    }
+
+    public void StopApprovalsPolling()
+    {
+        _approvalsPollCts?.Cancel();
+        _approvalsPollCts?.Dispose();
+        _approvalsPollCts = null;
+    }
+
+    private bool CanInteractWithApprovals() => !IsApprovalsBusy;
+
+    private async Task RefreshApprovalsInternalAsync(CancellationToken ct)
+    {
+        Dispatcher.UIThread.Post(() => IsApprovalsBusy = true);
+        try
+        {
+            using var client = CreateAdminClient(out var error);
+            if (client is null)
+            {
+                Dispatcher.UIThread.Post(() =>
+                {
+                    ApprovalsStatus = error ?? "Invalid gateway URL.";
+                    PendingApprovals.Clear();
+                    OnPropertyChanged(nameof(PendingApprovalsCount));
+                });
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(AuthToken))
+            {
+                Dispatcher.UIThread.Post(() =>
+                {
+                    ApprovalsStatus = "Operator token required to load approvals.";
+                    PendingApprovals.Clear();
+                    OnPropertyChanged(nameof(PendingApprovalsCount));
+                });
+                return;
+            }
+
+            var response = await client.GetIntegrationApprovalsAsync(channelId: null, senderId: null, ct);
+            var items = response.Items
+                .Select(PendingApprovalItem.FromRequest)
+                .ToList();
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                MergePendingApprovals(items);
+                ApprovalsLastPolled = DateTimeOffset.UtcNow;
+                ApprovalsStatus = items.Count == 0
+                    ? "No pending approvals."
+                    : $"{items.Count} pending approval{(items.Count == 1 ? "" : "s")}.";
+                OnPropertyChanged(nameof(PendingApprovalsCount));
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during shutdown / cancellation.
+        }
+        catch (Exception ex)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                ApprovalsStatus = $"Approvals refresh failed: {ex.Message}";
+            });
+        }
+        finally
+        {
+            Dispatcher.UIThread.Post(() => IsApprovalsBusy = false);
+        }
+    }
+
+    internal void MergePendingApprovals(IReadOnlyList<PendingApprovalItem> latest)
+    {
+        var latestIds = latest.Select(static i => i.ApprovalId).ToHashSet(StringComparer.Ordinal);
+        for (var i = PendingApprovals.Count - 1; i >= 0; i--)
+        {
+            if (!latestIds.Contains(PendingApprovals[i].ApprovalId))
+                PendingApprovals.RemoveAt(i);
+        }
+
+        var existingIds = PendingApprovals.Select(static i => i.ApprovalId).ToHashSet(StringComparer.Ordinal);
+        foreach (var item in latest)
+        {
+            if (!existingIds.Contains(item.ApprovalId))
+                PendingApprovals.Add(item);
+        }
+    }
+
+    private async Task SubmitApprovalDecisionAsync(PendingApprovalItem item, bool approved)
+    {
+        using var client = CreateAdminClient(out var error);
+        if (client is null)
+        {
+            ApprovalsStatus = error ?? "Invalid gateway URL.";
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(AuthToken))
+        {
+            ApprovalsStatus = "Operator token required to decide approvals.";
+            return;
+        }
+
+        // Optimistically remove; re-add on failure so the user sees immediate feedback.
+        var index = PendingApprovals.IndexOf(item);
+        if (index >= 0)
+            PendingApprovals.RemoveAt(index);
+        OnPropertyChanged(nameof(PendingApprovalsCount));
+
+        try
+        {
+            var response = approved
+                ? await client.ApproveToolRequestAsync(item.ApprovalId, CancellationToken.None)
+                : await client.DenyToolRequestAsync(item.ApprovalId, CancellationToken.None);
+
+            if (response.Success)
+            {
+                ApprovalsStatus = approved
+                    ? $"Approved '{item.ToolName}'."
+                    : $"Denied '{item.ToolName}'.";
+            }
+            else
+            {
+                ApprovalsStatus = $"Decision failed: {response.Error ?? "server rejected the request"}.";
+                if (index >= 0 && index <= PendingApprovals.Count)
+                    PendingApprovals.Insert(index, item);
+                OnPropertyChanged(nameof(PendingApprovalsCount));
+            }
+        }
+        catch (Exception ex)
+        {
+            ApprovalsStatus = $"Decision failed: {ex.Message}";
+            if (index >= 0 && index <= PendingApprovals.Count)
+                PendingApprovals.Insert(index, item);
+            OnPropertyChanged(nameof(PendingApprovalsCount));
+        }
+    }
+}
+
+public sealed class PendingApprovalItem
+{
+    public required string ApprovalId { get; init; }
+    public required string ToolName { get; init; }
+    public required string ChannelId { get; init; }
+    public required string SenderId { get; init; }
+    public required string SessionId { get; init; }
+    public required string ArgumentsPreview { get; init; }
+    public required DateTimeOffset CreatedAt { get; init; }
+    public string? Action { get; init; }
+    public bool IsMutation { get; init; }
+    public string Summary { get; init; } = "";
+
+    public string Origin => string.IsNullOrWhiteSpace(SenderId) ? ChannelId : $"{ChannelId} · {SenderId}";
+
+    public static PendingApprovalItem FromRequest(ToolApprovalRequest request)
+        => new()
+        {
+            ApprovalId = request.ApprovalId,
+            ToolName = request.ToolName,
+            ChannelId = request.ChannelId,
+            SenderId = request.SenderId,
+            SessionId = request.SessionId,
+            ArgumentsPreview = BuildPreview(request.Arguments),
+            CreatedAt = request.CreatedAt,
+            Action = request.Action,
+            IsMutation = request.IsMutation,
+            Summary = request.Summary ?? ""
+        };
+
+    private static string BuildPreview(string arguments)
+    {
+        if (string.IsNullOrWhiteSpace(arguments))
+            return "(no arguments)";
+
+        try
+        {
+            using var doc = JsonDocument.Parse(arguments);
+            var pretty = JsonSerializer.Serialize(
+                doc.RootElement,
+                new JsonSerializerOptions { WriteIndented = true });
+            return pretty.Length > 500 ? pretty[..500] + "…" : pretty;
+        }
+        catch
+        {
+            return arguments.Length > 500 ? arguments[..500] + "…" : arguments;
+        }
+    }
+}

--- a/src/OpenClaw.Companion/Views/MainWindow.axaml
+++ b/src/OpenClaw.Companion/Views/MainWindow.axaml
@@ -76,6 +76,89 @@
                 </Grid>
             </TabItem>
 
+            <TabItem>
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <TextBlock Text="Approvals" VerticalAlignment="Center" />
+                        <Border Background="{DynamicResource SystemControlBackgroundAccentBrush}"
+                                CornerRadius="9" Padding="6,1"
+                                IsVisible="{Binding PendingApprovalsCount}">
+                            <TextBlock Text="{Binding PendingApprovalsCount}"
+                                       FontSize="11" FontWeight="SemiBold"
+                                       Foreground="White" VerticalAlignment="Center" />
+                        </Border>
+                    </StackPanel>
+                </TabItem.Header>
+                <Grid RowDefinitions="Auto,*" RowSpacing="10">
+                    <Border Grid.Row="0" Padding="10" CornerRadius="8" BorderThickness="1"
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                            <StackPanel Grid.Column="0" Spacing="2">
+                                <TextBlock Text="{Binding ApprovalsStatus}" TextWrapping="Wrap" />
+                                <TextBlock Text="{Binding ApprovalsLastPolled, StringFormat='Last polled: {0:HH:mm:ss} UTC'}"
+                                           FontSize="11" Opacity="0.65"
+                                           IsVisible="{Binding ApprovalsLastPolled, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                            </StackPanel>
+                            <Button Grid.Column="1" Content="Refresh"
+                                    Command="{Binding RefreshApprovalsCommand}"
+                                    IsEnabled="{Binding IsApprovalsBusy, Converter={StaticResource InverseBool}}" />
+                        </Grid>
+                    </Border>
+
+                    <Border Grid.Row="1" Padding="10" CornerRadius="8" BorderThickness="1"
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
+                        <Grid>
+                            <TextBlock Text="No pending approvals. Tools that require operator approval will appear here."
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                       Opacity="0.55" TextWrapping="Wrap" TextAlignment="Center"
+                                       IsVisible="{Binding !PendingApprovalsCount}" />
+                            <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto"
+                                          IsVisible="{Binding PendingApprovalsCount}">
+                                <ItemsControl ItemsSource="{Binding PendingApprovals}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="vm:PendingApprovalItem">
+                                            <Border Margin="0,0,0,8" Padding="10" CornerRadius="6" BorderThickness="1"
+                                                    BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
+                                                <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto,Auto" RowSpacing="6">
+                                                    <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="8">
+                                                        <TextBlock Text="{Binding ToolName}" FontWeight="SemiBold" FontSize="14" />
+                                                        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                                                                CornerRadius="4" Padding="5,1"
+                                                                IsVisible="{Binding IsMutation}">
+                                                            <TextBlock Text="mutation" FontSize="10" />
+                                                        </Border>
+                                                        <TextBlock Text="{Binding Action}" Opacity="0.7"
+                                                                   IsVisible="{Binding Action, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                                    </StackPanel>
+                                                    <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Spacing="6">
+                                                        <Button Content="Approve"
+                                                                Command="{Binding $parent[ItemsControl].((vm:MainWindowViewModel)DataContext).ApproveApprovalCommand}"
+                                                                CommandParameter="{Binding}" />
+                                                        <Button Content="Deny"
+                                                                Command="{Binding $parent[ItemsControl].((vm:MainWindowViewModel)DataContext).DenyApprovalCommand}"
+                                                                CommandParameter="{Binding}" />
+                                                    </StackPanel>
+                                                    <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="12">
+                                                        <TextBlock Text="{Binding Origin}" FontSize="11" Opacity="0.7" />
+                                                        <TextBlock Text="{Binding SessionId, StringFormat=session {0}}" FontSize="11" Opacity="0.7" />
+                                                        <TextBlock Text="{Binding CreatedAt, StringFormat='queued {0:HH:mm:ss} UTC'}" FontSize="11" Opacity="0.7" />
+                                                    </StackPanel>
+                                                    <TextBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"
+                                                             Text="{Binding ArgumentsPreview, Mode=OneWay}"
+                                                             IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"
+                                                             FontFamily="Consolas, Menlo, monospace" FontSize="12"
+                                                             MaxHeight="160" />
+                                                </Grid>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </ScrollViewer>
+                        </Grid>
+                    </Border>
+                </Grid>
+            </TabItem>
+
             <TabItem Header="Admin">
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
                     <StackPanel Spacing="12" Margin="0,4,0,0">

--- a/src/OpenClaw.Companion/Views/MainWindow.axaml
+++ b/src/OpenClaw.Companion/Views/MainWindow.axaml
@@ -82,7 +82,7 @@
                         <TextBlock Text="Approvals" VerticalAlignment="Center" />
                         <Border Background="{DynamicResource SystemControlBackgroundAccentBrush}"
                                 CornerRadius="9" Padding="6,1"
-                                IsVisible="{Binding PendingApprovalsCount}">
+                                IsVisible="{Binding HasPendingApprovals}">
                             <TextBlock Text="{Binding PendingApprovalsCount}"
                                        FontSize="11" FontWeight="SemiBold"
                                        Foreground="White" VerticalAlignment="Center" />
@@ -111,9 +111,9 @@
                             <TextBlock Text="No pending approvals. Tools that require operator approval will appear here."
                                        HorizontalAlignment="Center" VerticalAlignment="Center"
                                        Opacity="0.55" TextWrapping="Wrap" TextAlignment="Center"
-                                       IsVisible="{Binding !PendingApprovalsCount}" />
+                                       IsVisible="{Binding !HasPendingApprovals}" />
                             <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto"
-                                          IsVisible="{Binding PendingApprovalsCount}">
+                                          IsVisible="{Binding HasPendingApprovals}">
                                 <ItemsControl ItemsSource="{Binding PendingApprovals}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate DataType="vm:PendingApprovalItem">

--- a/src/OpenClaw.Tests/CompanionApprovalsTests.cs
+++ b/src/OpenClaw.Tests/CompanionApprovalsTests.cs
@@ -5,8 +5,19 @@ using Xunit;
 
 namespace OpenClaw.Tests;
 
-public sealed class CompanionApprovalsTests
+public sealed class CompanionApprovalsTests : IDisposable
 {
+    private readonly List<string> _tempDirs = [];
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            try { Directory.Delete(dir, recursive: true); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+
     [Fact]
     public void FromRequest_CopiesCoreFields()
     {
@@ -142,10 +153,24 @@ public sealed class CompanionApprovalsTests
         Assert.Equal(0, viewModel.PendingApprovalsCount);
     }
 
-    private static MainWindowViewModel CreateViewModel()
+    [Fact]
+    public void HasPendingApprovals_TracksQueueState()
+    {
+        var viewModel = CreateViewModel();
+        Assert.False(viewModel.HasPendingApprovals);
+
+        viewModel.MergePendingApprovals([NewItem("apr_1")]);
+        Assert.True(viewModel.HasPendingApprovals);
+
+        viewModel.MergePendingApprovals([]);
+        Assert.False(viewModel.HasPendingApprovals);
+    }
+
+    private MainWindowViewModel CreateViewModel()
     {
         var dir = Path.Combine(Path.GetTempPath(), "openclaw-companion-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
+        _tempDirs.Add(dir);
         var settings = new SettingsStore(dir);
         return new MainWindowViewModel(settings, new GatewayWebSocketClient());
     }

--- a/src/OpenClaw.Tests/CompanionApprovalsTests.cs
+++ b/src/OpenClaw.Tests/CompanionApprovalsTests.cs
@@ -1,0 +1,174 @@
+using OpenClaw.Companion.Services;
+using OpenClaw.Companion.ViewModels;
+using OpenClaw.Core.Pipeline;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class CompanionApprovalsTests
+{
+    [Fact]
+    public void FromRequest_CopiesCoreFields()
+    {
+        var req = new ToolApprovalRequest
+        {
+            ApprovalId = "apr_1",
+            SessionId = "sess_1",
+            ChannelId = "websocket",
+            SenderId = "user@example.com",
+            ToolName = "shell",
+            Arguments = "{}",
+            Action = "run",
+            IsMutation = true,
+            Summary = "Run a shell command."
+        };
+
+        var item = PendingApprovalItem.FromRequest(req);
+
+        Assert.Equal("apr_1", item.ApprovalId);
+        Assert.Equal("sess_1", item.SessionId);
+        Assert.Equal("websocket", item.ChannelId);
+        Assert.Equal("user@example.com", item.SenderId);
+        Assert.Equal("shell", item.ToolName);
+        Assert.Equal("run", item.Action);
+        Assert.True(item.IsMutation);
+        Assert.Equal("Run a shell command.", item.Summary);
+    }
+
+    [Fact]
+    public void FromRequest_EmptyArguments_ShowsPlaceholder()
+    {
+        var req = NewRequest(arguments: "");
+        var item = PendingApprovalItem.FromRequest(req);
+
+        Assert.Equal("(no arguments)", item.ArgumentsPreview);
+    }
+
+    [Fact]
+    public void FromRequest_ValidJson_PrettyPrintsWithNewlines()
+    {
+        var req = NewRequest(arguments: "{\"path\":\"/tmp/a.txt\",\"mode\":\"read\"}");
+        var item = PendingApprovalItem.FromRequest(req);
+
+        Assert.Contains('\n', item.ArgumentsPreview);
+        Assert.Contains("\"path\"", item.ArgumentsPreview, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FromRequest_InvalidJson_FallsBackToRaw()
+    {
+        var req = NewRequest(arguments: "not-json-at-all");
+        var item = PendingApprovalItem.FromRequest(req);
+
+        Assert.Equal("not-json-at-all", item.ArgumentsPreview);
+    }
+
+    [Fact]
+    public void FromRequest_VeryLongArguments_AreTruncated()
+    {
+        var raw = new string('x', 900);
+        var req = NewRequest(arguments: raw);
+        var item = PendingApprovalItem.FromRequest(req);
+
+        Assert.EndsWith("…", item.ArgumentsPreview, StringComparison.Ordinal);
+        Assert.True(item.ArgumentsPreview.Length < raw.Length);
+    }
+
+    [Fact]
+    public void Origin_OmitsSender_WhenBlank()
+    {
+        var req = NewRequest(senderId: "");
+        var item = PendingApprovalItem.FromRequest(req);
+
+        Assert.Equal(req.ChannelId, item.Origin);
+    }
+
+    [Fact]
+    public void Origin_IncludesSender_WhenPresent()
+    {
+        var req = NewRequest(senderId: "user@example.com");
+        var item = PendingApprovalItem.FromRequest(req);
+
+        Assert.Contains(req.ChannelId, item.Origin);
+        Assert.Contains("user@example.com", item.Origin, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MergePendingApprovals_AddsNewItems()
+    {
+        var viewModel = CreateViewModel();
+        Assert.Empty(viewModel.PendingApprovals);
+
+        viewModel.MergePendingApprovals([NewItem("apr_1"), NewItem("apr_2")]);
+
+        Assert.Equal(2, viewModel.PendingApprovals.Count);
+        Assert.Equal(2, viewModel.PendingApprovalsCount);
+    }
+
+    [Fact]
+    public void MergePendingApprovals_RemovesMissingItems()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.MergePendingApprovals([NewItem("apr_1"), NewItem("apr_2")]);
+
+        viewModel.MergePendingApprovals([NewItem("apr_2")]);
+
+        Assert.Single(viewModel.PendingApprovals);
+        Assert.Equal("apr_2", viewModel.PendingApprovals[0].ApprovalId);
+    }
+
+    [Fact]
+    public void MergePendingApprovals_PreservesExistingItemReferences()
+    {
+        var viewModel = CreateViewModel();
+        var original = NewItem("apr_1");
+        viewModel.MergePendingApprovals([original]);
+
+        viewModel.MergePendingApprovals([NewItem("apr_1"), NewItem("apr_2")]);
+
+        Assert.Equal(2, viewModel.PendingApprovals.Count);
+        Assert.Same(original, viewModel.PendingApprovals.Single(i => i.ApprovalId == "apr_1"));
+    }
+
+    [Fact]
+    public void MergePendingApprovals_WithEmptyLatest_ClearsQueue()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.MergePendingApprovals([NewItem("apr_1"), NewItem("apr_2")]);
+
+        viewModel.MergePendingApprovals([]);
+
+        Assert.Empty(viewModel.PendingApprovals);
+        Assert.Equal(0, viewModel.PendingApprovalsCount);
+    }
+
+    private static MainWindowViewModel CreateViewModel()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "openclaw-companion-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var settings = new SettingsStore(dir);
+        return new MainWindowViewModel(settings, new GatewayWebSocketClient());
+    }
+
+    private static ToolApprovalRequest NewRequest(string arguments = "{}", string senderId = "sender")
+        => new()
+        {
+            ApprovalId = Guid.NewGuid().ToString("N"),
+            SessionId = "sess",
+            ChannelId = "websocket",
+            SenderId = senderId,
+            ToolName = "shell",
+            Arguments = arguments
+        };
+
+    private static PendingApprovalItem NewItem(string approvalId)
+        => PendingApprovalItem.FromRequest(new ToolApprovalRequest
+        {
+            ApprovalId = approvalId,
+            SessionId = "sess",
+            ChannelId = "websocket",
+            SenderId = "sender",
+            ToolName = "shell",
+            Arguments = "{}"
+        });
+}


### PR DESCRIPTION
## Summary

Closes the operator-side visibility gap reported when `OpenClaw:Tooling:RequireToolApproval=true`. Tools triggered on non-WS channels (CLI chat, HTTP, channel adapters) would silently auto-deny while an operator watched the Companion chat tab, because the Companion had no approvals surface.

v1 of the feature as scoped earlier in discussion. Pull-based (HTTP polling) — no new server-side WS event type.

## What changed

**Client wrappers — [OpenClawHttpClient.cs](src/OpenClaw.Client/OpenClawHttpClient.cs):**
- `ApproveToolRequestAsync(approvalId, ct)` / `DenyToolRequestAsync(approvalId, ct)` posting to `/tools/approve` in admin-bypass mode (operator token only).

**Companion UI — [MainWindow.axaml](src/OpenClaw.Companion/Views/MainWindow.axaml):**
- New **Approvals** tab between Chat and Admin.
- Tab header shows a count badge when pending > 0.
- Empty state when idle.
- Per-item card: tool name · mutation flag · action · origin (channel · sender) · session · queued-at · pretty-printed JSON arguments (truncated to 500 chars) · Approve / Deny buttons.

**Companion ViewModel — [MainWindowViewModel.Approvals.cs](src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Approvals.cs):**
- Partial on the existing `MainWindowViewModel`, matching the `.WhatsApp.cs` pattern.
- Polls `GET /api/integration/approvals` on a 5s cadence using `Task.Run` + `CancellationTokenSource` (same pattern as the WhatsApp auth stream).
- Polling starts on app startup and stops on exit, so the tab badge count stays accurate even when the tab isn't visible.
- Optimistic remove on approve/deny with re-insert on server failure.
- Merge policy preserves object identity for items still pending — prevents the list from flickering on each tick.

**Tests — [CompanionApprovalsTests.cs](src/OpenClaw.Tests/CompanionApprovalsTests.cs):**
- 11 new tests covering `PendingApprovalItem.FromRequest` (pretty-print, invalid-JSON fallback, truncation, origin formatting) and `MergePendingApprovals` (add, remove, preserve references, clear on empty).
- Added `InternalsVisibleTo("OpenClaw.Tests")` on Companion so the merge helper can be exercised directly.

## Scope / decisions from earlier discussion

- **Pull, not push.** The existing `tool_approval_required` WS envelope is scoped to the requester channel/sender. An operator watching in the Companion isn't the requester, so there's no natural WS event today. Adding an admin-scope push event is v2 material — out of scope here.
- **Admin bypass, not requester match.** Operator acts as operator; we pass no `requesterChannelId`/`senderId` and let the server use the admin bypass path. Still requires `RequireRequesterMatchForHttpToolApproval=false` (the default).
- **No auto-approve grant UI.** Grants are security-sensitive and deserve their own design pass.
- **No history view.** `GetIntegrationApprovalHistoryAsync` already exists; easy v2 add.

## Test plan

- [x] `dotnet build src/OpenClaw.Companion -c Release` — 0 warnings, 0 errors
- [x] `dotnet test src/OpenClaw.Tests -c Release` — 832/832 passing (+11 new)
- [ ] Manual: launch Companion against a local gateway with `RequireToolApproval=true` and a tool-invoking session on a non-WS channel; confirm the item appears in the Approvals tab within ~5s
- [ ] Manual: approve an item; confirm it's removed and the upstream session proceeds; confirm the audit log shows `tool_approval_admin`
- [ ] Manual: deny an item; confirm it's removed and the upstream session gets denied
- [ ] Manual: simulate server rejection (stop the gateway) and click Approve; confirm the item is re-inserted and the status line shows the error
- [ ] Manual: with no operator token loaded, open the Approvals tab; confirm the status reads "Operator token required"

## Risks called out in the scope doc

- **Polling race.** If the operator clicks Approve and the poll fires between click and HTTP response, the item might briefly reappear. Mitigated by optimistic remove + rehydrate on next poll.
- **Multiple Companion instances.** Two operators, both click Approve — second gets 404 "already decided" from the server; surfaces via the status line, no crash.
- **Requester-match mismatch** if the gateway has `RequireRequesterMatchForHttpToolApproval=true`. The admin-bypass path will 400; the status line will show the server's error. Fast-follow could send the known requester channel/sender, but v1 keeps admin bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)