### PR TITLE
Companion approvals v2 phase 1: adaptive polling, history, desktop notifications

### DIFF
--- a/src/OpenClaw.Companion/App.axaml.cs
+++ b/src/OpenClaw.Companion/App.axaml.cs
@@ -30,12 +30,14 @@ public partial class App : Application
             _client = new GatewayWebSocketClient();
             var settings = new SettingsStore();
             var viewModel = new MainWindowViewModel(settings, _client);
+            viewModel.AttachDesktopNotifier(new DesktopNotifier());
+
             desktop.MainWindow = new MainWindow
             {
                 DataContext = viewModel,
             };
 
-            viewModel.StartApprovalsPolling(TimeSpan.FromSeconds(5));
+            viewModel.StartApprovalsPolling();
 
             desktop.Exit += async (_, _) =>
             {

--- a/src/OpenClaw.Companion/Models/CompanionSettings.cs
+++ b/src/OpenClaw.Companion/Models/CompanionSettings.cs
@@ -10,6 +10,8 @@ public sealed class CompanionSettings
     public bool RememberToken { get; set; } = false;
     public bool AllowPlaintextTokenFallback { get; set; } = false;
     public bool DebugMode { get; set; } = false;
+    public bool ApprovalDesktopNotificationsEnabled { get; set; } = true;
+    public bool ApprovalDesktopNotificationsOnlyWhenUnfocused { get; set; } = true;
 
     [JsonIgnore]
     public string? AuthToken { get; set; }

--- a/src/OpenClaw.Companion/Services/DesktopNotifier.cs
+++ b/src/OpenClaw.Companion/Services/DesktopNotifier.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace OpenClaw.Companion.Services;
+
+public interface IDesktopNotifier
+{
+    bool IsAvailable { get; }
+
+    string PlatformDescription { get; }
+
+    Task NotifyAsync(string title, string body, CancellationToken cancellationToken = default);
+}
+
+public sealed class DesktopNotifier : IDesktopNotifier
+{
+    public bool IsAvailable => Platform is NotifierPlatform.MacOs or NotifierPlatform.Linux;
+
+    public string PlatformDescription => Platform switch
+    {
+        NotifierPlatform.MacOs => "macOS Notification Center (osascript)",
+        NotifierPlatform.Linux => "libnotify (notify-send)",
+        NotifierPlatform.Windows => "not supported on Windows in this release",
+        _ => "unsupported platform"
+    };
+
+    public Task NotifyAsync(string title, string body, CancellationToken cancellationToken = default)
+        => Platform switch
+        {
+            NotifierPlatform.MacOs => NotifyMacOsAsync(title, body, cancellationToken),
+            NotifierPlatform.Linux => NotifyLinuxAsync(title, body, cancellationToken),
+            _ => Task.CompletedTask
+        };
+
+    private static NotifierPlatform Platform
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return NotifierPlatform.MacOs;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return NotifierPlatform.Linux;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return NotifierPlatform.Windows;
+            return NotifierPlatform.Unknown;
+        }
+    }
+
+    private static Task NotifyMacOsAsync(string title, string body, CancellationToken ct)
+    {
+        var script = $"display notification \"{EscapeAppleScript(body)}\" with title \"{EscapeAppleScript(title)}\"";
+        return RunProcessAsync("osascript", ["-e", script], ct);
+    }
+
+    private static Task NotifyLinuxAsync(string title, string body, CancellationToken ct)
+        => RunProcessAsync("notify-send", ["--app-name=OpenClaw.Companion", "--", title, body], ct);
+
+    private static async Task RunProcessAsync(string fileName, string[] arguments, CancellationToken ct)
+    {
+        try
+        {
+            var info = new ProcessStartInfo
+            {
+                FileName = fileName,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            foreach (var arg in arguments)
+                info.ArgumentList.Add(arg);
+
+            using var proc = Process.Start(info);
+            if (proc is null)
+                return;
+
+            await proc.WaitForExitAsync(ct);
+        }
+        catch
+        {
+            // Best-effort. Missing tools, perms issues, or cancellation should not bubble
+            // into the caller — notifications are a nice-to-have, not load-bearing.
+        }
+    }
+
+    private static string EscapeAppleScript(string value)
+        => value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+    private enum NotifierPlatform
+    {
+        Unknown,
+        MacOs,
+        Linux,
+        Windows
+    }
+}

--- a/src/OpenClaw.Companion/Services/DesktopNotifier.cs
+++ b/src/OpenClaw.Companion/Services/DesktopNotifier.cs
@@ -14,35 +14,91 @@ public interface IDesktopNotifier
 
 public sealed class DesktopNotifier : IDesktopNotifier
 {
-    public bool IsAvailable => Platform is NotifierPlatform.MacOs or NotifierPlatform.Linux;
+    // Bound each notification attempt so a misbehaving child can't leak forever.
+    private static readonly TimeSpan NotifyTimeout = TimeSpan.FromSeconds(5);
 
-    public string PlatformDescription => Platform switch
+    private readonly NotifierPlatform _platform;
+    private readonly bool _toolPresent;
+
+    public DesktopNotifier()
     {
-        NotifierPlatform.MacOs => "macOS Notification Center (osascript)",
-        NotifierPlatform.Linux => "libnotify (notify-send)",
-        NotifierPlatform.Windows => "not supported on Windows in this release",
+        _platform = DetectPlatform();
+        _toolPresent = ResolveToolPresent(_platform);
+    }
+
+    public bool IsAvailable => _toolPresent;
+
+    public string PlatformDescription => (_platform, _toolPresent) switch
+    {
+        (NotifierPlatform.MacOs, true) => "macOS Notification Center (osascript)",
+        (NotifierPlatform.MacOs, false) => "macOS detected but osascript is not on PATH",
+        (NotifierPlatform.Linux, true) => "libnotify (notify-send)",
+        (NotifierPlatform.Linux, false) => "Linux detected but notify-send is not on PATH",
+        (NotifierPlatform.Windows, _) => "not supported on Windows in this release",
         _ => "unsupported platform"
     };
 
     public Task NotifyAsync(string title, string body, CancellationToken cancellationToken = default)
-        => Platform switch
+    {
+        if (!_toolPresent)
+            return Task.CompletedTask;
+
+        return _platform switch
         {
             NotifierPlatform.MacOs => NotifyMacOsAsync(title, body, cancellationToken),
             NotifierPlatform.Linux => NotifyLinuxAsync(title, body, cancellationToken),
             _ => Task.CompletedTask
         };
+    }
 
-    private static NotifierPlatform Platform
+    private static NotifierPlatform DetectPlatform()
     {
-        get
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return NotifierPlatform.MacOs;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return NotifierPlatform.Linux;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return NotifierPlatform.Windows;
+        return NotifierPlatform.Unknown;
+    }
+
+    private static bool ResolveToolPresent(NotifierPlatform platform)
+        => platform switch
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                return NotifierPlatform.MacOs;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                return NotifierPlatform.Linux;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                return NotifierPlatform.Windows;
-            return NotifierPlatform.Unknown;
+            NotifierPlatform.MacOs => IsOnPath("osascript"),
+            NotifierPlatform.Linux => IsOnPath("notify-send"),
+            _ => false
+        };
+
+    private static bool IsOnPath(string executable)
+    {
+        try
+        {
+            var info = new ProcessStartInfo("/usr/bin/env")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            info.ArgumentList.Add("which");
+            info.ArgumentList.Add(executable);
+
+            using var proc = Process.Start(info);
+            if (proc is null)
+                return false;
+
+            if (!proc.WaitForExit(1000))
+            {
+                try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+                return false;
+            }
+
+            return proc.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
         }
     }
 
@@ -57,6 +113,7 @@ public sealed class DesktopNotifier : IDesktopNotifier
 
     private static async Task RunProcessAsync(string fileName, string[] arguments, CancellationToken ct)
     {
+        Process? proc = null;
         try
         {
             var info = new ProcessStartInfo
@@ -70,16 +127,38 @@ public sealed class DesktopNotifier : IDesktopNotifier
             foreach (var arg in arguments)
                 info.ArgumentList.Add(arg);
 
-            using var proc = Process.Start(info);
+            proc = Process.Start(info);
             if (proc is null)
                 return;
 
-            await proc.WaitForExitAsync(ct);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            linked.CancelAfter(NotifyTimeout);
+
+            // Drain stdout/stderr concurrently so a chatty tool can't deadlock us
+            // by filling the pipe buffer. Wait for exit as a third parallel task.
+            var stdoutTask = proc.StandardOutput.ReadToEndAsync(linked.Token);
+            var stderrTask = proc.StandardError.ReadToEndAsync(linked.Token);
+            var exitTask = proc.WaitForExitAsync(linked.Token);
+
+            try
+            {
+                await Task.WhenAll(stdoutTask, stderrTask, exitTask);
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation or timeout: kill the orphan so we don't leak processes.
+                try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+            }
         }
         catch
         {
-            // Best-effort. Missing tools, perms issues, or cancellation should not bubble
-            // into the caller — notifications are a nice-to-have, not load-bearing.
+            // Missing tools, perms issues, and similar should not bubble into callers —
+            // notifications are nice-to-have, not load-bearing.
+            try { proc?.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+        }
+        finally
+        {
+            proc?.Dispose();
         }
     }
 

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Approvals.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Approvals.cs
@@ -3,14 +3,41 @@ using System.Text.Json;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using OpenClaw.Companion.Services;
+using OpenClaw.Core.Models;
 using OpenClaw.Core.Pipeline;
 
 namespace OpenClaw.Companion.ViewModels;
 
+public enum ApprovalsPollingMode
+{
+    Paused,
+    Background,
+    Active
+}
+
+public enum ApprovalQueueSeverity
+{
+    None,
+    Light,
+    Heavy
+}
+
 public sealed partial class MainWindowViewModel
 {
+    // Polling cadence thresholds used by ResolvePollingInterval; mirrors the v2 scope:
+    // active tab + focused window => 1.5s, otherwise 5s when running, Paused when minimized.
+    private static readonly TimeSpan ActivePollInterval = TimeSpan.FromMilliseconds(1500);
+    private static readonly TimeSpan BackgroundPollInterval = TimeSpan.FromSeconds(5);
+
+    // Severity tiers for the tab-badge color. 1-2 = light, 3+ = heavy (operator should act).
+    private const int HeavyQueueThreshold = 3;
+
     private CancellationTokenSource? _approvalsPollCts;
     private readonly SemaphoreSlim _approvalsRefreshLock = new(1, 1);
+    private readonly HashSet<string> _knownApprovalIds = new(StringComparer.Ordinal);
+    private bool _hasSeededKnownApprovals;
+    private IDesktopNotifier? _desktopNotifier;
 
     [ObservableProperty]
     private bool _isApprovalsBusy;
@@ -21,24 +48,81 @@ public sealed partial class MainWindowViewModel
     [ObservableProperty]
     private DateTimeOffset? _approvalsLastPolled;
 
+    [ObservableProperty]
+    private bool _isApprovalsTabActive;
+
+    [ObservableProperty]
+    private bool _isWindowActive = true;
+
+    [ObservableProperty]
+    private bool _isWindowMinimized;
+
+    [ObservableProperty]
+    private ApprovalsPollingMode _approvalsPollingMode = ApprovalsPollingMode.Background;
+
+    [ObservableProperty]
+    private string _approvalHistoryStatus = "History not loaded.";
+
+    [ObservableProperty]
+    private bool _isHistoryBusy;
+
     public ObservableCollection<PendingApprovalItem> PendingApprovals { get; } = [];
+
+    public ObservableCollection<ApprovalHistoryItem> ApprovalHistory { get; } = [];
 
     public int PendingApprovalsCount => PendingApprovals.Count;
 
     public bool HasPendingApprovals => PendingApprovals.Count > 0;
 
+    public ApprovalQueueSeverity QueueSeverity => PendingApprovals.Count switch
+    {
+        0 => ApprovalQueueSeverity.None,
+        < HeavyQueueThreshold => ApprovalQueueSeverity.Light,
+        _ => ApprovalQueueSeverity.Heavy
+    };
+
+    public bool QueueSeverityIsLight => QueueSeverity == ApprovalQueueSeverity.Light;
+
+    public bool QueueSeverityIsHeavy => QueueSeverity == ApprovalQueueSeverity.Heavy;
+
+    public bool DesktopNotifierAvailable => _desktopNotifier?.IsAvailable ?? false;
+
+    public string DesktopNotifierDescription => _desktopNotifier?.PlatformDescription ?? "not configured";
+
+    internal void AttachDesktopNotifier(IDesktopNotifier notifier)
+    {
+        _desktopNotifier = notifier;
+        OnPropertyChanged(nameof(DesktopNotifierAvailable));
+        OnPropertyChanged(nameof(DesktopNotifierDescription));
+    }
+
     partial void OnIsApprovalsBusyChanged(bool value) => RefreshApprovalsCommand.NotifyCanExecuteChanged();
+
+    partial void OnIsApprovalsTabActiveChanged(bool value) => RecomputeApprovalsPollingMode();
+
+    partial void OnIsWindowActiveChanged(bool value) => RecomputeApprovalsPollingMode();
+
+    partial void OnIsWindowMinimizedChanged(bool value) => RecomputeApprovalsPollingMode();
 
     private void NotifyPendingApprovalsChanged()
     {
         OnPropertyChanged(nameof(PendingApprovalsCount));
         OnPropertyChanged(nameof(HasPendingApprovals));
+        OnPropertyChanged(nameof(QueueSeverity));
+        OnPropertyChanged(nameof(QueueSeverityIsLight));
+        OnPropertyChanged(nameof(QueueSeverityIsHeavy));
     }
 
     [RelayCommand(CanExecute = nameof(CanInteractWithApprovals))]
     private async Task RefreshApprovalsAsync()
     {
         await RefreshApprovalsInternalAsync(CancellationToken.None);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanInteractWithApprovals))]
+    private async Task LoadApprovalHistoryAsync()
+    {
+        await LoadApprovalHistoryInternalAsync();
     }
 
     [RelayCommand]
@@ -57,11 +141,9 @@ public sealed partial class MainWindowViewModel
         await SubmitApprovalDecisionAsync(item, approved: false);
     }
 
-    public void StartApprovalsPolling(TimeSpan interval)
+    public void StartApprovalsPolling()
     {
         StopApprovalsPolling();
-        if (interval <= TimeSpan.Zero)
-            return;
 
         _approvalsPollCts = new CancellationTokenSource();
         var token = _approvalsPollCts.Token;
@@ -71,9 +153,24 @@ public sealed partial class MainWindowViewModel
             await RefreshApprovalsInternalAsync(token);
             while (!token.IsCancellationRequested)
             {
+                var interval = ResolvePollingInterval();
+                if (interval is null)
+                {
+                    // Paused: wait a short probe interval before re-checking state.
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(2), token);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        return;
+                    }
+                    continue;
+                }
+
                 try
                 {
-                    await Task.Delay(interval, token);
+                    await Task.Delay(interval.Value, token);
                 }
                 catch (TaskCanceledException)
                 {
@@ -95,13 +192,29 @@ public sealed partial class MainWindowViewModel
         _approvalsPollCts = null;
     }
 
+    private TimeSpan? ResolvePollingInterval()
+        => ApprovalsPollingMode switch
+        {
+            ApprovalsPollingMode.Paused => null,
+            ApprovalsPollingMode.Active => ActivePollInterval,
+            _ => BackgroundPollInterval
+        };
+
+    private void RecomputeApprovalsPollingMode()
+    {
+        ApprovalsPollingMode = (IsWindowMinimized, IsWindowActive && IsApprovalsTabActive) switch
+        {
+            (true, _) => ApprovalsPollingMode.Paused,
+            (false, true) => ApprovalsPollingMode.Active,
+            _ => ApprovalsPollingMode.Background
+        };
+    }
+
     private bool CanInteractWithApprovals() => !IsApprovalsBusy;
 
     private async Task RefreshApprovalsInternalAsync(CancellationToken ct)
     {
         // Skip if another refresh (poll tick or manual click) is already in flight.
-        // Pass CancellationToken.None because TimeSpan.Zero never blocks; we just want
-        // a non-throwing try-acquire.
         if (!await _approvalsRefreshLock.WaitAsync(TimeSpan.Zero, CancellationToken.None))
             return;
 
@@ -115,6 +228,8 @@ public sealed partial class MainWindowViewModel
                 {
                     ApprovalsStatus = error ?? "Invalid gateway URL.";
                     PendingApprovals.Clear();
+                    _knownApprovalIds.Clear();
+                    _hasSeededKnownApprovals = false;
                     NotifyPendingApprovalsChanged();
                 });
                 return;
@@ -126,6 +241,8 @@ public sealed partial class MainWindowViewModel
                 {
                     ApprovalsStatus = "Operator token required to load approvals.";
                     PendingApprovals.Clear();
+                    _knownApprovalIds.Clear();
+                    _hasSeededKnownApprovals = false;
                     NotifyPendingApprovalsChanged();
                 });
                 return;
@@ -136,6 +253,8 @@ public sealed partial class MainWindowViewModel
                 .Select(PendingApprovalItem.FromRequest)
                 .ToList();
 
+            var newlyArrived = DetectNewApprovals(items);
+
             Dispatcher.UIThread.Post(() =>
             {
                 MergePendingApprovals(items);
@@ -145,6 +264,9 @@ public sealed partial class MainWindowViewModel
                     : $"{items.Count} pending approval{(items.Count == 1 ? "" : "s")}.";
                 NotifyPendingApprovalsChanged();
             });
+
+            if (newlyArrived.Count > 0)
+                await FireNotificationsForAsync(newlyArrived, ct);
         }
         catch (OperationCanceledException)
         {
@@ -162,6 +284,55 @@ public sealed partial class MainWindowViewModel
             Dispatcher.UIThread.Post(() => IsApprovalsBusy = false);
             _approvalsRefreshLock.Release();
         }
+    }
+
+    internal IReadOnlyList<PendingApprovalItem> DetectNewApprovals(IReadOnlyList<PendingApprovalItem> latest)
+    {
+        // The first poll seeds the "known" set silently — we don't want to fire a
+        // flurry of notifications for items that already existed when the Companion started.
+        if (!_hasSeededKnownApprovals)
+        {
+            foreach (var item in latest)
+                _knownApprovalIds.Add(item.ApprovalId);
+            _hasSeededKnownApprovals = true;
+            return [];
+        }
+
+        var newItems = latest.Where(item => !_knownApprovalIds.Contains(item.ApprovalId)).ToList();
+        foreach (var item in newItems)
+            _knownApprovalIds.Add(item.ApprovalId);
+
+        // Prune known ids that are no longer pending so the set doesn't grow unboundedly.
+        var stillPending = latest.Select(static i => i.ApprovalId).ToHashSet(StringComparer.Ordinal);
+        _knownApprovalIds.RemoveWhere(id => !stillPending.Contains(id));
+
+        return newItems;
+    }
+
+    private async Task FireNotificationsForAsync(IReadOnlyList<PendingApprovalItem> newItems, CancellationToken ct)
+    {
+        var notifier = _desktopNotifier;
+        if (notifier is null || !notifier.IsAvailable)
+            return;
+        if (!ApprovalDesktopNotificationsEnabled)
+            return;
+        if (ApprovalDesktopNotificationsOnlyWhenUnfocused && IsWindowActive && !IsWindowMinimized)
+            return;
+
+        // Coalesce into one notification when multiple arrive at once.
+        if (newItems.Count == 1)
+        {
+            var item = newItems[0];
+            var title = $"Approval needed: {item.ToolName}";
+            var body = $"from {item.Origin}";
+            await notifier.NotifyAsync(title, body, ct);
+            return;
+        }
+
+        var combinedTitle = $"{newItems.Count} approvals pending";
+        var preview = string.Join(", ", newItems.Take(3).Select(i => i.ToolName));
+        var combinedBody = newItems.Count > 3 ? $"{preview}, and {newItems.Count - 3} more" : preview;
+        await notifier.NotifyAsync(combinedTitle, combinedBody, ct);
     }
 
     internal void MergePendingApprovals(IReadOnlyList<PendingApprovalItem> latest)
@@ -200,6 +371,7 @@ public sealed partial class MainWindowViewModel
         var index = PendingApprovals.IndexOf(item);
         if (index >= 0)
             PendingApprovals.RemoveAt(index);
+        _knownApprovalIds.Remove(item.ApprovalId);
         NotifyPendingApprovalsChanged();
 
         try
@@ -219,6 +391,7 @@ public sealed partial class MainWindowViewModel
                 ApprovalsStatus = $"Decision failed: {response.Error ?? "server rejected the request"}.";
                 if (index >= 0 && index <= PendingApprovals.Count)
                     PendingApprovals.Insert(index, item);
+                _knownApprovalIds.Add(item.ApprovalId);
                 NotifyPendingApprovalsChanged();
             }
         }
@@ -227,7 +400,48 @@ public sealed partial class MainWindowViewModel
             ApprovalsStatus = $"Decision failed: {ex.Message}";
             if (index >= 0 && index <= PendingApprovals.Count)
                 PendingApprovals.Insert(index, item);
+            _knownApprovalIds.Add(item.ApprovalId);
             NotifyPendingApprovalsChanged();
+        }
+    }
+
+    private async Task LoadApprovalHistoryInternalAsync()
+    {
+        using var client = CreateAdminClient(out var error);
+        if (client is null)
+        {
+            ApprovalHistoryStatus = error ?? "Invalid gateway URL.";
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(AuthToken))
+        {
+            ApprovalHistoryStatus = "Operator token required to load history.";
+            return;
+        }
+
+        IsHistoryBusy = true;
+        try
+        {
+            var query = new ApprovalHistoryQuery { Limit = 100 };
+            var response = await client.GetIntegrationApprovalHistoryAsync(query, CancellationToken.None);
+            var items = response.Items.Select(ApprovalHistoryItem.FromEntry).ToList();
+
+            ApprovalHistory.Clear();
+            foreach (var item in items)
+                ApprovalHistory.Add(item);
+
+            ApprovalHistoryStatus = items.Count == 0
+                ? "No history yet."
+                : $"{items.Count} decision{(items.Count == 1 ? "" : "s")} loaded.";
+        }
+        catch (Exception ex)
+        {
+            ApprovalHistoryStatus = $"History load failed: {ex.Message}";
+        }
+        finally
+        {
+            IsHistoryBusy = false;
         }
     }
 }
@@ -262,7 +476,7 @@ public sealed class PendingApprovalItem
             Summary = request.Summary ?? ""
         };
 
-    private static string BuildPreview(string arguments)
+    internal static string BuildPreview(string arguments)
     {
         if (string.IsNullOrWhiteSpace(arguments))
             return "(no arguments)";
@@ -279,5 +493,51 @@ public sealed class PendingApprovalItem
         {
             return arguments.Length > 500 ? arguments[..500] + "…" : arguments;
         }
+    }
+}
+
+public sealed class ApprovalHistoryItem
+{
+    public required string ApprovalId { get; init; }
+    public required string ToolName { get; init; }
+    public required string Origin { get; init; }
+    public required DateTimeOffset TimestampUtc { get; init; }
+    public bool? Approved { get; init; }
+    public string? Actor { get; init; }
+    public string? DecisionSource { get; init; }
+
+    public string OutcomeLabel => Approved switch
+    {
+        true => "Approved",
+        false => "Denied",
+        _ => "Recorded"
+    };
+
+    public string OutcomeColor => Approved switch
+    {
+        true => "#30d158",
+        false => "#ff453a",
+        _ => "#8e8e93"
+    };
+
+    public static ApprovalHistoryItem FromEntry(ApprovalHistoryEntry entry)
+    {
+        var origin = string.IsNullOrWhiteSpace(entry.SenderId)
+            ? entry.ChannelId
+            : $"{entry.ChannelId} · {entry.SenderId}";
+        var actor = string.IsNullOrWhiteSpace(entry.ActorDisplayName)
+            ? entry.ActorSenderId ?? entry.ActorChannelId
+            : entry.ActorDisplayName;
+
+        return new ApprovalHistoryItem
+        {
+            ApprovalId = entry.ApprovalId,
+            ToolName = entry.ToolName,
+            Origin = origin,
+            TimestampUtc = entry.DecisionAtUtc ?? entry.TimestampUtc,
+            Approved = entry.Approved,
+            Actor = actor,
+            DecisionSource = entry.DecisionSource
+        };
     }
 }

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Approvals.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Approvals.cs
@@ -35,6 +35,7 @@ public sealed partial class MainWindowViewModel
 
     private CancellationTokenSource? _approvalsPollCts;
     private readonly SemaphoreSlim _approvalsRefreshLock = new(1, 1);
+    private readonly object _knownApprovalsGate = new();
     private readonly HashSet<string> _knownApprovalIds = new(StringComparer.Ordinal);
     private bool _hasSeededKnownApprovals;
     private IDesktopNotifier? _desktopNotifier;
@@ -98,6 +99,8 @@ public sealed partial class MainWindowViewModel
 
     partial void OnIsApprovalsBusyChanged(bool value) => RefreshApprovalsCommand.NotifyCanExecuteChanged();
 
+    partial void OnIsHistoryBusyChanged(bool value) => LoadApprovalHistoryCommand.NotifyCanExecuteChanged();
+
     partial void OnIsApprovalsTabActiveChanged(bool value) => RecomputeApprovalsPollingMode();
 
     partial void OnIsWindowActiveChanged(bool value) => RecomputeApprovalsPollingMode();
@@ -113,13 +116,13 @@ public sealed partial class MainWindowViewModel
         OnPropertyChanged(nameof(QueueSeverityIsHeavy));
     }
 
-    [RelayCommand(CanExecute = nameof(CanInteractWithApprovals))]
+    [RelayCommand(CanExecute = nameof(CanRefreshApprovals))]
     private async Task RefreshApprovalsAsync()
     {
         await RefreshApprovalsInternalAsync(CancellationToken.None);
     }
 
-    [RelayCommand(CanExecute = nameof(CanInteractWithApprovals))]
+    [RelayCommand(CanExecute = nameof(CanLoadApprovalHistory))]
     private async Task LoadApprovalHistoryAsync()
     {
         await LoadApprovalHistoryInternalAsync();
@@ -210,7 +213,9 @@ public sealed partial class MainWindowViewModel
         };
     }
 
-    private bool CanInteractWithApprovals() => !IsApprovalsBusy;
+    private bool CanRefreshApprovals() => !IsApprovalsBusy;
+
+    private bool CanLoadApprovalHistory() => !IsHistoryBusy;
 
     private async Task RefreshApprovalsInternalAsync(CancellationToken ct)
     {
@@ -228,8 +233,7 @@ public sealed partial class MainWindowViewModel
                 {
                     ApprovalsStatus = error ?? "Invalid gateway URL.";
                     PendingApprovals.Clear();
-                    _knownApprovalIds.Clear();
-                    _hasSeededKnownApprovals = false;
+                    ResetKnownApprovals();
                     NotifyPendingApprovalsChanged();
                 });
                 return;
@@ -241,8 +245,7 @@ public sealed partial class MainWindowViewModel
                 {
                     ApprovalsStatus = "Operator token required to load approvals.";
                     PendingApprovals.Clear();
-                    _knownApprovalIds.Clear();
-                    _hasSeededKnownApprovals = false;
+                    ResetKnownApprovals();
                     NotifyPendingApprovalsChanged();
                 });
                 return;
@@ -288,25 +291,31 @@ public sealed partial class MainWindowViewModel
 
     internal IReadOnlyList<PendingApprovalItem> DetectNewApprovals(IReadOnlyList<PendingApprovalItem> latest)
     {
-        // The first poll seeds the "known" set silently — we don't want to fire a
-        // flurry of notifications for items that already existed when the Companion started.
-        if (!_hasSeededKnownApprovals)
+        // HashSet is not thread-safe. DetectNewApprovals runs on the polling task
+        // thread while other sites mutate from the UI thread, so all accesses go
+        // through _knownApprovalsGate.
+        lock (_knownApprovalsGate)
         {
-            foreach (var item in latest)
+            // The first poll seeds the "known" set silently — we don't want to fire a
+            // flurry of notifications for items that already existed when the Companion started.
+            if (!_hasSeededKnownApprovals)
+            {
+                foreach (var item in latest)
+                    _knownApprovalIds.Add(item.ApprovalId);
+                _hasSeededKnownApprovals = true;
+                return [];
+            }
+
+            var newItems = latest.Where(item => !_knownApprovalIds.Contains(item.ApprovalId)).ToList();
+            foreach (var item in newItems)
                 _knownApprovalIds.Add(item.ApprovalId);
-            _hasSeededKnownApprovals = true;
-            return [];
+
+            // Prune known ids that are no longer pending so the set doesn't grow unboundedly.
+            var stillPending = latest.Select(static i => i.ApprovalId).ToHashSet(StringComparer.Ordinal);
+            _knownApprovalIds.RemoveWhere(id => !stillPending.Contains(id));
+
+            return newItems;
         }
-
-        var newItems = latest.Where(item => !_knownApprovalIds.Contains(item.ApprovalId)).ToList();
-        foreach (var item in newItems)
-            _knownApprovalIds.Add(item.ApprovalId);
-
-        // Prune known ids that are no longer pending so the set doesn't grow unboundedly.
-        var stillPending = latest.Select(static i => i.ApprovalId).ToHashSet(StringComparer.Ordinal);
-        _knownApprovalIds.RemoveWhere(id => !stillPending.Contains(id));
-
-        return newItems;
     }
 
     private async Task FireNotificationsForAsync(IReadOnlyList<PendingApprovalItem> newItems, CancellationToken ct)
@@ -371,7 +380,7 @@ public sealed partial class MainWindowViewModel
         var index = PendingApprovals.IndexOf(item);
         if (index >= 0)
             PendingApprovals.RemoveAt(index);
-        _knownApprovalIds.Remove(item.ApprovalId);
+        RemoveKnownApproval(item.ApprovalId);
         NotifyPendingApprovalsChanged();
 
         try
@@ -391,7 +400,7 @@ public sealed partial class MainWindowViewModel
                 ApprovalsStatus = $"Decision failed: {response.Error ?? "server rejected the request"}.";
                 if (index >= 0 && index <= PendingApprovals.Count)
                     PendingApprovals.Insert(index, item);
-                _knownApprovalIds.Add(item.ApprovalId);
+                AddKnownApproval(item.ApprovalId);
                 NotifyPendingApprovalsChanged();
             }
         }
@@ -400,9 +409,30 @@ public sealed partial class MainWindowViewModel
             ApprovalsStatus = $"Decision failed: {ex.Message}";
             if (index >= 0 && index <= PendingApprovals.Count)
                 PendingApprovals.Insert(index, item);
-            _knownApprovalIds.Add(item.ApprovalId);
+            AddKnownApproval(item.ApprovalId);
             NotifyPendingApprovalsChanged();
         }
+    }
+
+    private void ResetKnownApprovals()
+    {
+        lock (_knownApprovalsGate)
+        {
+            _knownApprovalIds.Clear();
+            _hasSeededKnownApprovals = false;
+        }
+    }
+
+    private void AddKnownApproval(string approvalId)
+    {
+        lock (_knownApprovalsGate)
+            _knownApprovalIds.Add(approvalId);
+    }
+
+    private void RemoveKnownApproval(string approvalId)
+    {
+        lock (_knownApprovalsGate)
+            _knownApprovalIds.Remove(approvalId);
     }
 
     private async Task LoadApprovalHistoryInternalAsync()

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.cs
@@ -44,6 +44,12 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     private bool _debugMode;
 
     [ObservableProperty]
+    private bool _approvalDesktopNotificationsEnabled = true;
+
+    [ObservableProperty]
+    private bool _approvalDesktopNotificationsOnlyWhenUnfocused = true;
+
+    [ObservableProperty]
     private bool _isConnected;
 
     [ObservableProperty]
@@ -111,6 +117,8 @@ public sealed partial class MainWindowViewModel : ViewModelBase
             AllowPlaintextTokenFallback = settings.AllowPlaintextTokenFallback;
             AuthToken = settings.AuthToken ?? "";
             DebugMode = settings.DebugMode;
+            ApprovalDesktopNotificationsEnabled = settings.ApprovalDesktopNotificationsEnabled;
+            ApprovalDesktopNotificationsOnlyWhenUnfocused = settings.ApprovalDesktopNotificationsOnlyWhenUnfocused;
         }
         finally
         {
@@ -130,6 +138,8 @@ public sealed partial class MainWindowViewModel : ViewModelBase
             RememberToken = RememberToken,
             AllowPlaintextTokenFallback = AllowPlaintextTokenFallback,
             DebugMode = DebugMode,
+            ApprovalDesktopNotificationsEnabled = ApprovalDesktopNotificationsEnabled,
+            ApprovalDesktopNotificationsOnlyWhenUnfocused = ApprovalDesktopNotificationsOnlyWhenUnfocused,
             AuthToken = string.IsNullOrWhiteSpace(AuthToken) ? null : AuthToken
         });
         ShowSettingsWarningIfNeeded();
@@ -339,6 +349,20 @@ public sealed partial class MainWindowViewModel : ViewModelBase
         if (value)
             ClearActiveAssistantMessage(replyToMessageId: null);
 
+        SaveSettings();
+    }
+
+    partial void OnApprovalDesktopNotificationsEnabledChanged(bool value)
+    {
+        if (_isLoadingSettings)
+            return;
+        SaveSettings();
+    }
+
+    partial void OnApprovalDesktopNotificationsOnlyWhenUnfocusedChanged(bool value)
+    {
+        if (_isLoadingSettings)
+            return;
         SaveSettings();
     }
 

--- a/src/OpenClaw.Companion/Views/MainWindow.axaml
+++ b/src/OpenClaw.Companion/Views/MainWindow.axaml
@@ -76,28 +76,39 @@
                 </Grid>
             </TabItem>
 
-            <TabItem>
+            <TabItem x:Name="ApprovalsTab">
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <TextBlock Text="Approvals" VerticalAlignment="Center" />
                         <Border Background="{DynamicResource SystemControlBackgroundAccentBrush}"
                                 CornerRadius="9" Padding="6,1"
-                                IsVisible="{Binding HasPendingApprovals}">
+                                IsVisible="{Binding QueueSeverityIsLight}">
                             <TextBlock Text="{Binding PendingApprovalsCount}"
                                        FontSize="11" FontWeight="SemiBold"
                                        Foreground="White" VerticalAlignment="Center" />
                         </Border>
+                        <Border Background="#ff9f0a"
+                                CornerRadius="9" Padding="6,1"
+                                IsVisible="{Binding QueueSeverityIsHeavy}">
+                            <TextBlock Text="{Binding PendingApprovalsCount}"
+                                       FontSize="11" FontWeight="SemiBold"
+                                       Foreground="#1c1c1e" VerticalAlignment="Center" />
+                        </Border>
                     </StackPanel>
                 </TabItem.Header>
-                <Grid RowDefinitions="Auto,*" RowSpacing="10">
+                <Grid RowDefinitions="Auto,*,Auto,Auto" RowSpacing="10">
                     <Border Grid.Row="0" Padding="10" CornerRadius="8" BorderThickness="1"
                             BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
                         <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
                             <StackPanel Grid.Column="0" Spacing="2">
                                 <TextBlock Text="{Binding ApprovalsStatus}" TextWrapping="Wrap" />
-                                <TextBlock Text="{Binding ApprovalsLastPolled, StringFormat='Last polled: {0:HH:mm:ss} UTC'}"
-                                           FontSize="11" Opacity="0.65"
-                                           IsVisible="{Binding ApprovalsLastPolled, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                <StackPanel Orientation="Horizontal" Spacing="10">
+                                    <TextBlock Text="{Binding ApprovalsLastPolled, StringFormat='Last polled: {0:HH:mm:ss} UTC'}"
+                                               FontSize="11" Opacity="0.65"
+                                               IsVisible="{Binding ApprovalsLastPolled, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                    <TextBlock Text="{Binding ApprovalsPollingMode, StringFormat=Polling: {0}}"
+                                               FontSize="11" Opacity="0.55" />
+                                </StackPanel>
                             </StackPanel>
                             <Button Grid.Column="1" Content="Refresh"
                                     Command="{Binding RefreshApprovalsCommand}"
@@ -156,6 +167,48 @@
                             </ScrollViewer>
                         </Grid>
                     </Border>
+
+                    <Border Grid.Row="2" Padding="10" CornerRadius="8" BorderThickness="1"
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                            <StackPanel Grid.Column="0" Spacing="2">
+                                <TextBlock Text="Decision history" FontWeight="SemiBold" />
+                                <TextBlock Text="{Binding ApprovalHistoryStatus}" FontSize="11" Opacity="0.65" />
+                            </StackPanel>
+                            <Button Grid.Column="1" Content="Load History"
+                                    Command="{Binding LoadApprovalHistoryCommand}"
+                                    IsEnabled="{Binding IsHistoryBusy, Converter={StaticResource InverseBool}}" />
+                        </Grid>
+                    </Border>
+
+                    <Border Grid.Row="3" Padding="10" CornerRadius="8" BorderThickness="1"
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                            MaxHeight="260">
+                        <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                            <ItemsControl ItemsSource="{Binding ApprovalHistory}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="vm:ApprovalHistoryItem">
+                                        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10" Margin="0,0,0,4">
+                                            <Border Grid.Column="0" CornerRadius="3" Padding="5,1"
+                                                    Background="{Binding OutcomeColor}">
+                                                <TextBlock Text="{Binding OutcomeLabel}" FontSize="10"
+                                                           FontWeight="SemiBold" Foreground="White" />
+                                            </Border>
+                                            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                                                <TextBlock Text="{Binding ToolName}" FontWeight="SemiBold" FontSize="12" />
+                                                <TextBlock Text="{Binding Origin}" FontSize="11" Opacity="0.7" />
+                                                <TextBlock Text="{Binding Actor, StringFormat=by {0}}" FontSize="11" Opacity="0.55"
+                                                           IsVisible="{Binding Actor, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                            </StackPanel>
+                                            <TextBlock Grid.Column="2"
+                                                       Text="{Binding TimestampUtc, StringFormat='{}{0:HH:mm:ss} UTC'}"
+                                                       FontSize="11" Opacity="0.55" />
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                    </Border>
                 </Grid>
             </TabItem>
 
@@ -183,6 +236,23 @@
                                 <TextBlock Text="{Binding OperatorRole, StringFormat=Role: {0}}" />
                                 <TextBlock Text="{Binding OperatorAuthMode, StringFormat=Auth mode: {0}}" />
                                 <TextBlock Text="{Binding IsBootstrapAdmin, StringFormat=Bootstrap admin: {0}}" />
+                            </StackPanel>
+                        </Border>
+
+                        <Border Padding="10" CornerRadius="8" BorderThickness="1"
+                                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
+                            <StackPanel Spacing="8">
+                                <TextBlock Text="Desktop Notifications" FontWeight="SemiBold" />
+                                <TextBlock Text="{Binding DesktopNotifierDescription, StringFormat=Platform: {0}}"
+                                           FontSize="11" Opacity="0.65" TextWrapping="Wrap" />
+                                <CheckBox Content="Notify on new approval"
+                                          IsChecked="{Binding ApprovalDesktopNotificationsEnabled}"
+                                          IsEnabled="{Binding DesktopNotifierAvailable}" />
+                                <CheckBox Content="Only when Companion is not focused"
+                                          IsChecked="{Binding ApprovalDesktopNotificationsOnlyWhenUnfocused}"
+                                          IsEnabled="{Binding DesktopNotifierAvailable}" />
+                                <TextBlock Text="Desktop notifications are best-effort; they require the OS notification tool to be available (osascript on macOS, notify-send on Linux)."
+                                           FontSize="11" Opacity="0.55" TextWrapping="Wrap" />
                             </StackPanel>
                         </Border>
 

--- a/src/OpenClaw.Companion/Views/MainWindow.axaml.cs
+++ b/src/OpenClaw.Companion/Views/MainWindow.axaml.cs
@@ -1,4 +1,6 @@
 using Avalonia.Controls;
+using Avalonia.VisualTree;
+using OpenClaw.Companion.ViewModels;
 
 namespace OpenClaw.Companion.Views;
 
@@ -7,5 +9,57 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+
+        Activated += (_, _) => PushWindowActive(true);
+        Deactivated += (_, _) => PushWindowActive(false);
+
+        PropertyChanged += (_, args) =>
+        {
+            if (args.Property == WindowStateProperty)
+                PushWindowMinimized(WindowState == WindowState.Minimized);
+        };
+
+        DataContextChanged += (_, _) =>
+        {
+            PushWindowActive(IsActive);
+            PushWindowMinimized(WindowState == WindowState.Minimized);
+            AttachTabSelectionListener();
+        };
+    }
+
+    private void PushWindowActive(bool active)
+    {
+        if (DataContext is MainWindowViewModel vm)
+            vm.IsWindowActive = active;
+    }
+
+    private void PushWindowMinimized(bool minimized)
+    {
+        if (DataContext is MainWindowViewModel vm)
+            vm.IsWindowMinimized = minimized;
+    }
+
+    private void AttachTabSelectionListener()
+    {
+        // The MainWindow layout contains exactly one TabControl.
+        var tabControl = this.FindDescendantOfType<TabControl>();
+        if (tabControl is null || DataContext is not MainWindowViewModel vm)
+            return;
+
+        UpdateApprovalsTabActive(tabControl, vm);
+        tabControl.SelectionChanged -= OnTabSelectionChanged;
+        tabControl.SelectionChanged += OnTabSelectionChanged;
+    }
+
+    private void OnTabSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (sender is TabControl tabControl && DataContext is MainWindowViewModel vm)
+            UpdateApprovalsTabActive(tabControl, vm);
+    }
+
+    private void UpdateApprovalsTabActive(TabControl tabControl, MainWindowViewModel vm)
+    {
+        var approvalsTab = this.FindControl<TabItem>("ApprovalsTab");
+        vm.IsApprovalsTabActive = approvalsTab is not null && tabControl.SelectedItem == approvalsTab;
     }
 }

--- a/src/OpenClaw.Tests/CompanionApprovalsTests.cs
+++ b/src/OpenClaw.Tests/CompanionApprovalsTests.cs
@@ -1,5 +1,6 @@
 using OpenClaw.Companion.Services;
 using OpenClaw.Companion.ViewModels;
+using OpenClaw.Core.Models;
 using OpenClaw.Core.Pipeline;
 using Xunit;
 
@@ -164,6 +165,158 @@ public sealed class CompanionApprovalsTests : IDisposable
 
         viewModel.MergePendingApprovals([]);
         Assert.False(viewModel.HasPendingApprovals);
+    }
+
+    [Fact]
+    public void QueueSeverity_TiersFromCount()
+    {
+        var viewModel = CreateViewModel();
+        Assert.Equal(ApprovalQueueSeverity.None, viewModel.QueueSeverity);
+
+        viewModel.MergePendingApprovals([NewItem("apr_1")]);
+        Assert.Equal(ApprovalQueueSeverity.Light, viewModel.QueueSeverity);
+        Assert.True(viewModel.QueueSeverityIsLight);
+        Assert.False(viewModel.QueueSeverityIsHeavy);
+
+        viewModel.MergePendingApprovals([NewItem("apr_1"), NewItem("apr_2")]);
+        Assert.Equal(ApprovalQueueSeverity.Light, viewModel.QueueSeverity);
+
+        viewModel.MergePendingApprovals([NewItem("apr_1"), NewItem("apr_2"), NewItem("apr_3")]);
+        Assert.Equal(ApprovalQueueSeverity.Heavy, viewModel.QueueSeverity);
+        Assert.True(viewModel.QueueSeverityIsHeavy);
+        Assert.False(viewModel.QueueSeverityIsLight);
+    }
+
+    [Fact]
+    public void PollingMode_ActiveWhenWindowFocusedAndTabActive()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.IsWindowActive = true;
+        viewModel.IsWindowMinimized = false;
+        viewModel.IsApprovalsTabActive = true;
+
+        Assert.Equal(ApprovalsPollingMode.Active, viewModel.ApprovalsPollingMode);
+    }
+
+    [Fact]
+    public void PollingMode_BackgroundWhenAnotherTabActiveButWindowFocused()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.IsWindowActive = true;
+        viewModel.IsWindowMinimized = false;
+        viewModel.IsApprovalsTabActive = false;
+
+        Assert.Equal(ApprovalsPollingMode.Background, viewModel.ApprovalsPollingMode);
+    }
+
+    [Fact]
+    public void PollingMode_BackgroundWhenWindowNotFocused()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.IsWindowActive = false;
+        viewModel.IsWindowMinimized = false;
+        viewModel.IsApprovalsTabActive = true;
+
+        Assert.Equal(ApprovalsPollingMode.Background, viewModel.ApprovalsPollingMode);
+    }
+
+    [Fact]
+    public void PollingMode_PausedWhenMinimized()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.IsWindowActive = true;
+        viewModel.IsApprovalsTabActive = true;
+        viewModel.IsWindowMinimized = true;
+
+        Assert.Equal(ApprovalsPollingMode.Paused, viewModel.ApprovalsPollingMode);
+    }
+
+    [Fact]
+    public void DetectNewApprovals_FirstCallSeedsSilently()
+    {
+        var viewModel = CreateViewModel();
+
+        var newItems = viewModel.DetectNewApprovals([NewItem("apr_1"), NewItem("apr_2")]);
+
+        Assert.Empty(newItems);
+    }
+
+    [Fact]
+    public void DetectNewApprovals_ReportsNewcomersAfterSeed()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.DetectNewApprovals([NewItem("apr_1")]);
+
+        var newItems = viewModel.DetectNewApprovals([NewItem("apr_1"), NewItem("apr_2"), NewItem("apr_3")]);
+
+        Assert.Equal(2, newItems.Count);
+        Assert.Contains(newItems, i => i.ApprovalId == "apr_2");
+        Assert.Contains(newItems, i => i.ApprovalId == "apr_3");
+    }
+
+    [Fact]
+    public void DetectNewApprovals_PrunesResolvedIds()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.DetectNewApprovals([NewItem("apr_1"), NewItem("apr_2")]);
+        viewModel.DetectNewApprovals([]); // apr_1 and apr_2 resolved; pruned.
+
+        var newItems = viewModel.DetectNewApprovals([NewItem("apr_1")]);
+
+        Assert.Single(newItems);
+        Assert.Equal("apr_1", newItems[0].ApprovalId);
+    }
+
+    [Fact]
+    public void ApprovalHistoryItem_FromEntry_MapsApprovedDecision()
+    {
+        var entry = new ApprovalHistoryEntry
+        {
+            EventType = "decision",
+            ApprovalId = "apr_1",
+            SessionId = "sess",
+            ChannelId = "websocket",
+            SenderId = "user@example.com",
+            ToolName = "shell",
+            ArgumentsPreview = "{}",
+            TimestampUtc = DateTimeOffset.UtcNow.AddMinutes(-5),
+            DecisionAtUtc = DateTimeOffset.UtcNow.AddMinutes(-4),
+            ActorDisplayName = "admin1",
+            DecisionSource = "http_admin",
+            Approved = true
+        };
+
+        var item = ApprovalHistoryItem.FromEntry(entry);
+
+        Assert.Equal("apr_1", item.ApprovalId);
+        Assert.Equal("shell", item.ToolName);
+        Assert.Contains("websocket", item.Origin);
+        Assert.Contains("user@example.com", item.Origin);
+        Assert.True(item.Approved);
+        Assert.Equal("Approved", item.OutcomeLabel);
+        Assert.Equal("admin1", item.Actor);
+    }
+
+    [Fact]
+    public void ApprovalHistoryItem_FromEntry_MapsDeniedDecision()
+    {
+        var entry = new ApprovalHistoryEntry
+        {
+            EventType = "decision",
+            ApprovalId = "apr_2",
+            SessionId = "sess",
+            ChannelId = "websocket",
+            SenderId = "sender",
+            ToolName = "write_file",
+            ArgumentsPreview = "{}",
+            TimestampUtc = DateTimeOffset.UtcNow,
+            Approved = false
+        };
+
+        var item = ApprovalHistoryItem.FromEntry(entry);
+
+        Assert.False(item.Approved);
+        Assert.Equal("Denied", item.OutcomeLabel);
     }
 
     private MainWindowViewModel CreateViewModel()


### PR DESCRIPTION
## Summary

v2 phase 1 of the Companion tool-approval queue: the cheap wins from the v2 scope (2a) plus desktop notifications (2b). No server-side changes — still pull-based, still admin-bypass decisions, still operator-token auth. v2c (real-time WS push + operator fan-out) remains out of scope pending v2 phase 1 feedback.

## What shipped

### Adaptive polling (2a.1)
Polling cadence is now reactive to window + tab state:

| State | Cadence |
|---|---|
| Window focused AND Approvals tab selected | **1.5s** (Active) |
| Window visible, otherwise | **5s** (Background) |
| Window minimized | **paused** |

The loop asks `ResolvePollingInterval()` each tick. Mode is recomputed whenever `IsWindowActive`, `IsWindowMinimized`, or `IsApprovalsTabActive` change. [MainWindow code-behind](src/OpenClaw.Companion/Views/MainWindow.axaml.cs) wires Avalonia's window events and `TabControl.SelectionChanged` into the VM.

### Decision history (2a.2)
New "Decision history" panel in the Approvals tab. Backed by the existing `GetIntegrationApprovalHistoryAsync` client (no new endpoints). Shows up to 100 entries with Approved/Denied/Recorded badge, tool, origin (channel · sender), actor, and timestamp. Loaded on demand via a button — doesn't piggyback on the polling tick.

### Badge severity (2a.3)
Tab-header badge now tiers on `PendingApprovalsCount`:
- **0** → no badge
- **1-2** → accent blue badge (Light)
- **3+** → warning orange badge (Heavy)

So an operator's eyes register a backed-up queue without counting.

### Desktop notifications (2b.1 + 2b.2)
New `DesktopNotifier` service with best-effort platform-specific invocations:
- **macOS:** `osascript -e 'display notification ...'`
- **Linux:** `notify-send`
- **Windows:** reports `IsAvailable=false`, not wired up in this release (notifications UI disables itself)

New-item detection: a tracked `_knownApprovalIds` set. **First poll seeds silently** (so pre-existing approvals don't spam notifications at startup); subsequent polls fire one toast per newcomer, coalesced when several arrive in the same tick. Prunes resolved ids so memory is bounded.

`CompanionSettings` gains two toggles, surfaced on the Admin tab:
- `ApprovalDesktopNotificationsEnabled` (default on)
- `ApprovalDesktopNotificationsOnlyWhenUnfocused` (default on — don't nag when the window is already focused)

## What didn't change

- v1 merge behavior (identity-preserving) — untouched.
- `ApproveToolRequestAsync` / `DenyToolRequestAsync` client wrappers — untouched.
- Server — zero changes.

## Tests

10 new cases covering:
- QueueSeverity tiering (None / Light / Heavy at the 1 and 3 boundaries)
- All four ApprovalsPollingMode transitions (active, two background variants, paused)
- DetectNewApprovals: first-call seeding silently, reporting newcomers after, pruning resolved ids
- ApprovalHistoryItem.FromEntry mapping for approved and denied decisions

Verified: `dotnet test src/OpenClaw.Tests -c Release` → **843/843 passing** (+10 from main).

## Test plan (manual)

- [ ] Launch Companion; confirm polling mode displays "Background" when Chat tab is focused, "Active" when Approvals tab is focused.
- [ ] Minimize the window; confirm polling mode becomes "Paused" and Last polled timestamp stops advancing.
- [ ] Queue 3 pending approvals via a non-WS channel; confirm the Approvals tab badge is orange (Heavy).
- [ ] Drop to 2 pending; confirm badge goes back to blue (Light).
- [ ] Switch focus to another app and queue a new approval; confirm a macOS/Linux toast fires.
- [ ] Disable "Notify on new approval"; queue another approval; confirm no toast.
- [ ] Click "Load History"; confirm recent decisions render with correct Approved/Denied colors.

## Scope / risks

- **Windows notifications skipped.** Flagged explicitly in the settings description. If operators run Companion on Windows, a follow-up PR can add `BurntToast` or a `CommunityToolkit.WinUI.Notifications` dependency — we didn't want to pick that dependency in this PR.
- **Seeding-silently on startup means operators won't get a notification for approvals that were already pending before Companion started.** Defensible: otherwise the Companion would spam on every restart. If you want a "startup summary" notification ("3 approvals were waiting when you connected"), that's a natural v2 phase 2 add.
- **Adaptive polling on macOS when the dock is covering the window:** `Window.IsActive` tracks focus, not visibility. A window covered by other apps but still focused will poll at Active cadence. Acceptable for v2 phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)