### PR TITLE
[codex] Improve gateway startup guidance and local recovery

### DIFF
--- a/src/OpenClaw.Gateway/Bootstrap/InteractiveStartupRecovery.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/InteractiveStartupRecovery.cs
@@ -1,0 +1,327 @@
+using OpenClaw.Core.Models;
+
+namespace OpenClaw.Gateway.Bootstrap;
+
+internal enum StartupRecoveryResult
+{
+    NotHandled,
+    Recovered,
+    Declined
+}
+
+internal static class InteractiveStartupRecovery
+{
+    private const string ModelProviderKeyEnv = "MODEL_PROVIDER_KEY";
+    private const string OpenAiApiKeyEnv = "OPENAI_API_KEY";
+    private const string ModelProviderEndpointEnv = "MODEL_PROVIDER_ENDPOINT";
+    private const string WorkspaceEnv = "OPENCLAW_WORKSPACE";
+    private const string BindAddressEnv = "OpenClaw__BindAddress";
+    private const string PortEnv = "OpenClaw__Port";
+    private const string MemoryProviderEnv = "OpenClaw__Memory__Provider";
+    private const string MemoryStoragePathEnv = "OpenClaw__Memory__StoragePath";
+    private const string MemoryRetentionEnabledEnv = "OpenClaw__Memory__Retention__Enabled";
+
+    public static StartupRecoveryResult TryRecover(
+        Exception ex,
+        GatewayStartupContext? startup,
+        string environmentName,
+        string currentDirectory,
+        bool canPrompt,
+        TextReader? input = null,
+        TextWriter? output = null)
+    {
+        if (!canPrompt)
+            return StartupRecoveryResult.NotHandled;
+
+        if (input is null || output is null)
+        {
+            if (!IsInteractiveConsole())
+                return StartupRecoveryResult.NotHandled;
+
+            input = Console.In;
+            output = Console.Out;
+        }
+
+        if (!IsRecoverable(ex))
+            return StartupRecoveryResult.NotHandled;
+
+        output.WriteLine();
+        output.WriteLine(StartupFailureReporter.Render(ex, startup, environmentName, isDoctorMode: false));
+        output.WriteLine();
+        output.WriteLine("A minimal local setup can apply safe defaults for this run and retry startup.");
+        output.WriteLine("It keeps the gateway on 127.0.0.1, uses file memory under a writable local path, and does not persist anything to your shell.");
+        if (!PromptYesNo(output, input, "Apply minimal local setup now?", defaultValue: true))
+            return StartupRecoveryResult.Declined;
+
+        var defaults = BuildDefaults(ex, startup, currentDirectory);
+        output.WriteLine();
+        output.WriteLine($"Provider/model: {defaults.Provider}/{defaults.Model}");
+        output.WriteLine("Local bind: 127.0.0.1");
+
+        var workspacePath = Prompt(output, input, "Workspace path", defaults.WorkspacePath);
+        var memoryPath = Prompt(output, input, "Memory path", defaults.MemoryPath);
+        var port = PromptPort(output, input, defaults.Port);
+        var apiKey = ResolveApiKey(output, input, defaults.Provider, defaults.ApiKey);
+        var endpoint = ResolveEndpoint(output, input, defaults.Provider, defaults.Endpoint);
+
+        try
+        {
+            Directory.CreateDirectory(workspacePath);
+            Directory.CreateDirectory(memoryPath);
+        }
+        catch (Exception createError) when (createError is IOException or UnauthorizedAccessException)
+        {
+            output.WriteLine($"Could not prepare the local workspace or memory path: {createError.Message}");
+            return StartupRecoveryResult.Declined;
+        }
+
+        ApplyLocalOverrides(workspacePath, memoryPath, port, apiKey, endpoint);
+
+        output.WriteLine();
+        output.WriteLine("Applied local startup overrides for this process. Retrying gateway startup...");
+        output.WriteLine("For a persistent setup later, run: openclaw setup");
+        return StartupRecoveryResult.Recovered;
+    }
+
+    private static StartupRecoveryDefaults BuildDefaults(Exception ex, GatewayStartupContext? startup, string currentDirectory)
+    {
+        var config = startup?.Config ?? new GatewayConfig();
+        var port = config.Port > 0 ? config.Port : 18789;
+        if (IsPortInUse(ex))
+            port++;
+
+        var workspacePath = Environment.GetEnvironmentVariable(WorkspaceEnv);
+        if (string.IsNullOrWhiteSpace(workspacePath))
+            workspacePath = startup?.WorkspacePath;
+        if (string.IsNullOrWhiteSpace(workspacePath))
+            workspacePath = currentDirectory;
+
+        var provider = string.IsNullOrWhiteSpace(config.Llm.Provider) ? new GatewayConfig().Llm.Provider : config.Llm.Provider;
+        var model = string.IsNullOrWhiteSpace(config.Llm.Model) ? new GatewayConfig().Llm.Model : config.Llm.Model;
+
+        return new StartupRecoveryDefaults
+        {
+            WorkspacePath = Path.GetFullPath(workspacePath),
+            MemoryPath = Path.Combine(currentDirectory, "memory"),
+            Port = port,
+            Provider = provider,
+            Model = model,
+            ApiKey = ResolveExistingApiKey(provider),
+            Endpoint = ResolveExistingEndpoint(config)
+        };
+    }
+
+    private static void ApplyLocalOverrides(string workspacePath, string memoryPath, int port, string? apiKey, string? endpoint)
+    {
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", Environments.Development);
+        Environment.SetEnvironmentVariable(WorkspaceEnv, workspacePath);
+        Environment.SetEnvironmentVariable(BindAddressEnv, "127.0.0.1");
+        Environment.SetEnvironmentVariable(PortEnv, port.ToString());
+        Environment.SetEnvironmentVariable(MemoryProviderEnv, "file");
+        Environment.SetEnvironmentVariable(MemoryStoragePathEnv, memoryPath);
+        Environment.SetEnvironmentVariable(MemoryRetentionEnabledEnv, "false");
+
+        if (!string.IsNullOrWhiteSpace(apiKey))
+            Environment.SetEnvironmentVariable(ModelProviderKeyEnv, apiKey);
+        if (!string.IsNullOrWhiteSpace(endpoint))
+            Environment.SetEnvironmentVariable(ModelProviderEndpointEnv, endpoint);
+    }
+
+    private static string? ResolveExistingApiKey(string provider)
+    {
+        var configured = Environment.GetEnvironmentVariable(ModelProviderKeyEnv);
+        if (!string.IsNullOrWhiteSpace(configured))
+            return configured;
+
+        if (string.Equals(provider, "openai", StringComparison.OrdinalIgnoreCase))
+        {
+            var openAiApiKey = Environment.GetEnvironmentVariable(OpenAiApiKeyEnv);
+            if (!string.IsNullOrWhiteSpace(openAiApiKey))
+                return openAiApiKey;
+        }
+
+        return null;
+    }
+
+    private static string? ResolveExistingEndpoint(GatewayConfig config)
+        => Environment.GetEnvironmentVariable(ModelProviderEndpointEnv) ?? config.Llm.Endpoint;
+
+    private static string? ResolveApiKey(TextWriter output, TextReader input, string provider, string? existingApiKey)
+    {
+        if (!RequiresApiKey(provider))
+            return existingApiKey;
+
+        if (!string.IsNullOrWhiteSpace(existingApiKey))
+        {
+            if (string.Equals(provider, "openai", StringComparison.OrdinalIgnoreCase) &&
+                string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ModelProviderKeyEnv)) &&
+                !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(OpenAiApiKeyEnv)))
+            {
+                output.WriteLine($"Using {OpenAiApiKeyEnv} from the current environment for this run.");
+            }
+
+            return existingApiKey;
+        }
+
+        return PromptRequiredSecret(output, input, $"{provider} API key");
+    }
+
+    private static string? ResolveEndpoint(TextWriter output, TextReader input, string provider, string? existingEndpoint)
+    {
+        if (!RequiresEndpoint(provider))
+            return existingEndpoint;
+
+        if (!string.IsNullOrWhiteSpace(existingEndpoint))
+            return existingEndpoint;
+
+        return PromptRequired(output, input, $"{provider} endpoint");
+    }
+
+    private static bool RequiresApiKey(string provider)
+        => provider.Trim().ToLowerInvariant() switch
+        {
+            "openai" or "anthropic" or "claude" or "gemini" or "google" or "azure-openai" or "openai-compatible" or "groq" or "together" or "lmstudio" or "amazon-bedrock" or "anthropic-vertex" => true,
+            _ => false
+        };
+
+    private static bool RequiresEndpoint(string provider)
+        => provider.Trim().ToLowerInvariant() switch
+        {
+            "azure-openai" or "openai-compatible" or "groq" or "together" or "lmstudio" or "amazon-bedrock" or "anthropic-vertex" => true,
+            _ => false
+        };
+
+    private static bool IsRecoverable(Exception ex)
+    {
+        var message = ex.Message;
+        return Contains(message, "OPENCLAW_AUTH_TOKEN must be set when binding to a non-loopback address.") ||
+               Contains(message, "MODEL_PROVIDER_KEY must be set") ||
+               Contains(message, "MODEL_PROVIDER_ENDPOINT must be set") ||
+               Contains(message, "Endpoint must be set for provider") ||
+               Contains(message, "Memory.StoragePath") ||
+               IsStorageAccessError(ex) ||
+               IsPortInUse(ex);
+    }
+
+    private static bool IsInteractiveConsole()
+        => Environment.UserInteractive && !Console.IsInputRedirected && !Console.IsOutputRedirected;
+
+    private static bool IsStorageAccessError(Exception ex)
+    {
+        var baseMessage = ex.GetBaseException().Message;
+        return baseMessage.Contains("Read-only file system", StringComparison.OrdinalIgnoreCase) ||
+               baseMessage.Contains("Permission denied", StringComparison.OrdinalIgnoreCase) ||
+               baseMessage.Contains("Access to the path", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsPortInUse(Exception ex)
+    {
+        var baseException = ex.GetBaseException();
+        return string.Equals(baseException.GetType().Name, "AddressInUseException", StringComparison.Ordinal) ||
+               baseException.Message.Contains("address already in use", StringComparison.OrdinalIgnoreCase) ||
+               baseException.Message.Contains("Only one usage of each socket address", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool Contains(string value, string fragment)
+        => value.Contains(fragment, StringComparison.OrdinalIgnoreCase);
+
+    private static string Prompt(TextWriter output, TextReader input, string label, string defaultValue)
+    {
+        output.Write($"{label} [{defaultValue}]: ");
+        var value = input.ReadLine();
+        return string.IsNullOrWhiteSpace(value) ? defaultValue : value.Trim();
+    }
+
+    private static string PromptRequired(TextWriter output, TextReader input, string label)
+    {
+        while (true)
+        {
+            output.Write($"{label}: ");
+            var value = input.ReadLine()?.Trim();
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+
+            output.WriteLine("A value is required.");
+        }
+    }
+
+    private static string PromptRequiredSecret(TextWriter output, TextReader input, string label)
+    {
+        if (ReferenceEquals(input, Console.In) && ReferenceEquals(output, Console.Out) && !Console.IsInputRedirected)
+        {
+            return ReadSecretFromConsole(label);
+        }
+
+        return PromptRequired(output, input, label);
+    }
+
+    private static string ReadSecretFromConsole(string label)
+    {
+        while (true)
+        {
+            Console.Write($"{label}: ");
+            var buffer = new List<char>();
+            while (true)
+            {
+                var key = Console.ReadKey(intercept: true);
+                if (key.Key == ConsoleKey.Enter)
+                {
+                    Console.WriteLine();
+                    break;
+                }
+
+                if (key.Key == ConsoleKey.Backspace)
+                {
+                    if (buffer.Count == 0)
+                        continue;
+
+                    buffer.RemoveAt(buffer.Count - 1);
+                    continue;
+                }
+
+                if (!char.IsControl(key.KeyChar))
+                    buffer.Add(key.KeyChar);
+            }
+
+            var value = new string([.. buffer]).Trim();
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+
+            Console.WriteLine("A value is required.");
+        }
+    }
+
+    private static bool PromptYesNo(TextWriter output, TextReader input, string label, bool defaultValue)
+    {
+        var suffix = defaultValue ? "[Y/n]" : "[y/N]";
+        output.Write($"{label} {suffix}: ");
+        var value = input.ReadLine()?.Trim().ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(value))
+            return defaultValue;
+
+        return value is "y" or "yes";
+    }
+
+    private static int PromptPort(TextWriter output, TextReader input, int defaultPort)
+    {
+        while (true)
+        {
+            var value = Prompt(output, input, "Port", defaultPort.ToString());
+            if (int.TryParse(value, out var port) && port is > 0 and <= 65535)
+                return port;
+
+            output.WriteLine("Port must be between 1 and 65535.");
+        }
+    }
+
+    private sealed class StartupRecoveryDefaults
+    {
+        public required string WorkspacePath { get; init; }
+        public required string MemoryPath { get; init; }
+        public required int Port { get; init; }
+        public required string Provider { get; init; }
+        public required string Model { get; init; }
+        public string? ApiKey { get; init; }
+        public string? Endpoint { get; init; }
+    }
+}

--- a/src/OpenClaw.Gateway/Bootstrap/StartupFailureReporter.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/StartupFailureReporter.cs
@@ -1,0 +1,319 @@
+using System.Text;
+
+namespace OpenClaw.Gateway.Bootstrap;
+
+internal static class StartupFailureReporter
+{
+    public static void Write(
+        Exception ex,
+        GatewayStartupContext? startup,
+        string environmentName,
+        bool isDoctorMode,
+        TextWriter? error = null)
+    {
+        var writer = error ?? Console.Error;
+        writer.WriteLine(Render(ex, startup, environmentName, isDoctorMode));
+    }
+
+    internal static string Render(
+        Exception ex,
+        GatewayStartupContext? startup,
+        string environmentName,
+        bool isDoctorMode)
+    {
+        var report = Analyze(ex, startup, environmentName, isDoctorMode);
+        var sb = new StringBuilder();
+        sb.AppendLine($"Startup failed: {report.Title}");
+        sb.AppendLine();
+        sb.AppendLine(report.Summary);
+
+        if (report.Details.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Details:");
+            foreach (var detail in report.Details)
+                sb.AppendLine($"- {detail}");
+        }
+
+        if (report.Actions.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Suggested fixes:");
+            foreach (var action in report.Actions)
+                sb.AppendLine($"- {action}");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static StartupFailureReport Analyze(
+        Exception ex,
+        GatewayStartupContext? startup,
+        string environmentName,
+        bool isDoctorMode)
+    {
+        var message = ex.Message;
+
+        if (Contains(message, "OPENCLAW_AUTH_TOKEN must be set when binding to a non-loopback address."))
+            return BuildAuthTokenReport(startup, environmentName, isDoctorMode);
+
+        if (IsPortInUse(ex))
+            return BuildPortInUseReport(ex, startup, isDoctorMode);
+
+        if (Contains(message, "MODEL_PROVIDER_KEY must be set") ||
+            Contains(message, "MODEL_PROVIDER_ENDPOINT must be set") ||
+            Contains(message, "Endpoint must be set for provider") ||
+            Contains(message, "Configured provider '") ||
+            Contains(message, "Unsupported LLM provider"))
+        {
+            return BuildProviderReport(ex, startup, isDoctorMode);
+        }
+
+        if (Contains(message, "Memory.StoragePath") || IsStorageAccessError(ex))
+            return BuildStorageReport(ex, startup, environmentName, isDoctorMode);
+
+        return BuildGenericReport(ex, startup, environmentName, isDoctorMode);
+    }
+
+    private static StartupFailureReport BuildAuthTokenReport(
+        GatewayStartupContext? startup,
+        string environmentName,
+        bool isDoctorMode)
+    {
+        var details = new List<string>();
+        AddIfValue(details, "Current ASPNETCORE_ENVIRONMENT", environmentName);
+        AddIfValue(details, "BindAddress", startup?.Config.BindAddress);
+        details.Add("Non-loopback binds require OPENCLAW_AUTH_TOKEN so remote requests are authenticated.");
+
+        if (string.Equals(environmentName, Environments.Production, StringComparison.OrdinalIgnoreCase))
+        {
+            details.Add("Production settings can apply container-style defaults, so local launches often need explicit Development or bind-path overrides.");
+        }
+
+        var actions = new List<string>
+        {
+            "For local-only use, set OpenClaw__BindAddress to 127.0.0.1.",
+            "If you are starting the gateway on your machine, set ASPNETCORE_ENVIRONMENT to Development so the repo-local defaults are used.",
+            "If you do want a non-loopback bind, set OPENCLAW_AUTH_TOKEN to a strong random value before launch."
+        };
+        AddDoctorStep(actions, isDoctorMode);
+
+        return new StartupFailureReport(
+            Title: "authentication is required for a non-loopback bind.",
+            Summary: "The gateway is configured to listen on a network-reachable address, but no auth token was configured.",
+            Details: details,
+            Actions: actions);
+    }
+
+    private static StartupFailureReport BuildStorageReport(
+        Exception ex,
+        GatewayStartupContext? startup,
+        string environmentName,
+        bool isDoctorMode)
+    {
+        var details = new List<string>();
+        AddIfValue(details, "Current ASPNETCORE_ENVIRONMENT", environmentName);
+        AddIfValue(details, "Memory.StoragePath", startup?.Config.Memory.StoragePath);
+        if (string.Equals(startup?.Config.Memory.Provider, "sqlite", StringComparison.OrdinalIgnoreCase))
+            AddIfValue(details, "Memory.Sqlite.DbPath", startup?.Config.Memory.Sqlite.DbPath);
+        if (startup?.Config.Memory.Retention.Enabled == true)
+            AddIfValue(details, "Memory.Retention.ArchivePath", startup.Config.Memory.Retention.ArchivePath);
+        AddIfValue(details, "Underlying error", ex.GetBaseException().Message);
+
+        var actions = new List<string>();
+        if (string.Equals(environmentName, Environments.Production, StringComparison.OrdinalIgnoreCase))
+        {
+            actions.Add("If you are starting locally, set ASPNETCORE_ENVIRONMENT to Development so the gateway uses repo-local storage defaults.");
+        }
+
+        actions.Add("Set OpenClaw__Memory__StoragePath to a writable directory such as ./memory.");
+        if (string.Equals(startup?.Config.Memory.Provider, "sqlite", StringComparison.OrdinalIgnoreCase))
+        {
+            actions.Add("If sqlite is enabled, set OpenClaw__Memory__Sqlite__DbPath under that writable directory as well.");
+        }
+        if (startup?.Config.Memory.Retention.Enabled == true)
+        {
+            actions.Add("If retention archiving is enabled, set OpenClaw__Memory__Retention__ArchivePath under that writable directory too.");
+        }
+
+        actions.Add("Make sure the chosen directory exists or can be created by the current user.");
+        AddDoctorStep(actions, isDoctorMode);
+
+        return new StartupFailureReport(
+            Title: "the configured memory storage path is not writable.",
+            Summary: "The gateway could not create one of its startup files under the configured storage root.",
+            Details: details,
+            Actions: actions);
+    }
+
+    private static StartupFailureReport BuildProviderReport(
+        Exception ex,
+        GatewayStartupContext? startup,
+        bool isDoctorMode)
+    {
+        var config = startup?.Config;
+        var provider = config?.Llm.Provider ?? TryExtractQuotedValue(ex.Message, "Configured provider '");
+        var providerLabel = FormatProviderName(provider);
+        var details = new List<string>();
+        AddIfValue(details, "Provider", provider);
+        AddIfValue(details, "Model", config?.Llm.Model);
+        AddIfValue(details, "Underlying error", ex.GetBaseException().Message);
+
+        var actions = new List<string>();
+        string title;
+        string summary;
+        if (Contains(ex.Message, "MODEL_PROVIDER_KEY must be set"))
+        {
+            title = $"{providerLabel} credentials are missing.";
+            summary = "The built-in LLM provider could not be initialized because the required API key was not configured.";
+            actions.Add("Set MODEL_PROVIDER_KEY before launch.");
+            if (string.Equals(provider, "openai", StringComparison.OrdinalIgnoreCase))
+            {
+                actions.Add("If your OpenAI key is stored in OPENAI_API_KEY, copy or map that value into MODEL_PROVIDER_KEY before starting the gateway.");
+            }
+        }
+        else if (Contains(ex.Message, "MODEL_PROVIDER_ENDPOINT must be set") ||
+                 Contains(ex.Message, "Endpoint must be set for provider"))
+        {
+            title = $"{providerLabel} endpoint is missing.";
+            summary = "The selected LLM provider needs an explicit endpoint, but no endpoint was configured.";
+            actions.Add("Set MODEL_PROVIDER_ENDPOINT to the provider base URL before launch.");
+            if (string.Equals(provider, "azure-openai", StringComparison.OrdinalIgnoreCase))
+            {
+                actions.Add("For Azure OpenAI, use the Azure resource endpoint, for example https://<resource>.openai.azure.com/.");
+            }
+        }
+        else
+        {
+            title = $"{providerLabel} could not be initialized.";
+            summary = "The configured LLM provider was not available during startup.";
+            actions.Add("Confirm OpenClaw:Llm:Provider points to a built-in provider or to a plugin-backed provider that is enabled.");
+            actions.Add("If this provider should come from a plugin, enable that plugin before launch.");
+        }
+
+        AddDoctorStep(actions, isDoctorMode);
+
+        return new StartupFailureReport(
+            Title: title,
+            Summary: summary,
+            Details: details,
+            Actions: actions);
+    }
+
+    private static StartupFailureReport BuildPortInUseReport(
+        Exception ex,
+        GatewayStartupContext? startup,
+        bool isDoctorMode)
+    {
+        var details = new List<string>();
+        AddIfValue(details, "BindAddress", startup?.Config.BindAddress);
+        if (startup is not null)
+            details.Add($"Port: {startup.Config.Port}");
+        AddIfValue(details, "Underlying error", ex.GetBaseException().Message);
+
+        var actions = new List<string>
+        {
+            "Stop the process that is already using this port, or change OpenClaw__Port to a free port."
+        };
+        AddDoctorStep(actions, isDoctorMode);
+
+        return new StartupFailureReport(
+            Title: "the configured HTTP port is already in use.",
+            Summary: "Kestrel could not bind the gateway listener because another process already owns the requested address.",
+            Details: details,
+            Actions: actions);
+    }
+
+    private static StartupFailureReport BuildGenericReport(
+        Exception ex,
+        GatewayStartupContext? startup,
+        string environmentName,
+        bool isDoctorMode)
+    {
+        var details = new List<string>
+        {
+            $"Exception: {ex.GetType().Name}",
+            $"Message: {ex.GetBaseException().Message}"
+        };
+        AddIfValue(details, "Current ASPNETCORE_ENVIRONMENT", environmentName);
+        AddIfValue(details, "BindAddress", startup?.Config.BindAddress);
+        if (startup is not null)
+            details.Add($"Port: {startup.Config.Port}");
+        AddIfValue(details, "Memory.StoragePath", startup?.Config.Memory.StoragePath);
+        AddIfValue(details, "Provider", startup?.Config.Llm.Provider);
+        AddIfValue(details, "Model", startup?.Config.Llm.Model);
+
+        var actions = new List<string>
+        {
+            "Review the startup settings above and correct the misconfiguration before retrying."
+        };
+        AddDoctorStep(actions, isDoctorMode);
+
+        return new StartupFailureReport(
+            Title: "an unexpected startup exception occurred.",
+            Summary: "The gateway exited before it finished starting.",
+            Details: details,
+            Actions: actions);
+    }
+
+    private static bool IsStorageAccessError(Exception ex)
+    {
+        var baseMessage = ex.GetBaseException().Message;
+        return baseMessage.Contains("Read-only file system", StringComparison.OrdinalIgnoreCase) ||
+               baseMessage.Contains("Permission denied", StringComparison.OrdinalIgnoreCase) ||
+               baseMessage.Contains("Access to the path", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsPortInUse(Exception ex)
+    {
+        var baseException = ex.GetBaseException();
+        return string.Equals(baseException.GetType().Name, "AddressInUseException", StringComparison.Ordinal) ||
+               baseException.Message.Contains("address already in use", StringComparison.OrdinalIgnoreCase) ||
+               baseException.Message.Contains("Only one usage of each socket address", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void AddDoctorStep(ICollection<string> actions, bool isDoctorMode)
+    {
+        if (!isDoctorMode)
+        {
+            actions.Add("Run the preflight checks with: dotnet run --project src/OpenClaw.Gateway -c Release -- --doctor");
+        }
+    }
+
+    private static void AddIfValue(ICollection<string> details, string label, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+            details.Add($"{label}: {value}");
+    }
+
+    private static bool Contains(string value, string fragment)
+        => value.Contains(fragment, StringComparison.OrdinalIgnoreCase);
+
+    private static string? TryExtractQuotedValue(string value, string prefix)
+    {
+        var start = value.IndexOf(prefix, StringComparison.OrdinalIgnoreCase);
+        if (start < 0)
+            return null;
+
+        start += prefix.Length;
+        var end = value.IndexOf('\'', start);
+        return end > start ? value[start..end] : null;
+    }
+
+    private static string FormatProviderName(string? provider)
+        => provider?.ToLowerInvariant() switch
+        {
+            "openai" => "OpenAI provider",
+            "azure-openai" => "Azure OpenAI provider",
+            "anthropic" or "claude" => "Anthropic provider",
+            "gemini" or "google" => "Gemini provider",
+            { Length: > 0 } => $"Provider '{provider}'",
+            _ => "The configured provider"
+        };
+
+    private sealed record StartupFailureReport(
+        string Title,
+        string Summary,
+        IReadOnlyList<string> Details,
+        IReadOnlyList<string> Actions);
+}

--- a/src/OpenClaw.Gateway/Bootstrap/StartupFailureReporter.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/StartupFailureReporter.cs
@@ -13,6 +13,7 @@ internal static class StartupFailureReporter
     {
         var writer = error ?? Console.Error;
         writer.WriteLine(Render(ex, startup, environmentName, isDoctorMode));
+        writer.Flush();
     }
 
     internal static string Render(

--- a/src/OpenClaw.Gateway/Composition/BackendServicesExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/BackendServicesExtensions.cs
@@ -13,7 +13,16 @@ internal static class BackendServicesExtensions
             ? startup.Config.Memory.StoragePath
             : Path.GetFullPath(startup.Config.Memory.StoragePath);
         var keysDir = new DirectoryInfo(Path.Combine(rootedStorage, "admin", "keys"));
-        keysDir.Create();
+        try
+        {
+            keysDir.Create();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            throw new InvalidOperationException(
+                $"Memory.StoragePath '{rootedStorage}' is not writable. Failed to create '{keysDir.FullName}'.",
+                ex);
+        }
 
         services.AddDataProtection()
             .PersistKeysToFileSystem(keysDir)

--- a/src/OpenClaw.Gateway/Pipeline/PipelineExtensions.cs
+++ b/src/OpenClaw.Gateway/Pipeline/PipelineExtensions.cs
@@ -31,7 +31,7 @@ internal static class PipelineExtensions
         StartWorkers(app, startup, runtime);
         StartChannels(app, runtime);
         RegisterShutdown(app, startup, runtime);
-        LogStartupBanner(app, startup);
+        StartupReadyReporter.Register(app, startup);
     }
 
     private static void ConfigureForwardedHeaders(WebApplication app, GatewayStartupContext startup)
@@ -234,87 +234,4 @@ internal static class PipelineExtensions
         }
     }
 
-    private static void LogStartupBanner(WebApplication app, GatewayStartupContext startup)
-    {
-        if (!app.Logger.IsEnabled(LogLevel.Information))
-            return;
-
-        var isAot = startup.RuntimeState.EffectiveMode == OpenClaw.Core.Models.GatewayRuntimeMode.Aot;
-        app.Logger.LogInformation(
-            """
-            ╔══════════════════════════════════════════╗
-            ║  OpenClaw.NET Gateway                    ║
-            ║  Listening: ws://{BindAddress}:{Port}/ws  ║
-            ║  Model: {Model}  ║
-            ║  Runtime Mode: {RuntimeMode}  ║
-            ║  NativeAOT: {NativeAOT}  ║
-            ╚══════════════════════════════════════════╝
-            """,
-            FormatBindAddressForUri(startup.Config.BindAddress),
-            startup.Config.Port,
-            startup.Config.Llm.Model,
-            startup.RuntimeState.EffectiveModeName,
-            isAot ? "Yes" : "No");
-
-        if (startup.Config.Port <= 0)
-        {
-            app.Logger.LogInformation(
-                "Gateway ready. Bind address {BindAddress} resolved to port {Port} — URLs not shown because a valid port was not configured.",
-                startup.Config.BindAddress,
-                startup.Config.Port);
-            return;
-        }
-
-        var host = ResolveBannerHost(startup.Config.BindAddress);
-        var baseUrl = $"http://{host}:{startup.Config.Port}";
-        app.Logger.LogInformation(
-            """
-            Gateway ready. Open one of:
-              Chat UI            {ChatUrl}
-              Admin UI           {AdminUrl}
-              Doctor (text)      {DoctorUrl}
-              Health             {HealthUrl}
-              MCP endpoint       {McpUrl}
-              Integration API    {IntegrationUrl}
-            Note: the root URL (/) redirects to /chat — it is not the UI itself.
-            """,
-            $"{baseUrl}/chat",
-            $"{baseUrl}/admin",
-            $"{baseUrl}/doctor/text",
-            $"{baseUrl}/health",
-            $"{baseUrl}/mcp",
-            $"{baseUrl}/api/integration/status");
-    }
-
-    private static string ResolveBannerHost(string bindAddress)
-    {
-        if (string.IsNullOrWhiteSpace(bindAddress))
-            return "127.0.0.1";
-
-        switch (bindAddress)
-        {
-            case "0.0.0.0":
-            case "*":
-            case "+":
-            case "::":
-            case "[::]":
-                return "127.0.0.1";
-        }
-
-        return FormatBindAddressForUri(bindAddress);
-    }
-
-    private static string FormatBindAddressForUri(string bindAddress)
-    {
-        if (string.IsNullOrWhiteSpace(bindAddress))
-            return bindAddress;
-
-        if (bindAddress.StartsWith('['))
-            return bindAddress;
-
-        if (bindAddress.Contains(':'))
-            return $"[{bindAddress}]";
-
-        return bindAddress;
-    }
 }

--- a/src/OpenClaw.Gateway/Pipeline/StartupReadyReporter.cs
+++ b/src/OpenClaw.Gateway/Pipeline/StartupReadyReporter.cs
@@ -1,0 +1,86 @@
+using System.Text;
+using OpenClaw.Gateway.Bootstrap;
+
+namespace OpenClaw.Gateway.Pipeline;
+
+internal static class StartupReadyReporter
+{
+    public static void Register(WebApplication app, GatewayStartupContext startup)
+    {
+        app.Lifetime.ApplicationStarted.Register(() =>
+        {
+            try
+            {
+                Write(startup);
+            }
+            catch (Exception ex)
+            {
+                app.Logger.LogWarning(ex, "Failed to write startup readiness message.");
+            }
+        });
+    }
+
+    internal static void Write(GatewayStartupContext startup, TextWriter? output = null)
+    {
+        var writer = output ?? Console.Out;
+        writer.WriteLine(Render(startup));
+        writer.Flush();
+    }
+
+    internal static string Render(GatewayStartupContext startup)
+    {
+        var bindAddress = FormatHostForUri(startup.Config.BindAddress);
+        var sb = new StringBuilder();
+
+        sb.AppendLine("OpenClaw gateway ready.");
+        sb.AppendLine($"Listening on http://{bindAddress}:{startup.Config.Port}");
+
+        if (startup.Config.Port <= 0)
+        {
+            sb.AppendLine("URLs are not shown because a valid port was not configured.");
+            return sb.ToString().TrimEnd();
+        }
+
+        var host = ResolveDisplayHost(startup.Config.BindAddress);
+        var httpBase = $"http://{host}:{startup.Config.Port}";
+        var wsBase = $"ws://{host}:{startup.Config.Port}";
+
+        sb.AppendLine($"Chat UI: {httpBase}/chat");
+        sb.AppendLine($"Admin UI: {httpBase}/admin");
+        sb.AppendLine($"Doctor: {httpBase}/doctor/text");
+        sb.AppendLine($"Health: {httpBase}/health");
+        sb.AppendLine($"MCP: {httpBase}/mcp");
+        sb.AppendLine($"WebSocket: {wsBase}/ws");
+
+        return sb.ToString().TrimEnd();
+    }
+
+    internal static string ResolveDisplayHost(string bindAddress)
+    {
+        if (string.IsNullOrWhiteSpace(bindAddress))
+            return "localhost";
+
+        if (GatewaySecurity.IsLoopbackBind(bindAddress))
+            return "localhost";
+
+        return bindAddress switch
+        {
+            "0.0.0.0" or "*" or "+" or "::" or "[::]" => "localhost",
+            _ => FormatHostForUri(bindAddress)
+        };
+    }
+
+    internal static string FormatHostForUri(string bindAddress)
+    {
+        if (string.IsNullOrWhiteSpace(bindAddress))
+            return "localhost";
+
+        if (bindAddress.StartsWith('['))
+            return bindAddress;
+
+        if (bindAddress.Contains(':'))
+            return $"[{bindAddress}]";
+
+        return bindAddress;
+    }
+}

--- a/src/OpenClaw.Gateway/Program.cs
+++ b/src/OpenClaw.Gateway/Program.cs
@@ -14,51 +14,90 @@ using OpenClaw.MicrosoftAgentFrameworkAdapter;
 using OpenClawNet.Sandbox.OpenSandbox;
 #endif
 
-var builder = WebApplication.CreateSlimBuilder(args);
+var environmentName = Environments.Production;
+var isDoctorMode = args.Any(a => string.Equals(a, "--doctor", StringComparison.Ordinal));
+var isHealthCheckMode = args.Any(a => string.Equals(a, "--health-check", StringComparison.Ordinal));
+var currentDirectory = Directory.GetCurrentDirectory();
+var recoveryAttempted = false;
 
-var bootstrap = await builder.AddOpenClawBootstrapAsync(args);
-if (bootstrap.ShouldExit)
+while (true)
 {
-    Environment.ExitCode = bootstrap.ExitCode;
-    return;
-}
+    GatewayStartupContext? startup = null;
+    var started = false;
 
-var startup = bootstrap.Startup
-    ?? throw new InvalidOperationException("Bootstrap completed without a startup context.");
+    try
+    {
+        var builder = WebApplication.CreateSlimBuilder(args);
+        environmentName = builder.Environment.EnvironmentName;
 
-builder.Services.AddOpenApi("openclaw-integration");
-builder.AddOpenClawObservability();
-builder.Services.AddOpenClawCoreServices(startup);
-builder.Services.AddOpenClawChannelServices(startup);
-builder.Services.AddOpenClawToolServices(startup);
-builder.Services.AddOpenClawBackendServices(startup);
-builder.Services.AddOpenClawSecurityServices(startup);
-builder.Services.AddOpenClawMcpServices(startup);
-builder.Services.ApplyOpenClawRuntimeProfile(startup);
+        var bootstrap = await builder.AddOpenClawBootstrapAsync(args);
+        if (bootstrap.ShouldExit)
+        {
+            Environment.ExitCode = bootstrap.ExitCode;
+            return;
+        }
+
+        startup = bootstrap.Startup
+            ?? throw new InvalidOperationException("Bootstrap completed without a startup context.");
+
+        builder.Services.AddOpenApi("openclaw-integration");
+        builder.AddOpenClawObservability();
+        builder.Services.AddOpenClawCoreServices(startup);
+        builder.Services.AddOpenClawChannelServices(startup);
+        builder.Services.AddOpenClawToolServices(startup);
+        builder.Services.AddOpenClawBackendServices(startup);
+        builder.Services.AddOpenClawSecurityServices(startup);
+        builder.Services.AddOpenClawMcpServices(startup);
+        builder.Services.ApplyOpenClawRuntimeProfile(startup);
 #if OPENCLAW_ENABLE_MAF_EXPERIMENT
-builder.Services.AddMicrosoftAgentFrameworkExperiment(builder.Configuration);
-builder.Services.AddOpenClawA2AServices();
+        builder.Services.AddMicrosoftAgentFrameworkExperiment(builder.Configuration);
+        builder.Services.AddOpenClawA2AServices();
 #endif
 #if OPENCLAW_ENABLE_OPENSANDBOX
-builder.Services.AddOpenSandboxIntegration(builder.Configuration);
+        builder.Services.AddOpenSandboxIntegration(builder.Configuration);
 #endif
 
-var app = builder.Build();
-app.UseTickerQ();
-var runtime = await app.InitializeOpenClawRuntimeAsync(startup);
+        var app = builder.Build();
+        app.Lifetime.ApplicationStarted.Register(() => started = true);
+        app.UseTickerQ();
+        var runtime = await app.InitializeOpenClawRuntimeAsync(startup);
 
-app.InitializeMcpRuntime(runtime);
-app.UseOpenClawMcpAuth(startup, runtime);
+        app.InitializeMcpRuntime(runtime);
+        app.UseOpenClawMcpAuth(startup, runtime);
 #if OPENCLAW_ENABLE_MAF_EXPERIMENT
-app.UseOpenClawA2AAuth(startup, runtime);
+        app.UseOpenClawA2AAuth(startup, runtime);
 #endif
 
-app.UseOpenClawPipeline(startup, runtime);
-app.MapOpenApi("/openapi/{documentName}.json");
-app.MapOpenClawEndpoints(startup, runtime);
-app.MapMcp("/mcp");
+        app.UseOpenClawPipeline(startup, runtime);
+        app.MapOpenApi("/openapi/{documentName}.json");
+        app.MapOpenClawEndpoints(startup, runtime);
+        app.MapMcp("/mcp");
 #if OPENCLAW_ENABLE_MAF_EXPERIMENT
-app.MapOpenClawA2AEndpoints(startup, runtime);
+        app.MapOpenClawA2AEndpoints(startup, runtime);
 #endif
 
-app.Run($"http://{startup.Config.BindAddress}:{startup.Config.Port}");
+        app.Run($"http://{startup.Config.BindAddress}:{startup.Config.Port}");
+        return;
+    }
+    catch (Exception ex) when (!started)
+    {
+        var recovery = InteractiveStartupRecovery.TryRecover(
+            ex,
+            startup,
+            environmentName,
+            currentDirectory,
+            canPrompt: !recoveryAttempted && !isDoctorMode && !isHealthCheckMode);
+
+        if (recovery == StartupRecoveryResult.Recovered)
+        {
+            recoveryAttempted = true;
+            continue;
+        }
+
+        if (recovery == StartupRecoveryResult.NotHandled)
+            StartupFailureReporter.Write(ex, startup, environmentName, isDoctorMode);
+
+        Environment.ExitCode = 1;
+        return;
+    }
+}

--- a/src/OpenClaw.Gateway/Program.cs
+++ b/src/OpenClaw.Gateway/Program.cs
@@ -57,7 +57,7 @@ while (true)
         builder.Services.AddOpenSandboxIntegration(builder.Configuration);
 #endif
 
-        var app = builder.Build();
+        await using var app = builder.Build();
         app.Lifetime.ApplicationStarted.Register(() => started = true);
         app.UseTickerQ();
         var runtime = await app.InitializeOpenClawRuntimeAsync(startup);
@@ -76,7 +76,7 @@ while (true)
         app.MapOpenClawA2AEndpoints(startup, runtime);
 #endif
 
-        app.Run($"http://{startup.Config.BindAddress}:{startup.Config.Port}");
+        await app.RunAsync($"http://{startup.Config.BindAddress}:{startup.Config.Port}");
         return;
     }
     catch (Exception ex) when (!started)

--- a/src/OpenClaw.Tests/InteractiveStartupRecoveryTests.cs
+++ b/src/OpenClaw.Tests/InteractiveStartupRecoveryTests.cs
@@ -1,0 +1,127 @@
+using OpenClaw.Core.Models;
+using OpenClaw.Gateway.Bootstrap;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class InteractiveStartupRecoveryTests
+{
+    [Fact]
+    public void TryRecover_MissingAuthToken_AppliesLocalSessionOverrides()
+    {
+        var startup = CreateStartupContext(config =>
+        {
+            config.BindAddress = "0.0.0.0";
+            config.Port = 18789;
+            config.Llm.Provider = "openai";
+            config.Llm.Model = "gpt-4o";
+        });
+
+        var root = Path.Combine(Path.GetTempPath(), "openclaw-recovery-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var previousModelProviderKey = Environment.GetEnvironmentVariable("MODEL_PROVIDER_KEY");
+        var previousEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        var previousWorkspace = Environment.GetEnvironmentVariable("OPENCLAW_WORKSPACE");
+        var previousBind = Environment.GetEnvironmentVariable("OpenClaw__BindAddress");
+        var previousPort = Environment.GetEnvironmentVariable("OpenClaw__Port");
+        var previousMemoryProvider = Environment.GetEnvironmentVariable("OpenClaw__Memory__Provider");
+        var previousMemoryPath = Environment.GetEnvironmentVariable("OpenClaw__Memory__StoragePath");
+        var previousRetention = Environment.GetEnvironmentVariable("OpenClaw__Memory__Retention__Enabled");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("MODEL_PROVIDER_KEY", "test-key");
+            var input = new StringReader("y\n\n\n\n");
+            using var output = new StringWriter();
+
+            var result = InteractiveStartupRecovery.TryRecover(
+                new InvalidOperationException("OPENCLAW_AUTH_TOKEN must be set when binding to a non-loopback address."),
+                startup,
+                environmentName: "Production",
+                currentDirectory: root,
+                canPrompt: true,
+                input: input,
+                output: output);
+
+            Assert.Equal(StartupRecoveryResult.Recovered, result);
+            Assert.Equal("Development", Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
+            Assert.Equal("127.0.0.1", Environment.GetEnvironmentVariable("OpenClaw__BindAddress"));
+            Assert.Equal("18789", Environment.GetEnvironmentVariable("OpenClaw__Port"));
+            Assert.Equal("file", Environment.GetEnvironmentVariable("OpenClaw__Memory__Provider"));
+            Assert.Equal(Path.Combine(root, "memory"), Environment.GetEnvironmentVariable("OpenClaw__Memory__StoragePath"));
+            Assert.Equal("false", Environment.GetEnvironmentVariable("OpenClaw__Memory__Retention__Enabled"));
+            Assert.Equal(root, Environment.GetEnvironmentVariable("OPENCLAW_WORKSPACE"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MODEL_PROVIDER_KEY", previousModelProviderKey);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousEnvironment);
+            Environment.SetEnvironmentVariable("OPENCLAW_WORKSPACE", previousWorkspace);
+            Environment.SetEnvironmentVariable("OpenClaw__BindAddress", previousBind);
+            Environment.SetEnvironmentVariable("OpenClaw__Port", previousPort);
+            Environment.SetEnvironmentVariable("OpenClaw__Memory__Provider", previousMemoryProvider);
+            Environment.SetEnvironmentVariable("OpenClaw__Memory__StoragePath", previousMemoryPath);
+            Environment.SetEnvironmentVariable("OpenClaw__Memory__Retention__Enabled", previousRetention);
+        }
+    }
+
+    [Fact]
+    public void TryRecover_MissingProviderKey_UsesOpenAiApiKeyFromEnvironment()
+    {
+        var startup = CreateStartupContext(config =>
+        {
+            config.Llm.Provider = "openai";
+            config.Llm.Model = "gpt-4o";
+        });
+
+        var root = Path.Combine(Path.GetTempPath(), "openclaw-recovery-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var previousModelProviderKey = Environment.GetEnvironmentVariable("MODEL_PROVIDER_KEY");
+        var previousOpenAiApiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("MODEL_PROVIDER_KEY", null);
+            Environment.SetEnvironmentVariable("OPENAI_API_KEY", "sk-test-from-openai-env");
+            var input = new StringReader("y\n\n\n\n");
+            using var output = new StringWriter();
+
+            var result = InteractiveStartupRecovery.TryRecover(
+                new InvalidOperationException(
+                    "Configured provider 'openai' is not available. Built-in provider initialization failed: MODEL_PROVIDER_KEY must be set for the OpenAI provider.. Register it as the built-in provider or via a compatible plugin."),
+                startup,
+                environmentName: "Development",
+                currentDirectory: root,
+                canPrompt: true,
+                input: input,
+                output: output);
+
+            Assert.Equal(StartupRecoveryResult.Recovered, result);
+            Assert.Equal("sk-test-from-openai-env", Environment.GetEnvironmentVariable("MODEL_PROVIDER_KEY"));
+            Assert.Contains("Using OPENAI_API_KEY from the current environment", output.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MODEL_PROVIDER_KEY", previousModelProviderKey);
+            Environment.SetEnvironmentVariable("OPENAI_API_KEY", previousOpenAiApiKey);
+        }
+    }
+
+    private static GatewayStartupContext CreateStartupContext(Action<GatewayConfig>? configure = null)
+    {
+        var config = new GatewayConfig();
+        configure?.Invoke(config);
+        return new GatewayStartupContext
+        {
+            Config = config,
+            RuntimeState = new GatewayRuntimeState
+            {
+                RequestedMode = "auto",
+                EffectiveMode = GatewayRuntimeMode.Aot,
+                DynamicCodeSupported = false
+            },
+            IsNonLoopbackBind = !OpenClaw.Core.Security.BindAddressClassifier.IsLoopbackBind(config.BindAddress),
+            WorkspacePath = null
+        };
+    }
+}

--- a/src/OpenClaw.Tests/InteractiveStartupRecoveryTests.cs
+++ b/src/OpenClaw.Tests/InteractiveStartupRecoveryTests.cs
@@ -62,6 +62,7 @@ public sealed class InteractiveStartupRecoveryTests
             Environment.SetEnvironmentVariable("OpenClaw__Memory__Provider", previousMemoryProvider);
             Environment.SetEnvironmentVariable("OpenClaw__Memory__StoragePath", previousMemoryPath);
             Environment.SetEnvironmentVariable("OpenClaw__Memory__Retention__Enabled", previousRetention);
+            DeleteDirectoryBestEffort(root);
         }
     }
 
@@ -104,6 +105,21 @@ public sealed class InteractiveStartupRecoveryTests
         {
             Environment.SetEnvironmentVariable("MODEL_PROVIDER_KEY", previousModelProviderKey);
             Environment.SetEnvironmentVariable("OPENAI_API_KEY", previousOpenAiApiKey);
+            DeleteDirectoryBestEffort(root);
+        }
+    }
+
+    private static void DeleteDirectoryBestEffort(string path)
+    {
+        if (!Directory.Exists(path))
+            return;
+
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
         }
     }
 

--- a/src/OpenClaw.Tests/StartupFailureReporterTests.cs
+++ b/src/OpenClaw.Tests/StartupFailureReporterTests.cs
@@ -1,0 +1,97 @@
+using OpenClaw.Core.Models;
+using OpenClaw.Gateway.Bootstrap;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class StartupFailureReporterTests
+{
+    [Fact]
+    public void Render_MissingAuthToken_ShowsHelpfulBindGuidance()
+    {
+        var text = StartupFailureReporter.Render(
+            new InvalidOperationException("OPENCLAW_AUTH_TOKEN must be set when binding to a non-loopback address."),
+            startup: null,
+            environmentName: "Production",
+            isDoctorMode: false);
+
+        Assert.Contains("Startup failed: authentication is required for a non-loopback bind.", text, StringComparison.Ordinal);
+        Assert.Contains("Current ASPNETCORE_ENVIRONMENT: Production", text, StringComparison.Ordinal);
+        Assert.Contains("OpenClaw__BindAddress to 127.0.0.1", text, StringComparison.Ordinal);
+        Assert.Contains("ASPNETCORE_ENVIRONMENT to Development", text, StringComparison.Ordinal);
+        Assert.Contains("OPENCLAW_AUTH_TOKEN", text, StringComparison.Ordinal);
+        Assert.Contains("--doctor", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_ReadOnlyStorage_ShowsWritablePathGuidance()
+    {
+        var startup = CreateStartupContext(config =>
+        {
+            config.Memory.Provider = "sqlite";
+            config.Memory.StoragePath = "/app/memory";
+            config.Memory.Sqlite.DbPath = "/app/memory/openclaw.db";
+            config.Memory.Retention.Enabled = true;
+            config.Memory.Retention.ArchivePath = "/app/memory/archive";
+        });
+
+        var text = StartupFailureReporter.Render(
+            new InvalidOperationException(
+                "Memory.StoragePath '/app/memory' is not writable. Failed to create '/app/memory/admin/keys'.",
+                new IOException("Read-only file system : '/app'")),
+            startup,
+            environmentName: "Production",
+            isDoctorMode: false);
+
+        Assert.Contains("Startup failed: the configured memory storage path is not writable.", text, StringComparison.Ordinal);
+        Assert.Contains("Memory.StoragePath: /app/memory", text, StringComparison.Ordinal);
+        Assert.Contains("Memory.Sqlite.DbPath: /app/memory/openclaw.db", text, StringComparison.Ordinal);
+        Assert.Contains("Memory.Retention.ArchivePath: /app/memory/archive", text, StringComparison.Ordinal);
+        Assert.Contains("OpenClaw__Memory__StoragePath", text, StringComparison.Ordinal);
+        Assert.Contains("OpenClaw__Memory__Sqlite__DbPath", text, StringComparison.Ordinal);
+        Assert.Contains("OpenClaw__Memory__Retention__ArchivePath", text, StringComparison.Ordinal);
+        Assert.Contains("ASPNETCORE_ENVIRONMENT to Development", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_MissingProviderKey_ShowsModelProviderGuidance()
+    {
+        var startup = CreateStartupContext(config =>
+        {
+            config.Llm.Provider = "openai";
+            config.Llm.Model = "gpt-4o";
+        });
+
+        var text = StartupFailureReporter.Render(
+            new InvalidOperationException(
+                "Configured provider 'openai' is not available. Built-in provider initialization failed: MODEL_PROVIDER_KEY must be set for the OpenAI provider.. Register it as the built-in provider or via a compatible plugin."),
+            startup,
+            environmentName: "Development",
+            isDoctorMode: false);
+
+        Assert.Contains("Startup failed: OpenAI provider credentials are missing.", text, StringComparison.Ordinal);
+        Assert.Contains("Provider: openai", text, StringComparison.Ordinal);
+        Assert.Contains("Model: gpt-4o", text, StringComparison.Ordinal);
+        Assert.Contains("MODEL_PROVIDER_KEY", text, StringComparison.Ordinal);
+        Assert.Contains("OPENAI_API_KEY", text, StringComparison.Ordinal);
+        Assert.Contains("--doctor", text, StringComparison.Ordinal);
+    }
+
+    private static GatewayStartupContext CreateStartupContext(Action<GatewayConfig>? configure = null)
+    {
+        var config = new GatewayConfig();
+        configure?.Invoke(config);
+        return new GatewayStartupContext
+        {
+            Config = config,
+            RuntimeState = new GatewayRuntimeState
+            {
+                RequestedMode = "auto",
+                EffectiveMode = GatewayRuntimeMode.Aot,
+                DynamicCodeSupported = false
+            },
+            IsNonLoopbackBind = !OpenClaw.Core.Security.BindAddressClassifier.IsLoopbackBind(config.BindAddress),
+            WorkspacePath = null
+        };
+    }
+}

--- a/src/OpenClaw.Tests/StartupReadyReporterTests.cs
+++ b/src/OpenClaw.Tests/StartupReadyReporterTests.cs
@@ -1,0 +1,66 @@
+using OpenClaw.Core.Models;
+using OpenClaw.Gateway.Bootstrap;
+using OpenClaw.Gateway.Pipeline;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class StartupReadyReporterTests
+{
+    [Fact]
+    public void Render_LoopbackBind_UsesLocalhostUrls()
+    {
+        var startup = CreateStartupContext(config => config.BindAddress = "127.0.0.1");
+
+        var text = StartupReadyReporter.Render(startup);
+
+        Assert.Contains("OpenClaw gateway ready.", text, StringComparison.Ordinal);
+        Assert.Contains("Listening on http://127.0.0.1:18789", text, StringComparison.Ordinal);
+        Assert.Contains("Chat UI: http://localhost:18789/chat", text, StringComparison.Ordinal);
+        Assert.Contains("Admin UI: http://localhost:18789/admin", text, StringComparison.Ordinal);
+        Assert.Contains("Doctor: http://localhost:18789/doctor/text", text, StringComparison.Ordinal);
+        Assert.Contains("WebSocket: ws://localhost:18789/ws", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_WildcardBind_UsesLocalhostUrls()
+    {
+        var startup = CreateStartupContext(config => config.BindAddress = "0.0.0.0");
+
+        var text = StartupReadyReporter.Render(startup);
+
+        Assert.Contains("Listening on http://0.0.0.0:18789", text, StringComparison.Ordinal);
+        Assert.Contains("Chat UI: http://localhost:18789/chat", text, StringComparison.Ordinal);
+        Assert.Contains("MCP: http://localhost:18789/mcp", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_ExplicitLanBind_UsesBoundAddressUrls()
+    {
+        var startup = CreateStartupContext(config => config.BindAddress = "192.168.1.25");
+
+        var text = StartupReadyReporter.Render(startup);
+
+        Assert.Contains("Listening on http://192.168.1.25:18789", text, StringComparison.Ordinal);
+        Assert.Contains("Chat UI: http://192.168.1.25:18789/chat", text, StringComparison.Ordinal);
+        Assert.Contains("Health: http://192.168.1.25:18789/health", text, StringComparison.Ordinal);
+    }
+
+    private static GatewayStartupContext CreateStartupContext(Action<GatewayConfig>? configure = null)
+    {
+        var config = new GatewayConfig();
+        configure?.Invoke(config);
+        return new GatewayStartupContext
+        {
+            Config = config,
+            RuntimeState = new GatewayRuntimeState
+            {
+                RequestedMode = "auto",
+                EffectiveMode = GatewayRuntimeMode.Aot,
+                DynamicCodeSupported = false
+            },
+            IsNonLoopbackBind = !OpenClaw.Core.Security.BindAddressClassifier.IsLoopbackBind(config.BindAddress),
+            WorkspacePath = null
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- replace raw pre-start crashes with targeted startup failure guidance for missing auth, provider config, and writable storage issues
- print a clear terminal readiness message with localhost URLs after the gateway is actually listening
- offer a minimal interactive local recovery flow for terminal launches so missing config can be filled in and retried in-process

## Why
Local startup looked failed even when the gateway was healthy because warnings could appear without an obvious success message. When startup did fail, the process exited with stack traces and config details that were actionable only if the operator already knew the expected environment layering.

## Impact
Developers running `dotnet run` locally get guided recovery and an explicit ready state. Headless, doctor, and health-check executions still fail fast instead of blocking on prompts.

## Root Cause
Startup validation and runtime initialization exceptions were bubbling directly out of `Program.cs`, and the old readiness banner depended on info logging instead of a terminal-visible post-start signal.

## Validation
- `dotnet test /Users/telli/Desktop/openclaw.net/src/OpenClaw.Tests/OpenClaw.Tests.csproj --filter "InteractiveStartupRecoveryTests|StartupReadyReporterTests|StartupFailureReporterTests"`
- manual `dotnet run` verification for auth-missing, storage-path, provider-key, readiness-banner, and interactive-recovery flows