### PR TITLE
[codex] Improve local startup UX and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dotnet run --project src/OpenClaw.Cli -c Release -- setup
 dotnet run --project src/OpenClaw.Cli -c Release -- setup launch --config ~/.openclaw/config/openclaw.settings.json
 ```
 
-When the gateway prints its `Gateway ready` banner, open:
+When the gateway finishes startup it now prints explicit phase markers, a final `OpenClaw gateway ready.` block, the localhost URLs, `Ctrl-C to stop`, and any non-fatal startup notices under `Started with notices:`. Then open:
 
 | Surface | URL |
 |---------|-----|
@@ -44,6 +44,14 @@ When the gateway prints its `Gateway ready` banner, open:
 | MCP endpoint | `http://127.0.0.1:18789/mcp` |
 
 The root URL redirects to `/chat`. For the full first-run walkthrough (including the "First 10 Minutes" runbook and debugging flow), see [docs/QUICKSTART.md](docs/QUICKSTART.md). For the project shape and repository map before changing code, see [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
+
+If you want a direct gateway fallback instead of the full CLI onboarding flow, run:
+
+```bash
+dotnet run --project src/OpenClaw.Gateway -c Release -- --quickstart
+```
+
+`--quickstart` is interactive-only. It applies a minimal loopback-local profile for the current process, prompts for missing provider inputs, retries on the common first-run failures, and after a successful start can save the working setup to `~/.openclaw/config/openclaw.settings.json`.
 
 If the CLI is already on your `PATH`, the same guided entrypoints are:
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -217,6 +217,7 @@ What `setup` gives you:
 - an adjacent env example
 - the exact commands to launch the gateway
 - follow-up diagnostics commands such as `--doctor` and `openclaw admin posture`
+- a launch path that avoids the common local startup failures caused by raw production defaults
 
 Why this matters:
 
@@ -231,6 +232,14 @@ dotnet run --project src/OpenClaw.Cli -c Release -- setup launch --config ~/.ope
 ```
 
 `setup launch` is the easiest place to start because it boots the gateway, starts Companion, waits for readiness, and streams logs until you stop it.
+
+If you are starting `OpenClaw.Gateway` directly from a repo checkout and do not want to run `setup` first, the direct local fallback is:
+
+```bash
+dotnet run --project src/OpenClaw.Gateway -c Release -- --quickstart
+```
+
+That mode is interactive-only. It applies a loopback-local profile for the current process, prompts for missing provider inputs, retries on the common local startup failures, and can save the resulting config to `~/.openclaw/config/openclaw.settings.json` after the gateway is ready.
 
 ## What To Open After Startup
 
@@ -279,6 +288,16 @@ If you prefer direct server startup instead of the launch helper, use the comman
 dotnet run --project src/OpenClaw.Gateway -c Release -- --config ~/.openclaw/config/openclaw.settings.json
 ```
 
+The direct gateway path now prints startup phases and a clear ready block:
+
+- `Loading configuration`
+- `Building services`
+- `Initializing runtime`
+- `Starting listener`
+- `Ready`
+
+Then it prints `OpenClaw gateway ready.`, the working `/chat`, `/admin`, `/doctor/text`, `/health`, `/mcp`, and `/ws` URLs, `Ctrl-C to stop`, and a `Started with notices:` section for non-fatal startup advisories.
+
 ## Typical Setup Questions Answered
 
 ### Where does configuration live?
@@ -295,6 +314,23 @@ Use:
 - `http://127.0.0.1:18789/admin` for the admin UI
 
 The root URL (`/`) currently redirects to `/chat`, but `/chat` is still the canonical browser UI route.
+
+### What if the gateway fails before it starts listening?
+
+In an interactive local terminal, the gateway now classifies the common startup failures and offers a guided recovery path instead of exiting with a raw unhandled exception. This currently covers:
+
+- missing `OPENCLAW_AUTH_TOKEN` on a non-loopback bind
+- missing `MODEL_PROVIDER_KEY` or `MODEL_PROVIDER_ENDPOINT`
+- unwritable memory storage
+- port already in use
+
+For the shortest direct recovery path, rerun with:
+
+```bash
+dotnet run --project src/OpenClaw.Gateway -c Release -- --quickstart
+```
+
+Headless, redirected, `--doctor`, and `--health-check` runs still stay non-interactive and fail fast with actionable text.
 
 ### Do I need sandboxing to get started locally?
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -25,7 +25,7 @@ Accept the defaults. This writes `~/.openclaw/config/openclaw.settings.json`.
 dotnet run --project src/OpenClaw.Cli -c Release -- setup launch --config ~/.openclaw/config/openclaw.settings.json
 ```
 
-**Expected:** a log banner that ends with a "Gateway ready" block listing the working URLs. If you don't see that banner, the gateway is not ready — do not open a browser yet.
+**Expected:** startup phase lines (`Loading configuration`, `Building services`, `Initializing runtime`, `Starting listener`) followed by an `OpenClaw gateway ready.` block listing the working URLs. If you see `Started with notices:`, the gateway is still up; those are non-fatal startup advisories. If you do not see the ready block, the gateway is not ready yet.
 
 **4. Open the browser UI.**
 
@@ -38,6 +38,14 @@ dotnet run --project src/OpenClaw.Gateway -c Release -- --config ~/.openclaw/con
 ```
 
 That's the whole first run. Skip everything below until this works.
+
+If you intentionally skip the CLI flow and start the gateway process directly, use:
+
+```bash
+dotnet run --project src/OpenClaw.Gateway -c Release -- --quickstart
+```
+
+`--quickstart` is the direct terminal fallback. It keeps the gateway on `127.0.0.1`, prompts for missing provider values, retries in-process on the common local startup failures, and after a successful start can save the resulting config to the standard `~/.openclaw/config/openclaw.settings.json`.
 
 You explicitly do **not** need any of these to get started:
 
@@ -63,6 +71,7 @@ For a first run from source, prefer the generated external config from `openclaw
 | Command | Use when |
 | --- | --- |
 | `openclaw setup` | You want the guided onboarding flow that writes config, prints launch commands, and gives you `--doctor` plus `admin posture` follow-ups. |
+| `dotnet run --project src/OpenClaw.Gateway -c Release -- --quickstart` | You want to start the gateway directly from a repo checkout and let the gateway recover into a safe local profile instead of preparing config first. |
 | `openclaw init` | You want raw bootstrap files to edit manually before running the gateway. |
 | Direct config editing | You already know the runtime shape you want and do not need the guided path. |
 
@@ -90,6 +99,8 @@ If you prefer to run the gateway process directly, use the printed command, for 
 dotnet run --project src/OpenClaw.Gateway -c Release -- --config ~/.openclaw/config/openclaw.settings.json
 ```
 
+If that direct launch fails before the listener comes up and you are in an interactive terminal, the gateway now prints actionable guidance and offers a minimal local recovery flow instead of dropping straight to an unhandled exception. For the shortest direct path, prefer `--quickstart`.
+
 4. Run the printed verification commands after the gateway is up:
 
 ```bash
@@ -113,6 +124,7 @@ Important:
 
 - the browser chat UI is `/chat`, not the root URL
 - the admin UI is `http://127.0.0.1:18789/admin`
+- the ready banner also prints `Ctrl-C to stop`, startup notices, and follow-up commands
 
 ## Public / Reverse Proxy Start
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -28,6 +28,14 @@ openclaw setup service --config ~/.openclaw/config/openclaw.settings.json --plat
 openclaw setup status --config ~/.openclaw/config/openclaw.settings.json
 ```
 
+If you start the gateway directly from a local terminal instead of using `setup launch`, the direct fallback is:
+
+```bash
+dotnet run --project src/OpenClaw.Gateway -c Release -- --quickstart
+```
+
+That flow is interactive-only. It applies a minimal local loopback profile, prompts for missing provider inputs, retries on the common startup failures, and after a successful start can save the working config to `~/.openclaw/config/openclaw.settings.json`.
+
 If you want raw starter files instead of the guided flow, use `openclaw init`. For the supported upstream skill, plugin, and channel compatibility surface, treat the [Compatibility Guide](COMPATIBILITY.md) as the source of truth.
 
 After the base config exists, use the channel-specific setup wizard for the common chat integrations:
@@ -46,6 +54,7 @@ Important distinction:
 
 - `openclaw setup` and `openclaw init` generate the supported onboarding configs
 - directly editing `src/OpenClaw.Gateway/appsettings.json` is a lower-level path and can expose optional features that are not part of the easiest first run
+- direct gateway startup now prints explicit startup phases and a ready banner with `/chat`, `/admin`, `/doctor/text`, `/health`, `/mcp`, and `/ws`
 
 ## Operator Auth Model
 

--- a/docs/architecture-startup-refactor.md
+++ b/docs/architecture-startup-refactor.md
@@ -10,6 +10,7 @@ The gateway startup path is now split into three layers:
    - Applies environment overrides and explicit secret resolution.
    - Resolves `GatewayRuntimeState`.
    - Handles early exits for `--health-check` and `--doctor`.
+   - Handles interactive `--quickstart` and pre-listener startup recovery for local terminal launches.
    - Enforces non-loopback auth-token requirements and public-bind hardening.
 
 2. `Composition/` and `Profiles/`
@@ -26,6 +27,7 @@ The gateway startup path is now split into three layers:
 
 3. `Pipeline/` and `Endpoints/`
    - Applies forwarded headers, CORS, WebSockets, worker startup, channel startup, and shutdown handling.
+   - Prints the terminal-ready startup banner, startup notices, and post-ready local save/browser prompts.
    - Maps all HTTP/WebSocket routes outside `Program.cs`.
 
 ## AOT vs JIT
@@ -41,7 +43,7 @@ The gateway profile layer does not replace plugin/runtime capability enforcement
 ## Where Things Moved
 
 - `Program.cs`
-  - now only orchestrates bootstrap, service registration, runtime initialization, pipeline mapping, endpoint mapping, and `Run(...)`
+  - now orchestrates bootstrap, quickstart/recovery selection, service registration, runtime initialization, pipeline mapping, endpoint mapping, and `Run(...)`
 - `Bootstrap/GatewayBootstrapExtensions.cs`
   - config loading, validation, runtime-state resolution, and early exits
 - `Composition/*`

--- a/src/OpenClaw.Cli/BootstrapConfigFactory.cs
+++ b/src/OpenClaw.Cli/BootstrapConfigFactory.cs
@@ -1,4 +1,5 @@
 using OpenClaw.Core.Models;
+using CoreGatewaySetupProfileFactory = OpenClaw.Core.Setup.GatewaySetupProfileFactory;
 
 namespace OpenClaw.Cli;
 
@@ -16,61 +17,18 @@ internal static class BootstrapConfigFactory
         string apiKey,
         List<string>? warnings = null)
     {
-        var normalizedProfile = NormalizeProfile(profile);
-        var config = new GatewayConfig
-        {
-            BindAddress = bindAddress,
-            Port = port,
-            AuthToken = authToken,
-            Llm = new LlmProviderConfig
-            {
-                Provider = provider,
-                Model = model,
-                ApiKey = apiKey
-            },
-            Memory = new MemoryConfig
-            {
-                Provider = "file",
-                StoragePath = memoryPath,
-                Retention = new MemoryRetentionConfig
-                {
-                    ArchivePath = Path.Combine(memoryPath, "archive")
-                }
-            },
-            Tooling = new ToolingConfig
-            {
-                WorkspaceRoot = workspacePath,
-                WorkspaceOnly = true,
-                AllowShell = normalizedProfile == "local",
-                AllowedReadRoots = [workspacePath],
-                AllowedWriteRoots = [workspacePath],
-                RequireToolApproval = normalizedProfile == "public"
-            },
-            Security = new SecurityConfig
-            {
-                AllowQueryStringToken = false,
-                TrustForwardedHeaders = normalizedProfile == "public",
-                RequireRequesterMatchForHttpToolApproval = normalizedProfile == "public"
-            }
-        };
-
-        if (normalizedProfile == "public")
-        {
-            config.Plugins.Enabled = false;
-            warnings?.Add("Public profile disables third-party bridge plugins by default. Re-enable them only after you have a proxy, TLS, and explicit public-bind trust settings in place.");
-        }
-
-        if (normalizedProfile == "public" && !apiKey.StartsWith("env:", StringComparison.OrdinalIgnoreCase))
-            warnings?.Add("Public profile is using a direct API key value in the config file. Prefer env:... references or OS-backed secret storage.");
-
-        return config;
+        return CoreGatewaySetupProfileFactory.CreateProfileConfig(
+            profile,
+            bindAddress,
+            port,
+            authToken,
+            workspacePath,
+            memoryPath,
+            provider,
+            model,
+            apiKey,
+            warnings);
     }
 
-    public static string NormalizeProfile(string profile)
-    {
-        var normalized = profile.Trim().ToLowerInvariant();
-        if (normalized is not ("local" or "public"))
-            throw new ArgumentException("Invalid value for --profile (expected: local|public).");
-        return normalized;
-    }
+    public static string NormalizeProfile(string profile) => CoreGatewaySetupProfileFactory.NormalizeProfile(profile);
 }

--- a/src/OpenClaw.Cli/GatewayConfigFile.cs
+++ b/src/OpenClaw.Cli/GatewayConfigFile.cs
@@ -1,60 +1,18 @@
-using System.Text.Json;
-using System.Text.Json.Nodes;
 using OpenClaw.Core.Models;
+using CoreGatewayConfigFile = OpenClaw.Core.Setup.GatewayConfigFile;
+using GatewaySetupPaths = OpenClaw.Core.Setup.GatewaySetupPaths;
 
 namespace OpenClaw.Cli;
 
 internal static class GatewayConfigFile
 {
-    internal const string DefaultConfigPath = "~/.openclaw/config/openclaw.settings.json";
+    internal const string DefaultConfigPath = GatewaySetupPaths.DefaultConfigPath;
 
-    public static string ExpandPath(string path)
-    {
-        if (path.StartsWith("~/", StringComparison.Ordinal) || string.Equals(path, "~", StringComparison.Ordinal))
-        {
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            return path.Length == 1 ? home : Path.Combine(home, path[2..]);
-        }
+    public static string ExpandPath(string path) => GatewaySetupPaths.ExpandPath(path);
 
-        return path;
-    }
+    public static string QuoteIfNeeded(string path) => GatewaySetupPaths.QuoteIfNeeded(path);
 
-    public static string QuoteIfNeeded(string path)
-        => path.Contains(' ', StringComparison.Ordinal) ? $"\"{path}\"" : path;
+    public static GatewayConfig Load(string configPath) => CoreGatewayConfigFile.Load(configPath);
 
-    public static GatewayConfig Load(string configPath)
-    {
-        if (!File.Exists(configPath))
-            throw new FileNotFoundException($"Config file not found: {configPath}");
-
-        using var document = JsonDocument.Parse(File.ReadAllText(configPath));
-        var root = document.RootElement;
-        if (root.TryGetProperty("OpenClaw", out var openClaw))
-        {
-            return JsonSerializer.Deserialize(openClaw.GetRawText(), CoreJsonContext.Default.GatewayConfig)
-                ?? throw new InvalidOperationException($"Could not deserialize OpenClaw config from {configPath}.");
-        }
-
-        return JsonSerializer.Deserialize(root.GetRawText(), CoreJsonContext.Default.GatewayConfig)
-            ?? throw new InvalidOperationException($"Could not deserialize gateway config from {configPath}.");
-    }
-
-    public static async Task SaveAsync(GatewayConfig config, string configPath)
-    {
-        var openClawNode = JsonNode.Parse(JsonSerializer.Serialize(config, CoreJsonContext.Default.GatewayConfig))
-            ?? throw new InvalidOperationException("Failed to serialize gateway config.");
-        var root = new JsonObject
-        {
-            ["OpenClaw"] = openClawNode
-        };
-
-        var directory = Path.GetDirectoryName(configPath);
-        if (!string.IsNullOrWhiteSpace(directory))
-            Directory.CreateDirectory(directory);
-
-        await File.WriteAllTextAsync(
-            configPath,
-            root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }),
-            CancellationToken.None);
-    }
+    public static Task SaveAsync(GatewayConfig config, string configPath) => CoreGatewayConfigFile.SaveAsync(config, configPath);
 }

--- a/src/OpenClaw.Cli/Program.cs
+++ b/src/OpenClaw.Cli/Program.cs
@@ -144,6 +144,11 @@ internal static class Program
               openclaw admin incident export
               openclaw compatibility catalog --status compatible
 
+            Gateway direct-start fallback:
+              dotnet run --project src/OpenClaw.Gateway -c Release -- --quickstart
+              # Uses a minimal local loopback profile, prompts for missing provider inputs,
+              # retries in-process on common startup failures, and can save the working setup.
+
             Plugin management:
               openclaw plugins install <package-name>    Install from npm/ClawHub
               openclaw plugins install ./local-plugin     Install from local path
@@ -275,6 +280,7 @@ internal static class Program
               - Bare 'openclaw setup' launches a guided onboarding flow.
               - 'openclaw setup launch' starts the gateway in the current repo checkout, runs verification, and streams logs until Ctrl-C.
               - Use --with-companion to start Companion too.
+              - If you start the gateway directly and hit local startup friction, use: dotnet run --project src/OpenClaw.Gateway -c Release -- --quickstart
               - 'openclaw setup service' writes systemd/launchd/Caddy deployment artifacts next to the config.
               - 'openclaw setup status' summarizes bind/auth posture and deploy artifact presence.
               - 'openclaw setup verify' runs the first-run verification checks without launching the gateway.

--- a/src/OpenClaw.Cli/SetupCommand.cs
+++ b/src/OpenClaw.Cli/SetupCommand.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Security.Cryptography;
 using OpenClaw.Core.Models;
+using OpenClaw.Core.Setup;
 using OpenClaw.Core.Security;
 using OpenClaw.Core.Validation;
 
@@ -72,10 +73,14 @@ internal static class SetupCommand
 
         await GatewayConfigFile.SaveAsync(config, answers.ConfigPath);
 
-        var envExamplePath = BuildEnvExamplePath(answers.ConfigPath);
+        var envExamplePath = GatewaySetupArtifacts.BuildEnvExamplePath(answers.ConfigPath);
         await File.WriteAllTextAsync(
             envExamplePath,
-            BuildEnvExample(answers, BuildReachableBaseUrl(answers.BindAddress, answers.Port)),
+            GatewaySetupArtifacts.BuildEnvExample(
+                answers.ApiKey,
+                answers.AuthToken,
+                answers.Workspace,
+                BuildReachableBaseUrl(answers.BindAddress, answers.Port)),
             CancellationToken.None);
 
         output.WriteLine($"Wrote config: {answers.ConfigPath}");
@@ -295,49 +300,8 @@ internal static class SetupCommand
         }
     }
 
-    private static string BuildEnvExample(SetupAnswers answers, string baseUrl)
-    {
-        var lines = new List<string>
-        {
-            $"{ResolveProviderEnvVariable(answers.ApiKey)}=replace-me",
-            $"OPENCLAW_AUTH_TOKEN={answers.AuthToken}",
-            $"OPENCLAW_BASE_URL={baseUrl}",
-            $"OPENCLAW_WORKSPACE={answers.Workspace}"
-        };
-
-        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
-    }
-
-    private static string ResolveProviderEnvVariable(string apiKey)
-    {
-        if (apiKey.StartsWith("env:", StringComparison.OrdinalIgnoreCase) && apiKey.Length > 4)
-            return apiKey[4..];
-
-        return "MODEL_PROVIDER_KEY";
-    }
-
-    private static string BuildEnvExamplePath(string configPath)
-    {
-        var directory = Path.GetDirectoryName(configPath)
-            ?? throw new InvalidOperationException("Config path must contain a directory.");
-        var stem = Path.GetFileNameWithoutExtension(configPath);
-        return Path.Combine(directory, $"{stem}.env.example");
-    }
-
     internal static string BuildReachableBaseUrl(string bindAddress, int port)
-    {
-        if (string.Equals(bindAddress, "0.0.0.0", StringComparison.Ordinal) ||
-            string.Equals(bindAddress, "::", StringComparison.Ordinal) ||
-            string.Equals(bindAddress, "[::]", StringComparison.Ordinal))
-        {
-            return $"http://127.0.0.1:{port.ToString(CultureInfo.InvariantCulture)}";
-        }
-
-        if (bindAddress.Contains(':') && !bindAddress.StartsWith("[", StringComparison.Ordinal))
-            return $"http://[{bindAddress}]:{port.ToString(CultureInfo.InvariantCulture)}";
-
-        return $"http://{bindAddress}:{port.ToString(CultureInfo.InvariantCulture)}";
-    }
+        => GatewaySetupArtifacts.BuildReachableBaseUrl(bindAddress, port);
 
     private static string GetDefaultBindAddress(string profile)
         => profile == "public" ? "0.0.0.0" : "127.0.0.1";

--- a/src/OpenClaw.Core/Observability/IStartupNoticeSink.cs
+++ b/src/OpenClaw.Core/Observability/IStartupNoticeSink.cs
@@ -1,0 +1,19 @@
+namespace OpenClaw.Core.Observability;
+
+public interface IStartupNoticeSink
+{
+    void Record(string message);
+}
+
+public sealed class NullStartupNoticeSink : IStartupNoticeSink
+{
+    public static NullStartupNoticeSink Instance { get; } = new();
+
+    private NullStartupNoticeSink()
+    {
+    }
+
+    public void Record(string message)
+    {
+    }
+}

--- a/src/OpenClaw.Core/Pipeline/CronScheduler.cs
+++ b/src/OpenClaw.Core/Pipeline/CronScheduler.cs
@@ -2,6 +2,7 @@ using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using NCrontab;
 using OpenClaw.Core.Models;
+using OpenClaw.Core.Observability;
 using TickerQ.Utilities;
 
 namespace OpenClaw.Core.Pipeline;
@@ -15,13 +16,15 @@ public sealed class CronScheduler
 
     private readonly ICronJobSource _jobSource;
     private readonly ILogger<CronScheduler> _logger;
+    private readonly IStartupNoticeSink _startupNoticeSink;
     private readonly ChannelWriter<InboundMessage> _pipelineChannel;
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, DateTimeOffset> _runningJobs = new(StringComparer.OrdinalIgnoreCase);
 
-    public CronScheduler(ICronJobSource jobSource, ILogger<CronScheduler> logger, ChannelWriter<InboundMessage> pipelineChannel)
+    public CronScheduler(ICronJobSource jobSource, ILogger<CronScheduler> logger, IStartupNoticeSink startupNoticeSink, ChannelWriter<InboundMessage> pipelineChannel)
     {
         _jobSource = jobSource;
         _logger = logger;
+        _startupNoticeSink = startupNoticeSink;
         _pipelineChannel = pipelineChannel;
     }
 
@@ -106,7 +109,7 @@ public sealed class CronScheduler
         {
             if ((now - runningSince) <= MaxRunningDuration)
             {
-                _logger.LogWarning("Skipping cron job '{JobName}' because a previous invocation is still running.", jobName);
+                LogOverlap(jobName);
                 return;
             }
 
@@ -116,7 +119,7 @@ public sealed class CronScheduler
 
         if (!_runningJobs.TryAdd(jobName, now))
         {
-            _logger.LogWarning("Skipping cron job '{JobName}' because a previous invocation is still running.", jobName);
+            LogOverlap(jobName);
             return;
         }
 
@@ -219,5 +222,12 @@ public sealed class CronScheduler
                     nowUtc - kvp.Value);
             }
         }
+    }
+
+    private void LogOverlap(string jobName)
+    {
+        const string Template = "Background job '{JobName}' is still running from an earlier trigger; this tick was skipped.";
+        _logger.LogWarning(Template, jobName);
+        _startupNoticeSink.Record($"Background job '{jobName}' is still running from an earlier trigger; this tick was skipped.");
     }
 }

--- a/src/OpenClaw.Core/Setup/GatewayConfigFile.cs
+++ b/src/OpenClaw.Core/Setup/GatewayConfigFile.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using OpenClaw.Core.Models;
+
+namespace OpenClaw.Core.Setup;
+
+public static class GatewayConfigFile
+{
+    public static GatewayConfig Load(string configPath)
+    {
+        if (!File.Exists(configPath))
+            throw new FileNotFoundException($"Config file not found: {configPath}");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(configPath));
+        var root = document.RootElement;
+        if (root.TryGetProperty("OpenClaw", out var openClaw))
+        {
+            return JsonSerializer.Deserialize(openClaw.GetRawText(), CoreJsonContext.Default.GatewayConfig)
+                ?? throw new InvalidOperationException($"Could not deserialize OpenClaw config from {configPath}.");
+        }
+
+        return JsonSerializer.Deserialize(root.GetRawText(), CoreJsonContext.Default.GatewayConfig)
+            ?? throw new InvalidOperationException($"Could not deserialize gateway config from {configPath}.");
+    }
+
+    public static async Task SaveAsync(GatewayConfig config, string configPath)
+    {
+        var openClawNode = JsonNode.Parse(JsonSerializer.Serialize(config, CoreJsonContext.Default.GatewayConfig))
+            ?? throw new InvalidOperationException("Failed to serialize gateway config.");
+        var root = new JsonObject
+        {
+            ["OpenClaw"] = openClawNode
+        };
+
+        var directory = Path.GetDirectoryName(configPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+            Directory.CreateDirectory(directory);
+
+        await File.WriteAllTextAsync(
+            configPath,
+            root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }),
+            CancellationToken.None);
+    }
+}

--- a/src/OpenClaw.Core/Setup/GatewaySetupArtifacts.cs
+++ b/src/OpenClaw.Core/Setup/GatewaySetupArtifacts.cs
@@ -1,0 +1,50 @@
+using System.Globalization;
+
+namespace OpenClaw.Core.Setup;
+
+public static class GatewaySetupArtifacts
+{
+    public static string BuildEnvExample(string apiKeyRef, string authToken, string workspacePath, string baseUrl)
+    {
+        var lines = new List<string>
+        {
+            $"{ResolveProviderEnvVariable(apiKeyRef)}=replace-me",
+            $"OPENCLAW_AUTH_TOKEN={authToken}",
+            $"OPENCLAW_BASE_URL={baseUrl}",
+            $"OPENCLAW_WORKSPACE={workspacePath}"
+        };
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static string ResolveProviderEnvVariable(string apiKeyRef)
+    {
+        if (apiKeyRef.StartsWith("env:", StringComparison.OrdinalIgnoreCase) && apiKeyRef.Length > 4)
+            return apiKeyRef[4..];
+
+        return "MODEL_PROVIDER_KEY";
+    }
+
+    public static string BuildEnvExamplePath(string configPath)
+    {
+        var directory = Path.GetDirectoryName(configPath)
+            ?? throw new InvalidOperationException("Config path must contain a directory.");
+        var stem = Path.GetFileNameWithoutExtension(configPath);
+        return Path.Combine(directory, $"{stem}.env.example");
+    }
+
+    public static string BuildReachableBaseUrl(string bindAddress, int port)
+    {
+        if (string.Equals(bindAddress, "0.0.0.0", StringComparison.Ordinal) ||
+            string.Equals(bindAddress, "::", StringComparison.Ordinal) ||
+            string.Equals(bindAddress, "[::]", StringComparison.Ordinal))
+        {
+            return $"http://127.0.0.1:{port.ToString(CultureInfo.InvariantCulture)}";
+        }
+
+        if (bindAddress.Contains(':') && !bindAddress.StartsWith("[", StringComparison.Ordinal))
+            return $"http://[{bindAddress}]:{port.ToString(CultureInfo.InvariantCulture)}";
+
+        return $"http://{bindAddress}:{port.ToString(CultureInfo.InvariantCulture)}";
+    }
+}

--- a/src/OpenClaw.Core/Setup/GatewaySetupPaths.cs
+++ b/src/OpenClaw.Core/Setup/GatewaySetupPaths.cs
@@ -1,0 +1,27 @@
+namespace OpenClaw.Core.Setup;
+
+public static class GatewaySetupPaths
+{
+    public const string DefaultConfigPath = "~/.openclaw/config/openclaw.settings.json";
+    public const string DefaultLocalStartupStatePath = "~/.openclaw/state/local-startup.json";
+
+    public static string ExpandPath(string path)
+    {
+        if (path.StartsWith("~/", StringComparison.Ordinal) || string.Equals(path, "~", StringComparison.Ordinal))
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            return path.Length == 1 ? home : Path.Combine(home, path[2..]);
+        }
+
+        return path;
+    }
+
+    public static string QuoteIfNeeded(string path)
+        => path.Contains(' ', StringComparison.Ordinal) ? $"\"{path}\"" : path;
+
+    public static string ResolveDefaultConfigPath()
+        => Path.GetFullPath(ExpandPath(DefaultConfigPath));
+
+    public static string ResolveDefaultLocalStartupStatePath()
+        => Path.GetFullPath(ExpandPath(DefaultLocalStartupStatePath));
+}

--- a/src/OpenClaw.Core/Setup/GatewaySetupProfileFactory.cs
+++ b/src/OpenClaw.Core/Setup/GatewaySetupProfileFactory.cs
@@ -1,0 +1,76 @@
+using OpenClaw.Core.Models;
+
+namespace OpenClaw.Core.Setup;
+
+public static class GatewaySetupProfileFactory
+{
+    public static GatewayConfig CreateProfileConfig(
+        string profile,
+        string bindAddress,
+        int port,
+        string authToken,
+        string workspacePath,
+        string memoryPath,
+        string provider,
+        string model,
+        string apiKey,
+        List<string>? warnings = null)
+    {
+        var normalizedProfile = NormalizeProfile(profile);
+        var config = new GatewayConfig
+        {
+            BindAddress = bindAddress,
+            Port = port,
+            AuthToken = authToken,
+            Llm = new LlmProviderConfig
+            {
+                Provider = provider,
+                Model = model,
+                ApiKey = apiKey
+            },
+            Memory = new MemoryConfig
+            {
+                Provider = "file",
+                StoragePath = memoryPath,
+                Retention = new MemoryRetentionConfig
+                {
+                    ArchivePath = Path.Combine(memoryPath, "archive")
+                }
+            },
+            Tooling = new ToolingConfig
+            {
+                WorkspaceRoot = workspacePath,
+                WorkspaceOnly = true,
+                AllowShell = normalizedProfile == "local",
+                AllowedReadRoots = [workspacePath],
+                AllowedWriteRoots = [workspacePath],
+                RequireToolApproval = normalizedProfile == "public"
+            },
+            Security = new SecurityConfig
+            {
+                AllowQueryStringToken = false,
+                TrustForwardedHeaders = normalizedProfile == "public",
+                RequireRequesterMatchForHttpToolApproval = normalizedProfile == "public"
+            }
+        };
+
+        if (normalizedProfile == "public")
+        {
+            config.Plugins.Enabled = false;
+            warnings?.Add("Public profile disables third-party bridge plugins by default. Re-enable them only after you have a proxy, TLS, and explicit public-bind trust settings in place.");
+        }
+
+        if (normalizedProfile == "public" && !apiKey.StartsWith("env:", StringComparison.OrdinalIgnoreCase))
+            warnings?.Add("Public profile is using a direct API key value in the config file. Prefer env:... references or OS-backed secret storage.");
+
+        return config;
+    }
+
+    public static string NormalizeProfile(string profile)
+    {
+        var normalized = profile.Trim().ToLowerInvariant();
+        if (normalized is not ("local" or "public"))
+            throw new ArgumentException("Invalid value for --profile (expected: local|public).");
+        return normalized;
+    }
+}

--- a/src/OpenClaw.Gateway/Bootstrap/BrowserLauncher.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/BrowserLauncher.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics;
+
+namespace OpenClaw.Gateway.Bootstrap;
+
+internal static class BrowserLauncher
+{
+    public static void TryOpen(string url)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = url,
+                    UseShellExecute = true
+                }
+            };
+            process.Start();
+        }
+        catch
+        {
+        }
+    }
+}

--- a/src/OpenClaw.Gateway/Bootstrap/InteractiveStartupRecovery.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/InteractiveStartupRecovery.cs
@@ -2,13 +2,6 @@ using OpenClaw.Core.Models;
 
 namespace OpenClaw.Gateway.Bootstrap;
 
-internal enum StartupRecoveryResult
-{
-    NotHandled,
-    Recovered,
-    Declined
-}
-
 internal static class InteractiveStartupRecovery
 {
     private const string ModelProviderKeyEnv = "MODEL_PROVIDER_KEY";
@@ -21,46 +14,110 @@ internal static class InteractiveStartupRecovery
     private const string MemoryStoragePathEnv = "OpenClaw__Memory__StoragePath";
     private const string MemoryRetentionEnabledEnv = "OpenClaw__Memory__Retention__Enabled";
 
-    public static StartupRecoveryResult TryRecover(
+    public static StartupRecoveryOutcome TryQuickstart(
+        string currentDirectory,
+        LocalStartupStateStore stateStore,
+        TextReader? input = null,
+        TextWriter? output = null)
+    {
+        if (input is null || output is null)
+        {
+            if (!TerminalPrompts.IsInteractiveConsole())
+                return StartupRecoveryOutcome.NotHandled;
+
+            input = Console.In;
+            output = Console.Out;
+        }
+
+        var remembered = stateStore.Load();
+        var defaults = BuildQuickstartDefaults(currentDirectory, remembered);
+
+        output.WriteLine("Quickstart will apply a minimal local profile for this run.");
+        output.WriteLine($"Provider/model: {defaults.Provider}/{defaults.Model}");
+        output.WriteLine($"Workspace: {defaults.WorkspacePath}");
+        output.WriteLine($"Memory path: {defaults.MemoryPath}");
+        output.WriteLine($"Local bind: 127.0.0.1:{defaults.Port}");
+
+        var apiKey = ResolveApiKey(output, input, defaults.Provider, defaults.ApiKey);
+        var endpoint = ResolveEndpoint(output, input, defaults.Provider, defaults.Endpoint);
+
+        try
+        {
+            Directory.CreateDirectory(defaults.WorkspacePath);
+            Directory.CreateDirectory(defaults.MemoryPath);
+        }
+        catch (Exception createError) when (createError is IOException or UnauthorizedAccessException)
+        {
+            output.WriteLine($"Could not prepare the local workspace or memory path: {createError.Message}");
+            return StartupRecoveryOutcome.Declined;
+        }
+
+        var session = new LocalStartupSession(
+            Mode: "quickstart",
+            WorkspacePath: defaults.WorkspacePath,
+            MemoryPath: defaults.MemoryPath,
+            Port: defaults.Port,
+            Provider: defaults.Provider,
+            Model: defaults.Model,
+            ApiKeyReference: ResolveApiKeyReference(defaults.Provider),
+            Endpoint: endpoint);
+        ApplyLocalOverrides(session, apiKey);
+
+        output.WriteLine();
+        output.WriteLine("Applied quickstart local overrides for this process.");
+        output.WriteLine("The gateway will start on 127.0.0.1 with writable local storage.");
+        return StartupRecoveryOutcome.Recovered(session);
+    }
+
+    public static StartupRecoveryOutcome TryRecover(
         Exception ex,
         GatewayStartupContext? startup,
         string environmentName,
         string currentDirectory,
         bool canPrompt,
+        LocalStartupStateStore stateStore,
+        bool suggestQuickstart,
         TextReader? input = null,
         TextWriter? output = null)
     {
         if (!canPrompt)
-            return StartupRecoveryResult.NotHandled;
+            return StartupRecoveryOutcome.NotHandled;
 
         if (input is null || output is null)
         {
-            if (!IsInteractiveConsole())
-                return StartupRecoveryResult.NotHandled;
+            if (!TerminalPrompts.IsInteractiveConsole())
+                return StartupRecoveryOutcome.NotHandled;
 
             input = Console.In;
             output = Console.Out;
         }
 
         if (!IsRecoverable(ex))
-            return StartupRecoveryResult.NotHandled;
+            return StartupRecoveryOutcome.NotHandled;
 
         output.WriteLine();
-        output.WriteLine(StartupFailureReporter.Render(ex, startup, environmentName, isDoctorMode: false));
+        output.WriteLine(StartupFailureReporter.Render(ex, startup, environmentName, isDoctorMode: false, suggestQuickstart));
         output.WriteLine();
         output.WriteLine("A minimal local setup can apply safe defaults for this run and retry startup.");
-        output.WriteLine("It keeps the gateway on 127.0.0.1, uses file memory under a writable local path, and does not persist anything to your shell.");
-        if (!PromptYesNo(output, input, "Apply minimal local setup now?", defaultValue: true))
-            return StartupRecoveryResult.Declined;
+        output.WriteLine("It keeps the gateway on 127.0.0.1, uses file memory under a writable local path, and does not persist anything until you choose to save it.");
+        if (!TerminalPrompts.PromptYesNo(output, input, "Apply minimal local setup now?", defaultValue: true))
+            return StartupRecoveryOutcome.Declined;
 
-        var defaults = BuildDefaults(ex, startup, currentDirectory);
+        var defaults = BuildRecoveryDefaults(ex, startup, currentDirectory, stateStore.Load());
         output.WriteLine();
         output.WriteLine($"Provider/model: {defaults.Provider}/{defaults.Model}");
         output.WriteLine("Local bind: 127.0.0.1");
 
-        var workspacePath = Prompt(output, input, "Workspace path", defaults.WorkspacePath);
-        var memoryPath = Prompt(output, input, "Memory path", defaults.MemoryPath);
-        var port = PromptPort(output, input, defaults.Port);
+        if (IsPortInUse(ex) &&
+            defaults.Port < 65535 &&
+            TerminalPrompts.PromptYesNo(output, input, $"Port {defaults.Port} is busy. Use {defaults.Port + 1} instead?", defaultValue: true))
+        {
+            defaults = defaults with { Port = defaults.Port + 1 };
+        }
+
+        var workspacePath = TerminalPrompts.Prompt(output, input, "Workspace path", defaults.WorkspacePath);
+        var memoryPath = TerminalPrompts.Prompt(output, input, "Memory path", defaults.MemoryPath);
+        var port = TerminalPrompts.PromptPort(output, input, defaults.Port);
         var apiKey = ResolveApiKey(output, input, defaults.Provider, defaults.ApiKey);
         var endpoint = ResolveEndpoint(output, input, defaults.Provider, defaults.Endpoint);
 
@@ -72,59 +129,104 @@ internal static class InteractiveStartupRecovery
         catch (Exception createError) when (createError is IOException or UnauthorizedAccessException)
         {
             output.WriteLine($"Could not prepare the local workspace or memory path: {createError.Message}");
-            return StartupRecoveryResult.Declined;
+            return StartupRecoveryOutcome.Declined;
         }
 
-        ApplyLocalOverrides(workspacePath, memoryPath, port, apiKey, endpoint);
+        var session = new LocalStartupSession(
+            Mode: "recovery",
+            WorkspacePath: Path.GetFullPath(workspacePath),
+            MemoryPath: Path.GetFullPath(memoryPath),
+            Port: port,
+            Provider: defaults.Provider,
+            Model: defaults.Model,
+            ApiKeyReference: ResolveApiKeyReference(defaults.Provider),
+            Endpoint: endpoint);
+        ApplyLocalOverrides(session, apiKey);
 
         output.WriteLine();
         output.WriteLine("Applied local startup overrides for this process. Retrying gateway startup...");
         output.WriteLine("For a persistent setup later, run: openclaw setup");
-        return StartupRecoveryResult.Recovered;
+        return StartupRecoveryOutcome.Recovered(session);
     }
 
-    private static StartupRecoveryDefaults BuildDefaults(Exception ex, GatewayStartupContext? startup, string currentDirectory)
+    private static StartupRecoveryDefaults BuildQuickstartDefaults(string currentDirectory, LocalStartupState remembered)
+    {
+        var config = new GatewayConfig();
+        var workspacePath = ResolvePreferredPath(remembered.WorkspacePath, currentDirectory);
+        var memoryPath = ResolvePreferredPath(remembered.MemoryPath, Path.Combine(currentDirectory, "memory"));
+        var provider = string.IsNullOrWhiteSpace(remembered.Provider) ? config.Llm.Provider : remembered.Provider;
+        var model = string.IsNullOrWhiteSpace(remembered.Model) ? config.Llm.Model : remembered.Model;
+        var port = remembered.Port is >= 1 and <= 65535 ? remembered.Port.Value : 18789;
+        return new StartupRecoveryDefaults(
+            WorkspacePath: workspacePath,
+            MemoryPath: memoryPath,
+            Port: port,
+            Provider: provider,
+            Model: model,
+            ApiKey: ResolveExistingApiKey(provider),
+            Endpoint: ResolveExistingEndpoint(config));
+    }
+
+    private static StartupRecoveryDefaults BuildRecoveryDefaults(
+        Exception ex,
+        GatewayStartupContext? startup,
+        string currentDirectory,
+        LocalStartupState remembered)
     {
         var config = startup?.Config ?? new GatewayConfig();
-        var port = config.Port > 0 ? config.Port : 18789;
-        if (IsPortInUse(ex))
-            port++;
-
-        var workspacePath = Environment.GetEnvironmentVariable(WorkspaceEnv);
-        if (string.IsNullOrWhiteSpace(workspacePath))
-            workspacePath = startup?.WorkspacePath;
-        if (string.IsNullOrWhiteSpace(workspacePath))
-            workspacePath = currentDirectory;
+        var port = config.Port > 0 ? config.Port : (remembered.Port is >= 1 and <= 65535 ? remembered.Port.Value : 18789);
+        var workspacePath = ResolvePreferredPath(
+            remembered.WorkspacePath,
+            Environment.GetEnvironmentVariable(WorkspaceEnv) ?? startup?.WorkspacePath ?? currentDirectory);
+        var memoryPath = ResolvePreferredPath(remembered.MemoryPath, Path.Combine(currentDirectory, "memory"));
 
         var provider = string.IsNullOrWhiteSpace(config.Llm.Provider) ? new GatewayConfig().Llm.Provider : config.Llm.Provider;
         var model = string.IsNullOrWhiteSpace(config.Llm.Model) ? new GatewayConfig().Llm.Model : config.Llm.Model;
 
-        return new StartupRecoveryDefaults
-        {
-            WorkspacePath = Path.GetFullPath(workspacePath),
-            MemoryPath = Path.Combine(currentDirectory, "memory"),
-            Port = port,
-            Provider = provider,
-            Model = model,
-            ApiKey = ResolveExistingApiKey(provider),
-            Endpoint = ResolveExistingEndpoint(config)
-        };
+        return new StartupRecoveryDefaults(
+            WorkspacePath: workspacePath,
+            MemoryPath: memoryPath,
+            Port: port,
+            Provider: provider,
+            Model: model,
+            ApiKey: ResolveExistingApiKey(provider),
+            Endpoint: ResolveExistingEndpoint(config));
     }
 
-    private static void ApplyLocalOverrides(string workspacePath, string memoryPath, int port, string? apiKey, string? endpoint)
+    private static string ResolvePreferredPath(string? rememberedPath, string fallbackPath)
+    {
+        if (!string.IsNullOrWhiteSpace(rememberedPath))
+            return Path.GetFullPath(rememberedPath);
+
+        return Path.GetFullPath(fallbackPath);
+    }
+
+    private static void ApplyLocalOverrides(LocalStartupSession session, string? apiKey)
     {
         Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", Environments.Development);
-        Environment.SetEnvironmentVariable(WorkspaceEnv, workspacePath);
+        Environment.SetEnvironmentVariable(WorkspaceEnv, session.WorkspacePath);
         Environment.SetEnvironmentVariable(BindAddressEnv, "127.0.0.1");
-        Environment.SetEnvironmentVariable(PortEnv, port.ToString());
+        Environment.SetEnvironmentVariable(PortEnv, session.Port.ToString(System.Globalization.CultureInfo.InvariantCulture));
         Environment.SetEnvironmentVariable(MemoryProviderEnv, "file");
-        Environment.SetEnvironmentVariable(MemoryStoragePathEnv, memoryPath);
+        Environment.SetEnvironmentVariable(MemoryStoragePathEnv, session.MemoryPath);
         Environment.SetEnvironmentVariable(MemoryRetentionEnabledEnv, "false");
 
         if (!string.IsNullOrWhiteSpace(apiKey))
             Environment.SetEnvironmentVariable(ModelProviderKeyEnv, apiKey);
-        if (!string.IsNullOrWhiteSpace(endpoint))
-            Environment.SetEnvironmentVariable(ModelProviderEndpointEnv, endpoint);
+        if (!string.IsNullOrWhiteSpace(session.Endpoint))
+            Environment.SetEnvironmentVariable(ModelProviderEndpointEnv, session.Endpoint);
+    }
+
+    private static string ResolveApiKeyReference(string provider)
+    {
+        if (string.Equals(provider, "openai", StringComparison.OrdinalIgnoreCase) &&
+            string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ModelProviderKeyEnv)) &&
+            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(OpenAiApiKeyEnv)))
+        {
+            return "env:OPENAI_API_KEY";
+        }
+
+        return "env:MODEL_PROVIDER_KEY";
     }
 
     private static string? ResolveExistingApiKey(string provider)
@@ -163,7 +265,7 @@ internal static class InteractiveStartupRecovery
             return existingApiKey;
         }
 
-        return PromptRequiredSecret(output, input, $"{provider} API key");
+        return TerminalPrompts.PromptRequiredSecret(output, input, $"{provider} API key");
     }
 
     private static string? ResolveEndpoint(TextWriter output, TextReader input, string provider, string? existingEndpoint)
@@ -174,7 +276,7 @@ internal static class InteractiveStartupRecovery
         if (!string.IsNullOrWhiteSpace(existingEndpoint))
             return existingEndpoint;
 
-        return PromptRequired(output, input, $"{provider} endpoint");
+        return TerminalPrompts.PromptRequired(output, input, $"{provider} endpoint");
     }
 
     private static bool RequiresApiKey(string provider)
@@ -203,9 +305,6 @@ internal static class InteractiveStartupRecovery
                IsPortInUse(ex);
     }
 
-    private static bool IsInteractiveConsole()
-        => Environment.UserInteractive && !Console.IsInputRedirected && !Console.IsOutputRedirected;
-
     private static bool IsStorageAccessError(Exception ex)
     {
         var baseMessage = ex.GetBaseException().Message;
@@ -214,7 +313,7 @@ internal static class InteractiveStartupRecovery
                baseMessage.Contains("Access to the path", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool IsPortInUse(Exception ex)
+    internal static bool IsPortInUse(Exception ex)
     {
         var baseException = ex.GetBaseException();
         return string.Equals(baseException.GetType().Name, "AddressInUseException", StringComparison.Ordinal) ||
@@ -225,103 +324,12 @@ internal static class InteractiveStartupRecovery
     private static bool Contains(string value, string fragment)
         => value.Contains(fragment, StringComparison.OrdinalIgnoreCase);
 
-    private static string Prompt(TextWriter output, TextReader input, string label, string defaultValue)
-    {
-        output.Write($"{label} [{defaultValue}]: ");
-        var value = input.ReadLine();
-        return string.IsNullOrWhiteSpace(value) ? defaultValue : value.Trim();
-    }
-
-    private static string PromptRequired(TextWriter output, TextReader input, string label)
-    {
-        while (true)
-        {
-            output.Write($"{label}: ");
-            var value = input.ReadLine()?.Trim();
-            if (!string.IsNullOrWhiteSpace(value))
-                return value;
-
-            output.WriteLine("A value is required.");
-        }
-    }
-
-    private static string PromptRequiredSecret(TextWriter output, TextReader input, string label)
-    {
-        if (ReferenceEquals(input, Console.In) && ReferenceEquals(output, Console.Out) && !Console.IsInputRedirected)
-        {
-            return ReadSecretFromConsole(label);
-        }
-
-        return PromptRequired(output, input, label);
-    }
-
-    private static string ReadSecretFromConsole(string label)
-    {
-        while (true)
-        {
-            Console.Write($"{label}: ");
-            var buffer = new List<char>();
-            while (true)
-            {
-                var key = Console.ReadKey(intercept: true);
-                if (key.Key == ConsoleKey.Enter)
-                {
-                    Console.WriteLine();
-                    break;
-                }
-
-                if (key.Key == ConsoleKey.Backspace)
-                {
-                    if (buffer.Count == 0)
-                        continue;
-
-                    buffer.RemoveAt(buffer.Count - 1);
-                    continue;
-                }
-
-                if (!char.IsControl(key.KeyChar))
-                    buffer.Add(key.KeyChar);
-            }
-
-            var value = new string([.. buffer]).Trim();
-            if (!string.IsNullOrWhiteSpace(value))
-                return value;
-
-            Console.WriteLine("A value is required.");
-        }
-    }
-
-    private static bool PromptYesNo(TextWriter output, TextReader input, string label, bool defaultValue)
-    {
-        var suffix = defaultValue ? "[Y/n]" : "[y/N]";
-        output.Write($"{label} {suffix}: ");
-        var value = input.ReadLine()?.Trim().ToLowerInvariant();
-        if (string.IsNullOrWhiteSpace(value))
-            return defaultValue;
-
-        return value is "y" or "yes";
-    }
-
-    private static int PromptPort(TextWriter output, TextReader input, int defaultPort)
-    {
-        while (true)
-        {
-            var value = Prompt(output, input, "Port", defaultPort.ToString());
-            if (int.TryParse(value, out var port) && port is > 0 and <= 65535)
-                return port;
-
-            output.WriteLine("Port must be between 1 and 65535.");
-        }
-    }
-
-    private sealed class StartupRecoveryDefaults
-    {
-        public required string WorkspacePath { get; init; }
-        public required string MemoryPath { get; init; }
-        public required int Port { get; init; }
-        public required string Provider { get; init; }
-        public required string Model { get; init; }
-        public string? ApiKey { get; init; }
-        public string? Endpoint { get; init; }
-    }
+    private sealed record StartupRecoveryDefaults(
+        string WorkspacePath,
+        string MemoryPath,
+        int Port,
+        string Provider,
+        string Model,
+        string? ApiKey,
+        string? Endpoint);
 }

--- a/src/OpenClaw.Gateway/Bootstrap/LocalStartupPostReadyActions.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/LocalStartupPostReadyActions.cs
@@ -1,0 +1,121 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+using OpenClaw.Core.Setup;
+
+namespace OpenClaw.Gateway.Bootstrap;
+
+internal static class LocalStartupPostReadyActions
+{
+    public static async Task RunAsync(
+        GatewayStartupContext startup,
+        StartupLaunchOptions launchOptions,
+        LocalStartupSession localSession,
+        LocalStartupStateStore stateStore,
+        ILogger logger,
+        CancellationToken stoppingToken,
+        TextReader? input = null,
+        TextWriter? output = null,
+        Action<string>? openBrowser = null,
+        string? saveConfigPathOverride = null)
+    {
+        input ??= Console.In;
+        output ??= Console.Out;
+        openBrowser ??= BrowserLauncher.TryOpen;
+
+        try
+        {
+            var currentState = MergeState(stateStore.Load(), localSession);
+            PersistState(stateStore, currentState, logger);
+
+            if (!currentState.BrowserPromptShown)
+            {
+                if (TerminalPrompts.PromptYesNo(output, input, "Open Chat UI in your browser now?", defaultValue: true))
+                    openBrowser($"http://localhost:{localSession.Port}/chat");
+
+                currentState = MergeState(currentState, localSession, browserPromptShown: true);
+                PersistState(stateStore, currentState, logger);
+            }
+
+            if (!launchOptions.SuppressSavePrompt && !stoppingToken.IsCancellationRequested)
+            {
+                var defaultConfigPath = saveConfigPathOverride ?? GatewaySetupPaths.ResolveDefaultConfigPath();
+                if (TerminalPrompts.PromptYesNo(
+                    output,
+                    input,
+                    $"Save this local setup to {defaultConfigPath} for next time?",
+                    defaultValue: true))
+                {
+                    var saved = await SaveLocalConfigAsync(startup, localSession, defaultConfigPath);
+                    output.WriteLine($"Saved config: {saved.ConfigPath}");
+                    output.WriteLine($"Saved env example: {saved.EnvExamplePath}");
+                    output.Flush();
+
+                    currentState = MergeState(currentState, localSession, browserPromptShown: true, lastSavedConfigPath: saved.ConfigPath);
+                    PersistState(stateStore, currentState, logger);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Post-ready startup prompts failed.");
+        }
+    }
+
+    internal static LocalStartupState MergeState(
+        LocalStartupState state,
+        LocalStartupSession session,
+        bool? browserPromptShown = null,
+        string? lastSavedConfigPath = null)
+        => new()
+        {
+            WorkspacePath = session.WorkspacePath,
+            MemoryPath = session.MemoryPath,
+            Port = session.Port,
+            Provider = session.Provider,
+            Model = session.Model,
+            BrowserPromptShown = browserPromptShown ?? state.BrowserPromptShown,
+            LastSavedConfigPath = lastSavedConfigPath ?? state.LastSavedConfigPath
+        };
+
+    internal static void PersistState(LocalStartupStateStore stateStore, LocalStartupState state, ILogger logger)
+    {
+        if (!stateStore.TrySave(state, out var error) && !string.IsNullOrWhiteSpace(error))
+            logger.LogWarning("Failed to update local startup state: {Error}", error);
+    }
+
+    internal static async Task<(string ConfigPath, string EnvExamplePath)> SaveLocalConfigAsync(
+        GatewayStartupContext startup,
+        LocalStartupSession localSession,
+        string configPath)
+    {
+        var authToken = string.IsNullOrWhiteSpace(startup.Config.AuthToken)
+            ? $"oc_{Convert.ToHexString(RandomNumberGenerator.GetBytes(24)).ToLowerInvariant()}"
+            : startup.Config.AuthToken!;
+        var config = GatewaySetupProfileFactory.CreateProfileConfig(
+            profile: "local",
+            bindAddress: "127.0.0.1",
+            port: localSession.Port,
+            authToken: authToken,
+            workspacePath: localSession.WorkspacePath,
+            memoryPath: localSession.MemoryPath,
+            provider: localSession.Provider,
+            model: localSession.Model,
+            apiKey: localSession.ApiKeyReference,
+            warnings: null);
+
+        if (!string.IsNullOrWhiteSpace(localSession.Endpoint))
+            config.Llm.Endpoint = localSession.Endpoint;
+
+        await GatewayConfigFile.SaveAsync(config, configPath);
+        var envExamplePath = GatewaySetupArtifacts.BuildEnvExamplePath(configPath);
+        await File.WriteAllTextAsync(
+            envExamplePath,
+            GatewaySetupArtifacts.BuildEnvExample(
+                localSession.ApiKeyReference,
+                authToken,
+                localSession.WorkspacePath,
+                GatewaySetupArtifacts.BuildReachableBaseUrl("127.0.0.1", localSession.Port)),
+            CancellationToken.None);
+        return (configPath, envExamplePath);
+    }
+}

--- a/src/OpenClaw.Gateway/Bootstrap/LocalStartupSession.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/LocalStartupSession.cs
@@ -1,0 +1,11 @@
+namespace OpenClaw.Gateway.Bootstrap;
+
+internal sealed record LocalStartupSession(
+    string Mode,
+    string WorkspacePath,
+    string MemoryPath,
+    int Port,
+    string Provider,
+    string Model,
+    string ApiKeyReference,
+    string? Endpoint);

--- a/src/OpenClaw.Gateway/Bootstrap/LocalStartupState.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/LocalStartupState.cs
@@ -1,0 +1,12 @@
+namespace OpenClaw.Gateway.Bootstrap;
+
+internal sealed class LocalStartupState
+{
+    public string? WorkspacePath { get; init; }
+    public string? MemoryPath { get; init; }
+    public int? Port { get; init; }
+    public string? Provider { get; init; }
+    public string? Model { get; init; }
+    public bool BrowserPromptShown { get; init; }
+    public string? LastSavedConfigPath { get; init; }
+}

--- a/src/OpenClaw.Gateway/Bootstrap/LocalStartupStateStore.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/LocalStartupStateStore.cs
@@ -1,0 +1,26 @@
+using OpenClaw.Core.Setup;
+
+namespace OpenClaw.Gateway.Bootstrap;
+
+internal sealed class LocalStartupStateStore
+{
+    public LocalStartupStateStore(string? path = null)
+    {
+        Path = string.IsNullOrWhiteSpace(path)
+            ? GatewaySetupPaths.ResolveDefaultLocalStartupStatePath()
+            : System.IO.Path.GetFullPath(GatewaySetupPaths.ExpandPath(path));
+    }
+
+    public string Path { get; }
+
+    public LocalStartupState Load()
+    {
+        if (!AtomicJsonFileStore.TryLoad(Path, StartupJsonContext.Default.LocalStartupState, out LocalStartupState? state, out _))
+            return new LocalStartupState();
+
+        return state ?? new LocalStartupState();
+    }
+
+    public bool TrySave(LocalStartupState state, out string? error)
+        => AtomicJsonFileStore.TryWriteAtomic(Path, state, StartupJsonContext.Default.LocalStartupState, out error);
+}

--- a/src/OpenClaw.Gateway/Bootstrap/StartupConsoleCoordinator.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/StartupConsoleCoordinator.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Configuration;
+
+namespace OpenClaw.Gateway.Bootstrap;
+
+internal sealed class StartupConsoleCoordinator
+{
+    public void WritePhase(string phase, TextWriter? output = null)
+    {
+        var writer = output ?? Console.Out;
+        writer.WriteLine(phase);
+        writer.Flush();
+    }
+
+    public void WriteConfigurationSummary(
+        ConfigurationManager configuration,
+        string environmentName,
+        LocalStartupSession? session,
+        TextWriter? output = null)
+    {
+        var writer = output ?? Console.Out;
+        writer.WriteLine($"Startup environment: {environmentName}");
+        writer.WriteLine("Configuration sources:");
+
+        foreach (var source in BuildJsonSources(configuration))
+            writer.WriteLine($"- {source}");
+
+        writer.WriteLine(session is null
+            ? "- Session-only overrides: none"
+            : $"- Session-only overrides: active ({session.Mode})");
+        writer.Flush();
+    }
+
+    private static IReadOnlyList<string> BuildJsonSources(ConfigurationManager configuration)
+    {
+        var sources = new List<string>();
+        foreach (var source in configuration.Sources.OfType<FileConfigurationSource>())
+        {
+            if (string.IsNullOrWhiteSpace(source.Path) || !source.Path.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            sources.Add(source.Path);
+        }
+
+        return [.. sources.Distinct(StringComparer.OrdinalIgnoreCase)];
+    }
+}

--- a/src/OpenClaw.Gateway/Bootstrap/StartupFailureReporter.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/StartupFailureReporter.cs
@@ -9,10 +9,11 @@ internal static class StartupFailureReporter
         GatewayStartupContext? startup,
         string environmentName,
         bool isDoctorMode,
+        bool suggestQuickstart = false,
         TextWriter? error = null)
     {
         var writer = error ?? Console.Error;
-        writer.WriteLine(Render(ex, startup, environmentName, isDoctorMode));
+        writer.WriteLine(Render(ex, startup, environmentName, isDoctorMode, suggestQuickstart));
         writer.Flush();
     }
 
@@ -20,9 +21,10 @@ internal static class StartupFailureReporter
         Exception ex,
         GatewayStartupContext? startup,
         string environmentName,
-        bool isDoctorMode)
+        bool isDoctorMode,
+        bool suggestQuickstart = false)
     {
-        var report = Analyze(ex, startup, environmentName, isDoctorMode);
+        var report = Analyze(ex, startup, environmentName, isDoctorMode, suggestQuickstart);
         var sb = new StringBuilder();
         sb.AppendLine($"Startup failed: {report.Title}");
         sb.AppendLine();
@@ -51,15 +53,16 @@ internal static class StartupFailureReporter
         Exception ex,
         GatewayStartupContext? startup,
         string environmentName,
-        bool isDoctorMode)
+        bool isDoctorMode,
+        bool suggestQuickstart)
     {
         var message = ex.Message;
 
         if (Contains(message, "OPENCLAW_AUTH_TOKEN must be set when binding to a non-loopback address."))
-            return BuildAuthTokenReport(startup, environmentName, isDoctorMode);
+            return BuildAuthTokenReport(startup, environmentName, isDoctorMode, suggestQuickstart);
 
         if (IsPortInUse(ex))
-            return BuildPortInUseReport(ex, startup, isDoctorMode);
+            return BuildPortInUseReport(ex, startup, isDoctorMode, suggestQuickstart);
 
         if (Contains(message, "MODEL_PROVIDER_KEY must be set") ||
             Contains(message, "MODEL_PROVIDER_ENDPOINT must be set") ||
@@ -67,19 +70,20 @@ internal static class StartupFailureReporter
             Contains(message, "Configured provider '") ||
             Contains(message, "Unsupported LLM provider"))
         {
-            return BuildProviderReport(ex, startup, isDoctorMode);
+            return BuildProviderReport(ex, startup, isDoctorMode, suggestQuickstart);
         }
 
         if (Contains(message, "Memory.StoragePath") || IsStorageAccessError(ex))
-            return BuildStorageReport(ex, startup, environmentName, isDoctorMode);
+            return BuildStorageReport(ex, startup, environmentName, isDoctorMode, suggestQuickstart);
 
-        return BuildGenericReport(ex, startup, environmentName, isDoctorMode);
+        return BuildGenericReport(ex, startup, environmentName, isDoctorMode, suggestQuickstart);
     }
 
     private static StartupFailureReport BuildAuthTokenReport(
         GatewayStartupContext? startup,
         string environmentName,
-        bool isDoctorMode)
+        bool isDoctorMode,
+        bool suggestQuickstart)
     {
         var details = new List<string>();
         AddIfValue(details, "Current ASPNETCORE_ENVIRONMENT", environmentName);
@@ -97,7 +101,7 @@ internal static class StartupFailureReporter
             "If you are starting the gateway on your machine, set ASPNETCORE_ENVIRONMENT to Development so the repo-local defaults are used.",
             "If you do want a non-loopback bind, set OPENCLAW_AUTH_TOKEN to a strong random value before launch."
         };
-        AddDoctorStep(actions, isDoctorMode);
+        AddOperatorNextSteps(actions, isDoctorMode, suggestQuickstart);
 
         return new StartupFailureReport(
             Title: "authentication is required for a non-loopback bind.",
@@ -110,7 +114,8 @@ internal static class StartupFailureReporter
         Exception ex,
         GatewayStartupContext? startup,
         string environmentName,
-        bool isDoctorMode)
+        bool isDoctorMode,
+        bool suggestQuickstart)
     {
         var details = new List<string>();
         AddIfValue(details, "Current ASPNETCORE_ENVIRONMENT", environmentName);
@@ -138,7 +143,7 @@ internal static class StartupFailureReporter
         }
 
         actions.Add("Make sure the chosen directory exists or can be created by the current user.");
-        AddDoctorStep(actions, isDoctorMode);
+        AddOperatorNextSteps(actions, isDoctorMode, suggestQuickstart);
 
         return new StartupFailureReport(
             Title: "the configured memory storage path is not writable.",
@@ -150,7 +155,8 @@ internal static class StartupFailureReporter
     private static StartupFailureReport BuildProviderReport(
         Exception ex,
         GatewayStartupContext? startup,
-        bool isDoctorMode)
+        bool isDoctorMode,
+        bool suggestQuickstart)
     {
         var config = startup?.Config;
         var provider = config?.Llm.Provider ?? TryExtractQuotedValue(ex.Message, "Configured provider '");
@@ -192,7 +198,7 @@ internal static class StartupFailureReporter
             actions.Add("If this provider should come from a plugin, enable that plugin before launch.");
         }
 
-        AddDoctorStep(actions, isDoctorMode);
+        AddOperatorNextSteps(actions, isDoctorMode, suggestQuickstart);
 
         return new StartupFailureReport(
             Title: title,
@@ -204,7 +210,8 @@ internal static class StartupFailureReporter
     private static StartupFailureReport BuildPortInUseReport(
         Exception ex,
         GatewayStartupContext? startup,
-        bool isDoctorMode)
+        bool isDoctorMode,
+        bool suggestQuickstart)
     {
         var details = new List<string>();
         AddIfValue(details, "BindAddress", startup?.Config.BindAddress);
@@ -216,7 +223,7 @@ internal static class StartupFailureReporter
         {
             "Stop the process that is already using this port, or change OpenClaw__Port to a free port."
         };
-        AddDoctorStep(actions, isDoctorMode);
+        AddOperatorNextSteps(actions, isDoctorMode, suggestQuickstart);
 
         return new StartupFailureReport(
             Title: "the configured HTTP port is already in use.",
@@ -229,7 +236,8 @@ internal static class StartupFailureReporter
         Exception ex,
         GatewayStartupContext? startup,
         string environmentName,
-        bool isDoctorMode)
+        bool isDoctorMode,
+        bool suggestQuickstart)
     {
         var details = new List<string>
         {
@@ -248,7 +256,7 @@ internal static class StartupFailureReporter
         {
             "Review the startup settings above and correct the misconfiguration before retrying."
         };
-        AddDoctorStep(actions, isDoctorMode);
+        AddOperatorNextSteps(actions, isDoctorMode, suggestQuickstart);
 
         return new StartupFailureReport(
             Title: "an unexpected startup exception occurred.",
@@ -273,8 +281,11 @@ internal static class StartupFailureReporter
                baseException.Message.Contains("Only one usage of each socket address", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static void AddDoctorStep(ICollection<string> actions, bool isDoctorMode)
+    private static void AddOperatorNextSteps(ICollection<string> actions, bool isDoctorMode, bool suggestQuickstart)
     {
+        if (suggestQuickstart)
+            actions.Add("For an interactive local bootstrap, rerun the gateway with --quickstart.");
+
         if (!isDoctorMode)
         {
             actions.Add("Run the preflight checks with: dotnet run --project src/OpenClaw.Gateway -c Release -- --doctor");

--- a/src/OpenClaw.Gateway/Bootstrap/StartupJsonContext.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/StartupJsonContext.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace OpenClaw.Gateway.Bootstrap;
+
+[JsonSerializable(typeof(LocalStartupState))]
+internal sealed partial class StartupJsonContext : JsonSerializerContext
+{
+}

--- a/src/OpenClaw.Gateway/Bootstrap/StartupLaunchOptions.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/StartupLaunchOptions.cs
@@ -1,0 +1,100 @@
+using OpenClaw.Core.Setup;
+
+namespace OpenClaw.Gateway.Bootstrap;
+
+internal sealed class StartupLaunchOptions
+{
+    private StartupLaunchOptions(
+        string[] originalArgs,
+        string[] effectiveArgs,
+        bool isDoctorMode,
+        bool isHealthCheckMode,
+        bool isQuickstartRequested,
+        string? configPathFromArgs,
+        string? configPathFromEnvironment,
+        bool canPrompt)
+    {
+        OriginalArgs = originalArgs;
+        EffectiveArgs = effectiveArgs;
+        IsDoctorMode = isDoctorMode;
+        IsHealthCheckMode = isHealthCheckMode;
+        IsQuickstartRequested = isQuickstartRequested;
+        ConfigPathFromArgs = configPathFromArgs;
+        ConfigPathFromEnvironment = configPathFromEnvironment;
+        CanPrompt = canPrompt;
+    }
+
+    public string[] OriginalArgs { get; }
+
+    public string[] EffectiveArgs { get; }
+
+    public bool IsDoctorMode { get; }
+
+    public bool IsHealthCheckMode { get; }
+
+    public bool IsQuickstartRequested { get; }
+
+    public bool CanPrompt { get; }
+
+    public string? ConfigPathFromArgs { get; }
+
+    public string? ConfigPathFromEnvironment { get; }
+
+    public string? ExternalConfigPath => ConfigPathFromArgs ?? ConfigPathFromEnvironment;
+
+    public bool HasConfigArgument => !string.IsNullOrWhiteSpace(ConfigPathFromArgs);
+
+    public bool HasExternalConfigOverride => !string.IsNullOrWhiteSpace(ExternalConfigPath);
+
+    public bool SuppressSavePrompt => HasExternalConfigOverride;
+
+    public bool ShouldSuggestQuickstart => CanPrompt && !IsQuickstartRequested && !IsDoctorMode && !IsHealthCheckMode;
+
+    public static StartupLaunchOptions Parse(string[] args)
+    {
+        var configArg = FindArgValue(args, "--config");
+        var envConfigPath = Environment.GetEnvironmentVariable("OPENCLAW_CONFIG_PATH");
+        return new StartupLaunchOptions(
+            originalArgs: args,
+            effectiveArgs: [.. args.Where(static arg => !string.Equals(arg, "--quickstart", StringComparison.Ordinal))],
+            isDoctorMode: args.Any(static a => string.Equals(a, "--doctor", StringComparison.Ordinal)),
+            isHealthCheckMode: args.Any(static a => string.Equals(a, "--health-check", StringComparison.Ordinal)),
+            isQuickstartRequested: args.Any(static a => string.Equals(a, "--quickstart", StringComparison.Ordinal)),
+            configPathFromArgs: string.IsNullOrWhiteSpace(configArg) ? null : System.IO.Path.GetFullPath(GatewaySetupPaths.ExpandPath(configArg)),
+            configPathFromEnvironment: string.IsNullOrWhiteSpace(envConfigPath) ? null : System.IO.Path.GetFullPath(GatewaySetupPaths.ExpandPath(envConfigPath)),
+            canPrompt: TerminalPrompts.IsInteractiveConsole());
+    }
+
+    public string? ValidateQuickstart()
+    {
+        if (!IsQuickstartRequested)
+            return null;
+        if (IsDoctorMode)
+            return "--quickstart cannot be combined with --doctor.";
+        if (IsHealthCheckMode)
+            return "--quickstart cannot be combined with --health-check.";
+        if (HasConfigArgument)
+            return "--quickstart cannot be combined with --config.";
+        if (!string.IsNullOrWhiteSpace(ConfigPathFromEnvironment))
+            return "--quickstart cannot be used while OPENCLAW_CONFIG_PATH is set.";
+        if (!CanPrompt)
+            return "--quickstart requires an interactive terminal.";
+        return null;
+    }
+
+    private static string? FindArgValue(string[] argv, string name)
+    {
+        for (var i = 0; i < argv.Length; i++)
+        {
+            var arg = argv[i];
+            if (arg.Equals(name, StringComparison.Ordinal) && i + 1 < argv.Length)
+                return argv[i + 1];
+
+            var prefix = name + "=";
+            if (arg.StartsWith(prefix, StringComparison.Ordinal))
+                return arg[prefix.Length..];
+        }
+
+        return null;
+    }
+}

--- a/src/OpenClaw.Gateway/Bootstrap/StartupLaunchOptions.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/StartupLaunchOptions.cs
@@ -10,6 +10,7 @@ internal sealed class StartupLaunchOptions
         bool isDoctorMode,
         bool isHealthCheckMode,
         bool isQuickstartRequested,
+        bool hasConfigFlag,
         string? configPathFromArgs,
         string? configPathFromEnvironment,
         bool canPrompt)
@@ -19,6 +20,7 @@ internal sealed class StartupLaunchOptions
         IsDoctorMode = isDoctorMode;
         IsHealthCheckMode = isHealthCheckMode;
         IsQuickstartRequested = isQuickstartRequested;
+        HasConfigFlag = hasConfigFlag;
         ConfigPathFromArgs = configPathFromArgs;
         ConfigPathFromEnvironment = configPathFromEnvironment;
         CanPrompt = canPrompt;
@@ -35,6 +37,8 @@ internal sealed class StartupLaunchOptions
     public bool IsQuickstartRequested { get; }
 
     public bool CanPrompt { get; }
+
+    public bool HasConfigFlag { get; }
 
     public string? ConfigPathFromArgs { get; }
 
@@ -60,6 +64,7 @@ internal sealed class StartupLaunchOptions
             isDoctorMode: args.Any(static a => string.Equals(a, "--doctor", StringComparison.Ordinal)),
             isHealthCheckMode: args.Any(static a => string.Equals(a, "--health-check", StringComparison.Ordinal)),
             isQuickstartRequested: args.Any(static a => string.Equals(a, "--quickstart", StringComparison.Ordinal)),
+            hasConfigFlag: HasArg(args, "--config"),
             configPathFromArgs: string.IsNullOrWhiteSpace(configArg) ? null : System.IO.Path.GetFullPath(GatewaySetupPaths.ExpandPath(configArg)),
             configPathFromEnvironment: string.IsNullOrWhiteSpace(envConfigPath) ? null : System.IO.Path.GetFullPath(GatewaySetupPaths.ExpandPath(envConfigPath)),
             canPrompt: TerminalPrompts.IsInteractiveConsole());
@@ -73,13 +78,29 @@ internal sealed class StartupLaunchOptions
             return "--quickstart cannot be combined with --doctor.";
         if (IsHealthCheckMode)
             return "--quickstart cannot be combined with --health-check.";
-        if (HasConfigArgument)
+        if (HasConfigFlag)
             return "--quickstart cannot be combined with --config.";
         if (!string.IsNullOrWhiteSpace(ConfigPathFromEnvironment))
             return "--quickstart cannot be used while OPENCLAW_CONFIG_PATH is set.";
         if (!CanPrompt)
             return "--quickstart requires an interactive terminal.";
         return null;
+    }
+
+    private static bool HasArg(string[] argv, string name)
+    {
+        for (var i = 0; i < argv.Length; i++)
+        {
+            var arg = argv[i];
+            if (arg.Equals(name, StringComparison.Ordinal))
+                return true;
+
+            var prefix = name + "=";
+            if (arg.StartsWith(prefix, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
     }
 
     private static string? FindArgValue(string[] argv, string name)

--- a/src/OpenClaw.Gateway/Bootstrap/StartupRecoveryOutcome.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/StartupRecoveryOutcome.cs
@@ -1,0 +1,10 @@
+namespace OpenClaw.Gateway.Bootstrap;
+
+internal sealed record StartupRecoveryOutcome(StartupRecoveryResult Result, LocalStartupSession? Session = null)
+{
+    public static StartupRecoveryOutcome NotHandled { get; } = new(StartupRecoveryResult.NotHandled);
+
+    public static StartupRecoveryOutcome Declined { get; } = new(StartupRecoveryResult.Declined);
+
+    public static StartupRecoveryOutcome Recovered(LocalStartupSession session) => new(StartupRecoveryResult.Recovered, session);
+}

--- a/src/OpenClaw.Gateway/Bootstrap/StartupRecoveryResult.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/StartupRecoveryResult.cs
@@ -1,0 +1,8 @@
+namespace OpenClaw.Gateway.Bootstrap;
+
+internal enum StartupRecoveryResult
+{
+    NotHandled,
+    Recovered,
+    Declined
+}

--- a/src/OpenClaw.Gateway/Bootstrap/TerminalPrompts.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/TerminalPrompts.cs
@@ -1,0 +1,114 @@
+namespace OpenClaw.Gateway.Bootstrap;
+
+internal static class TerminalPrompts
+{
+    public static bool IsInteractiveConsole()
+        => Environment.UserInteractive && !Console.IsInputRedirected && !Console.IsOutputRedirected;
+
+    public static string Prompt(TextWriter output, TextReader input, string label, string defaultValue)
+    {
+        output.Write($"{label} [{defaultValue}]: ");
+        var value = input.ReadLine();
+        return string.IsNullOrWhiteSpace(value) ? defaultValue : value.Trim();
+    }
+
+    public static string PromptRequired(TextWriter output, TextReader input, string label)
+    {
+        while (true)
+        {
+            output.Write($"{label}: ");
+            var value = input.ReadLine()?.Trim();
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+
+            output.WriteLine("A value is required.");
+        }
+    }
+
+    public static string PromptRequiredSecret(TextWriter output, TextReader input, string label)
+    {
+        if (ReferenceEquals(input, Console.In) && ReferenceEquals(output, Console.Out) && !Console.IsInputRedirected)
+            return ReadSecretFromConsole(label);
+
+        return PromptRequired(output, input, label);
+    }
+
+    public static bool PromptYesNo(TextWriter output, TextReader input, string question, bool defaultValue)
+    {
+        while (true)
+        {
+            output.Write($"{question} [{(defaultValue ? "Y/n" : "y/N")}]: ");
+            var raw = input.ReadLine();
+            if (string.IsNullOrWhiteSpace(raw))
+                return defaultValue;
+
+            switch (raw.Trim().ToLowerInvariant())
+            {
+                case "y":
+                case "yes":
+                    return true;
+                case "n":
+                case "no":
+                    return false;
+                default:
+                    output.WriteLine("Please answer y or n.");
+                    break;
+            }
+        }
+    }
+
+    public static int PromptPort(TextWriter output, TextReader input, int defaultPort)
+    {
+        while (true)
+        {
+            var value = Prompt(output, input, "Port", defaultPort.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            if (int.TryParse(value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var port) &&
+                port is >= 1 and <= 65535)
+            {
+                return port;
+            }
+
+            output.WriteLine("Enter a valid TCP port between 1 and 65535.");
+        }
+    }
+
+    private static string ReadSecretFromConsole(string label)
+    {
+        while (true)
+        {
+            Console.Write($"{label}: ");
+            var buffer = new Stack<char>();
+            while (true)
+            {
+                var key = Console.ReadKey(intercept: true);
+                if (key.Key == ConsoleKey.Enter)
+                {
+                    Console.WriteLine();
+                    break;
+                }
+
+                if (key.Key == ConsoleKey.Backspace)
+                {
+                    if (buffer.Count == 0)
+                        continue;
+
+                    buffer.Pop();
+                    Console.Write("\b \b");
+                    continue;
+                }
+
+                if (!char.IsControl(key.KeyChar))
+                {
+                    buffer.Push(key.KeyChar);
+                    Console.Write('*');
+                }
+            }
+
+            var value = new string([.. buffer.Reverse()]);
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+
+            Console.WriteLine("A value is required.");
+        }
+    }
+}

--- a/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
@@ -56,6 +56,8 @@ internal static class CoreServicesExtensions
         services.AddSingleton<ProviderUsageTracker>();
         services.AddSingleton<ToolUsageTracker>();
         services.AddSingleton<ProviderSmokeRegistry>();
+        services.AddSingleton<StartupNoticeCollector>();
+        services.AddSingleton<IStartupNoticeSink>(sp => sp.GetRequiredService<StartupNoticeCollector>());
         services.AddSingleton(sp => new SetupVerificationSnapshotStore(config.Memory.StoragePath));
         services.AddSingleton(sp => new ToolAuditLog(
             Path.Combine(Path.GetFullPath(config.Memory.StoragePath), "audit", "tool-audit.jsonl"),
@@ -144,6 +146,7 @@ internal static class CoreServicesExtensions
             new CronScheduler(
                 sp.GetRequiredService<ICronJobSource>(),
                 sp.GetRequiredService<ILogger<CronScheduler>>(),
+                sp.GetRequiredService<IStartupNoticeSink>(),
                 sp.GetRequiredService<MessagePipeline>().InboundWriter));
         services.AddSingleton<CronSchedulerStartupService>();
         services.AddHostedService(sp => sp.GetRequiredService<CronSchedulerStartupService>());

--- a/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs
@@ -38,6 +38,7 @@ internal static class RuntimeInitializationExtensions
         var config = startup.Config;
         var loggerFactory = app.Services.GetRequiredService<ILoggerFactory>();
         var startupLogger = loggerFactory.CreateLogger("Startup");
+        var startupNoticeSink = app.Services.GetRequiredService<IStartupNoticeSink>();
         var browserAvailability = BrowserToolSupport.Evaluate(config, startup.RuntimeState);
         startupLogger.LogInformation(
             "Runtime mode resolved: requested={RequestedMode}, effective={EffectiveMode}, dynamicCodeSupported={DynamicCodeSupported}, orchestrator={Orchestrator}.",
@@ -47,8 +48,9 @@ internal static class RuntimeInitializationExtensions
             RuntimeOrchestrator.Normalize(config.Runtime.Orchestrator));
         if (browserAvailability.ConfiguredEnabled && !browserAvailability.Registered)
         {
-            startupLogger.LogWarning(
-                "Browser tool was not registered because local execution is unavailable in this runtime and no execution backend or sandbox route is configured.");
+            const string browserNotice = "Disabled: browser tool is unavailable because no execution backend or sandbox route is configured.";
+            startupLogger.LogInformation(browserNotice);
+            startupNoticeSink.Record(browserNotice);
         }
         if (startup.IsNonLoopbackBind && !config.Security.RequireRequesterMatchForHttpToolApproval)
         {

--- a/src/OpenClaw.Gateway/GatewayLlmExecutionService.cs
+++ b/src/OpenClaw.Gateway/GatewayLlmExecutionService.cs
@@ -14,6 +14,8 @@ namespace OpenClaw.Gateway;
 
 internal sealed class GatewayLlmExecutionService : ILlmExecutionService
 {
+    internal sealed record ProviderRuntimeFailureClassification(string Code, string UserMessage, string OperatorMessage);
+
     private sealed class CompatibilityServices
     {
         public required ConfiguredModelProfileRegistry Registry { get; init; }
@@ -41,6 +43,7 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
     private readonly PromptCacheWarmRegistry _promptCacheWarmRegistry;
     private readonly ILogger<GatewayLlmExecutionService> _logger;
     private readonly ConcurrentDictionary<string, RouteState> _routes = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, byte> _reportedProviderGuidance = new(StringComparer.OrdinalIgnoreCase);
 
     public GatewayLlmExecutionService(
         GatewayConfig config,
@@ -325,13 +328,14 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
                     }
                     catch (Exception ex)
                     {
-                        lastError = ex;
+                        var surfacedError = SurfaceProviderFailure(ex, candidate.Profile.ProviderId);
+                        lastError = surfacedError;
                         Interlocked.Increment(ref routeState.Errors);
-                        routeState.LastError = ex.Message;
+                        routeState.LastError = surfacedError.Message;
                         routeState.LastErrorAtUtc = DateTimeOffset.UtcNow;
                         _runtimeMetrics.IncrementLlmErrors();
                         _providerUsage.RecordError(candidate.Profile.ProviderId, modelId);
-                        RecordEvent(session, turnContext, "llm", "request_failed", "error", ex.Message, new()
+                        RecordEvent(session, turnContext, "llm", "request_failed", "error", surfacedError.Message, new()
                         {
                             ["providerId"] = candidate.Profile.ProviderId,
                             ["modelId"] = modelId,
@@ -468,21 +472,22 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
                 }
                 catch (Exception ex)
                 {
+                    var surfacedError = SurfaceProviderFailure(ex, providerId);
                     routeState.CircuitBreaker.RecordFailure();
                     Interlocked.Increment(ref routeState.Errors);
-                    routeState.LastError = ex.Message;
+                    routeState.LastError = surfacedError.Message;
                     routeState.LastErrorAtUtc = DateTimeOffset.UtcNow;
                     _runtimeMetrics.IncrementLlmErrors();
                     _providerUsage.RecordError(providerId, modelId);
                     _promptCacheCoordinator.RecordResponse(descriptor, 0, 0);
-                    RecordEvent(session, turnContext, "llm", "stream_failed", "error", ex.Message, new()
+                    RecordEvent(session, turnContext, "llm", "stream_failed", "error", surfacedError.Message, new()
                     {
                         ["providerId"] = providerId,
                         ["modelId"] = modelId,
                         ["profileId"] = profileId,
                         ["exceptionType"] = ex.GetType().Name
                     });
-                    throw;
+                    throw surfacedError;
                 }
 
                 foreach (var usage in current.Contents.OfType<UsageContent>())
@@ -676,11 +681,99 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
         });
     }
 
+    private Exception SurfaceProviderFailure(Exception ex, string providerId)
+    {
+        var classification = ClassifyProviderFailure(ex, providerId);
+        if (classification is null)
+            return ex;
+
+        if (_reportedProviderGuidance.TryAdd($"{providerId}:{classification.Code}", 0))
+            _logger.LogWarning("Provider guidance: {Guidance}", classification.OperatorMessage);
+
+        return new InvalidOperationException(classification.UserMessage, ex);
+    }
+
+    internal static ProviderRuntimeFailureClassification? ClassifyProviderFailure(Exception ex, string providerId)
+    {
+        var message = ex.GetBaseException().Message;
+        var providerLabel = FormatProviderLabel(providerId);
+        var apiKeyHint = ResolveApiKeyHint(providerId);
+
+        if (Contains(message, "MODEL_PROVIDER_KEY must be set"))
+        {
+            return new ProviderRuntimeFailureClassification(
+                Code: "missing-key",
+                UserMessage: $"{providerLabel} credentials are missing. Set {apiKeyHint} and retry.",
+                OperatorMessage: $"{providerLabel} requests cannot run because the API key is missing. Set {apiKeyHint} before retrying.");
+        }
+
+        if (Contains(message, "MODEL_PROVIDER_ENDPOINT must be set") ||
+            Contains(message, "Endpoint must be set for provider"))
+        {
+            return new ProviderRuntimeFailureClassification(
+                Code: "missing-endpoint",
+                UserMessage: $"{providerLabel} endpoint is missing. Set MODEL_PROVIDER_ENDPOINT or OpenClaw:Llm:Endpoint and retry.",
+                OperatorMessage: $"{providerLabel} requests cannot run because the provider endpoint is missing. Set MODEL_PROVIDER_ENDPOINT or OpenClaw:Llm:Endpoint before retrying.");
+        }
+
+        if (Contains(message, "invalid_api_key") ||
+            Contains(message, "Incorrect API key provided") ||
+            Contains(message, "invalid api key") ||
+            Contains(message, "invalid api-key"))
+        {
+            return new ProviderRuntimeFailureClassification(
+                Code: "invalid-key",
+                UserMessage: $"{providerLabel} credentials were rejected. Update {apiKeyHint} and retry.",
+                OperatorMessage: $"{providerLabel} requests are failing because the configured API key was rejected. Update {apiKeyHint} and retry.");
+        }
+
+        if ((Contains(message, "401") || Contains(message, "403")) &&
+            (Contains(message, "auth") || Contains(message, "unauthorized") || Contains(message, "forbidden")))
+        {
+            return new ProviderRuntimeFailureClassification(
+                Code: "auth-rejected",
+                UserMessage: $"{providerLabel} credentials were rejected. Update {apiKeyHint} and retry.",
+                OperatorMessage: $"{providerLabel} requests are returning authorization failures. Verify {apiKeyHint} and retry.");
+        }
+
+        if (Contains(message, "Unsupported LLM provider") ||
+            Contains(message, "Configured provider '"))
+        {
+            return new ProviderRuntimeFailureClassification(
+                Code: "unsupported-provider",
+                UserMessage: $"{providerLabel} is not available in the current runtime. Update OpenClaw:Llm:Provider or enable the required plugin.",
+                OperatorMessage: $"{providerLabel} is not available in the current runtime. Update OpenClaw:Llm:Provider or enable the required provider plugin before retrying.");
+        }
+
+        return null;
+    }
+
     private static bool IsTransient(Exception ex)
         => ex is HttpRequestException
             || ex is TimeoutException
             || ex is TaskCanceledException
             || ex is CircuitOpenException;
+
+    private static string ResolveApiKeyHint(string providerId)
+        => providerId.Trim().ToLowerInvariant() switch
+        {
+            "openai" => "MODEL_PROVIDER_KEY or OPENAI_API_KEY",
+            _ => "MODEL_PROVIDER_KEY"
+        };
+
+    private static string FormatProviderLabel(string providerId)
+        => providerId.Trim().ToLowerInvariant() switch
+        {
+            "openai" => "OpenAI",
+            "azure-openai" => "Azure OpenAI",
+            "anthropic" or "claude" => "Anthropic",
+            "gemini" or "google" => "Gemini",
+            { Length: > 0 } => $"Provider '{providerId}'",
+            _ => "The configured provider"
+        };
+
+    private static bool Contains(string value, string fragment)
+        => value.Contains(fragment, StringComparison.OrdinalIgnoreCase);
 
     private RouteState GetRouteStateSnapshot(string profileId, string providerId, string modelId)
         => _routes.TryGetValue(BuildRouteKey(profileId, providerId, modelId), out var state)

--- a/src/OpenClaw.Gateway/Pipeline/PipelineExtensions.cs
+++ b/src/OpenClaw.Gateway/Pipeline/PipelineExtensions.cs
@@ -16,7 +16,10 @@ internal static class PipelineExtensions
     public static void UseOpenClawPipeline(
         this WebApplication app,
         GatewayStartupContext startup,
-        GatewayAppRuntime runtime)
+        GatewayAppRuntime runtime,
+        StartupLaunchOptions launchOptions,
+        LocalStartupSession? localSession,
+        LocalStartupStateStore stateStore)
     {
         ConfigureForwardedHeaders(app, startup);
         ConfigureCors(app, runtime);
@@ -31,7 +34,7 @@ internal static class PipelineExtensions
         StartWorkers(app, startup, runtime);
         StartChannels(app, runtime);
         RegisterShutdown(app, startup, runtime);
-        StartupReadyReporter.Register(app, startup);
+        StartupReadyReporter.Register(app, startup, launchOptions, localSession, stateStore);
     }
 
     private static void ConfigureForwardedHeaders(WebApplication app, GatewayStartupContext startup)

--- a/src/OpenClaw.Gateway/Pipeline/StartupNoticeCollector.cs
+++ b/src/OpenClaw.Gateway/Pipeline/StartupNoticeCollector.cs
@@ -1,0 +1,72 @@
+using System.Collections.Concurrent;
+using OpenClaw.Core.Observability;
+
+namespace OpenClaw.Gateway.Pipeline;
+
+internal sealed record StartupNoticeSnapshot(string Message, int Count);
+
+internal sealed class StartupNoticeCollector : IStartupNoticeSink
+{
+    private readonly object _gate = new();
+    private readonly List<StartupNoticeSnapshot> _ordered = [];
+    private readonly Dictionary<string, int> _indexes = new(StringComparer.Ordinal);
+    private TextWriter? _liveOutput;
+    private DateTimeOffset _liveUntilUtc;
+    private bool _liveHeaderWritten;
+
+    public IReadOnlyList<StartupNoticeSnapshot> Snapshot()
+    {
+        lock (_gate)
+        {
+            return [.. _ordered];
+        }
+    }
+
+    public void EnableLiveOutput(TextWriter output, TimeSpan duration, bool headerAlreadyWritten)
+    {
+        lock (_gate)
+        {
+            _liveOutput = output;
+            _liveUntilUtc = DateTimeOffset.UtcNow.Add(duration);
+            _liveHeaderWritten = headerAlreadyWritten;
+        }
+    }
+
+    public void Record(string message)
+    {
+        TextWriter? liveOutput = null;
+        var writeHeader = false;
+        var writeMessage = false;
+
+        lock (_gate)
+        {
+            if (_indexes.TryGetValue(message, out var index))
+            {
+                var existing = _ordered[index];
+                _ordered[index] = existing with { Count = existing.Count + 1 };
+            }
+            else
+            {
+                _indexes[message] = _ordered.Count;
+                _ordered.Add(new StartupNoticeSnapshot(message, 1));
+
+                if (_liveOutput is not null && DateTimeOffset.UtcNow <= _liveUntilUtc)
+                {
+                    liveOutput = _liveOutput;
+                    writeHeader = !_liveHeaderWritten;
+                    _liveHeaderWritten = true;
+                    writeMessage = true;
+                }
+            }
+        }
+
+        if (liveOutput is not null && writeMessage)
+        {
+            if (writeHeader)
+                liveOutput.WriteLine("Started with notices:");
+
+            liveOutput.WriteLine($"- {message}");
+            liveOutput.Flush();
+        }
+    }
+}

--- a/src/OpenClaw.Gateway/Pipeline/StartupNoticeCollector.cs
+++ b/src/OpenClaw.Gateway/Pipeline/StartupNoticeCollector.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using OpenClaw.Core.Observability;
 
 namespace OpenClaw.Gateway.Pipeline;

--- a/src/OpenClaw.Gateway/Pipeline/StartupReadyReporter.cs
+++ b/src/OpenClaw.Gateway/Pipeline/StartupReadyReporter.cs
@@ -1,33 +1,69 @@
 using System.Text;
+using OpenClaw.Core.Setup;
 using OpenClaw.Gateway.Bootstrap;
 
 namespace OpenClaw.Gateway.Pipeline;
 
 internal static class StartupReadyReporter
 {
-    public static void Register(WebApplication app, GatewayStartupContext startup)
+    private static readonly TimeSpan LiveNoticeWindow = TimeSpan.FromSeconds(5);
+
+    public static void Register(
+        WebApplication app,
+        GatewayStartupContext startup,
+        StartupLaunchOptions launchOptions,
+        LocalStartupSession? localSession,
+        LocalStartupStateStore stateStore)
     {
         app.Lifetime.ApplicationStarted.Register(() =>
         {
             try
             {
-                Write(startup);
+                var collector = app.Services.GetRequiredService<StartupNoticeCollector>();
+                var notices = collector.Snapshot();
+                Console.Out.WriteLine("Ready");
+                Write(
+                    startup,
+                    notices,
+                    ResolveKnownConfigPath(launchOptions, stateStore));
+                collector.EnableLiveOutput(
+                    Console.Out,
+                    LiveNoticeWindow,
+                    headerAlreadyWritten: notices.Count > 0);
             }
             catch (Exception ex)
             {
                 app.Logger.LogWarning(ex, "Failed to write startup readiness message.");
             }
+
+            if (localSession is not null && launchOptions.CanPrompt)
+            {
+                _ = Task.Run(() => LocalStartupPostReadyActions.RunAsync(
+                    startup,
+                    launchOptions,
+                    localSession,
+                    stateStore,
+                    app.Logger,
+                    app.Lifetime.ApplicationStopping));
+            }
         });
     }
 
-    internal static void Write(GatewayStartupContext startup, TextWriter? output = null)
+    internal static void Write(
+        GatewayStartupContext startup,
+        IReadOnlyList<StartupNoticeSnapshot>? notices = null,
+        string? knownConfigPath = null,
+        TextWriter? output = null)
     {
         var writer = output ?? Console.Out;
-        writer.WriteLine(Render(startup));
+        writer.WriteLine(Render(startup, notices, knownConfigPath));
         writer.Flush();
     }
 
-    internal static string Render(GatewayStartupContext startup)
+    internal static string Render(
+        GatewayStartupContext startup,
+        IReadOnlyList<StartupNoticeSnapshot>? notices = null,
+        string? knownConfigPath = null)
     {
         var bindAddress = FormatHostForUri(startup.Config.BindAddress);
         var sb = new StringBuilder();
@@ -51,6 +87,31 @@ internal static class StartupReadyReporter
         sb.AppendLine($"Health: {httpBase}/health");
         sb.AppendLine($"MCP: {httpBase}/mcp");
         sb.AppendLine($"WebSocket: {wsBase}/ws");
+        sb.AppendLine("Ctrl-C to stop");
+
+        if (notices is not null && notices.Count > 0)
+        {
+            sb.AppendLine("Started with notices:");
+            foreach (var notice in notices)
+            {
+                sb.Append("- ");
+                sb.Append(notice.Message);
+                if (notice.Count > 1)
+                    sb.Append($" (x{notice.Count})");
+                sb.AppendLine();
+            }
+        }
+
+        sb.AppendLine("Next useful commands:");
+        if (!string.IsNullOrWhiteSpace(knownConfigPath))
+        {
+            sb.AppendLine($"- openclaw setup verify --config {GatewaySetupPaths.QuoteIfNeeded(knownConfigPath)}");
+        }
+        else
+        {
+            sb.AppendLine("- dotnet run --project src/OpenClaw.Gateway -c Release -- --doctor");
+            sb.AppendLine("- openclaw models doctor");
+        }
 
         return sb.ToString().TrimEnd();
     }
@@ -83,4 +144,7 @@ internal static class StartupReadyReporter
 
         return bindAddress;
     }
+
+    private static string? ResolveKnownConfigPath(StartupLaunchOptions launchOptions, LocalStartupStateStore stateStore)
+        => launchOptions.ExternalConfigPath ?? stateStore.Load().LastSavedConfigPath;
 }

--- a/src/OpenClaw.Gateway/Program.cs
+++ b/src/OpenClaw.Gateway/Program.cs
@@ -14,11 +14,33 @@ using OpenClaw.MicrosoftAgentFrameworkAdapter;
 using OpenClawNet.Sandbox.OpenSandbox;
 #endif
 
+var launchOptions = StartupLaunchOptions.Parse(args);
 var environmentName = Environments.Production;
-var isDoctorMode = args.Any(a => string.Equals(a, "--doctor", StringComparison.Ordinal));
-var isHealthCheckMode = args.Any(a => string.Equals(a, "--health-check", StringComparison.Ordinal));
 var currentDirectory = Directory.GetCurrentDirectory();
 var recoveryAttempted = false;
+var startupConsole = new StartupConsoleCoordinator();
+var stateStore = new LocalStartupStateStore();
+LocalStartupSession? localSession = null;
+
+var quickstartValidationError = launchOptions.ValidateQuickstart();
+if (!string.IsNullOrWhiteSpace(quickstartValidationError))
+{
+    Console.Error.WriteLine(quickstartValidationError);
+    Environment.ExitCode = 2;
+    return;
+}
+
+if (launchOptions.IsQuickstartRequested)
+{
+    var quickstart = InteractiveStartupRecovery.TryQuickstart(currentDirectory, stateStore);
+    if (quickstart.Result != StartupRecoveryResult.Recovered || quickstart.Session is null)
+    {
+        Environment.ExitCode = quickstart.Result == StartupRecoveryResult.NotHandled ? 2 : 1;
+        return;
+    }
+
+    localSession = quickstart.Session;
+}
 
 while (true)
 {
@@ -27,10 +49,11 @@ while (true)
 
     try
     {
-        var builder = WebApplication.CreateSlimBuilder(args);
+        startupConsole.WritePhase("Loading configuration");
+        var builder = WebApplication.CreateSlimBuilder(launchOptions.EffectiveArgs);
         environmentName = builder.Environment.EnvironmentName;
 
-        var bootstrap = await builder.AddOpenClawBootstrapAsync(args);
+        var bootstrap = await builder.AddOpenClawBootstrapAsync(launchOptions.EffectiveArgs);
         if (bootstrap.ShouldExit)
         {
             Environment.ExitCode = bootstrap.ExitCode;
@@ -40,6 +63,8 @@ while (true)
         startup = bootstrap.Startup
             ?? throw new InvalidOperationException("Bootstrap completed without a startup context.");
 
+        startupConsole.WriteConfigurationSummary(builder.Configuration, environmentName, localSession);
+        startupConsole.WritePhase("Building services");
         builder.Services.AddOpenApi("openclaw-integration");
         builder.AddOpenClawObservability();
         builder.Services.AddOpenClawCoreServices(startup);
@@ -59,6 +84,7 @@ while (true)
 
         await using var app = builder.Build();
         app.Lifetime.ApplicationStarted.Register(() => started = true);
+        startupConsole.WritePhase("Initializing runtime");
         app.UseTickerQ();
         var runtime = await app.InitializeOpenClawRuntimeAsync(startup);
 
@@ -68,7 +94,7 @@ while (true)
         app.UseOpenClawA2AAuth(startup, runtime);
 #endif
 
-        app.UseOpenClawPipeline(startup, runtime);
+        app.UseOpenClawPipeline(startup, runtime, launchOptions, localSession, stateStore);
         app.MapOpenApi("/openapi/{documentName}.json");
         app.MapOpenClawEndpoints(startup, runtime);
         app.MapMcp("/mcp");
@@ -76,6 +102,7 @@ while (true)
         app.MapOpenClawA2AEndpoints(startup, runtime);
 #endif
 
+        startupConsole.WritePhase("Starting listener");
         await app.RunAsync($"http://{startup.Config.BindAddress}:{startup.Config.Port}");
         return;
     }
@@ -86,16 +113,19 @@ while (true)
             startup,
             environmentName,
             currentDirectory,
-            canPrompt: !recoveryAttempted && !isDoctorMode && !isHealthCheckMode);
+            canPrompt: !recoveryAttempted && launchOptions.CanPrompt && !launchOptions.IsDoctorMode && !launchOptions.IsHealthCheckMode,
+            stateStore,
+            suggestQuickstart: launchOptions.ShouldSuggestQuickstart);
 
-        if (recovery == StartupRecoveryResult.Recovered)
+        if (recovery.Result == StartupRecoveryResult.Recovered && recovery.Session is not null)
         {
+            localSession = recovery.Session;
             recoveryAttempted = true;
             continue;
         }
 
-        if (recovery == StartupRecoveryResult.NotHandled)
-            StartupFailureReporter.Write(ex, startup, environmentName, isDoctorMode);
+        if (recovery.Result == StartupRecoveryResult.NotHandled)
+            StartupFailureReporter.Write(ex, startup, environmentName, launchOptions.IsDoctorMode, launchOptions.ShouldSuggestQuickstart);
 
         Environment.ExitCode = 1;
         return;

--- a/src/OpenClaw.Tests/GatewayLlmExecutionServiceTests.cs
+++ b/src/OpenClaw.Tests/GatewayLlmExecutionServiceTests.cs
@@ -1,0 +1,47 @@
+using OpenClaw.Gateway;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class GatewayLlmExecutionServiceTests
+{
+    [Fact]
+    public void ClassifyProviderFailure_InvalidApiKey_SanitizesMessage()
+    {
+        var classification = GatewayLlmExecutionService.ClassifyProviderFailure(
+            new InvalidOperationException("HTTP 401 (invalid_request_error: invalid_api_key) Incorrect API key provided."),
+            "openai");
+
+        Assert.NotNull(classification);
+        Assert.Equal("invalid-key", classification!.Code);
+        Assert.Contains("OpenAI credentials were rejected.", classification.UserMessage, StringComparison.Ordinal);
+        Assert.Contains("MODEL_PROVIDER_KEY or OPENAI_API_KEY", classification.OperatorMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain("invalid_request_error", classification.UserMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ClassifyProviderFailure_MissingEndpoint_HasActionableGuidance()
+    {
+        var classification = GatewayLlmExecutionService.ClassifyProviderFailure(
+            new InvalidOperationException("Endpoint must be set for provider 'azure-openai'."),
+            "azure-openai");
+
+        Assert.NotNull(classification);
+        Assert.Equal("missing-endpoint", classification!.Code);
+        Assert.Contains("MODEL_PROVIDER_ENDPOINT", classification.UserMessage, StringComparison.Ordinal);
+        Assert.Contains("OpenClaw:Llm:Endpoint", classification.OperatorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ClassifyProviderFailure_UnsupportedProvider_SanitizesMessage()
+    {
+        var classification = GatewayLlmExecutionService.ClassifyProviderFailure(
+            new InvalidOperationException("Unsupported LLM provider: custom-provider"),
+            "custom-provider");
+
+        Assert.NotNull(classification);
+        Assert.Equal("unsupported-provider", classification!.Code);
+        Assert.Contains("OpenClaw:Llm:Provider", classification.UserMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain("Unsupported LLM provider: custom-provider", classification.UserMessage, StringComparison.Ordinal);
+    }
+}

--- a/src/OpenClaw.Tests/GatewaySetupArtifactsTests.cs
+++ b/src/OpenClaw.Tests/GatewaySetupArtifactsTests.cs
@@ -1,0 +1,48 @@
+using OpenClaw.Core.Setup;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class GatewaySetupArtifactsTests
+{
+    [Fact]
+    public void BuildEnvExample_MatchesCliFormat()
+    {
+        var text = GatewaySetupArtifacts.BuildEnvExample(
+            apiKeyRef: "env:OPENAI_API_KEY",
+            authToken: "oc_test_token",
+            workspacePath: "/tmp/workspace",
+            baseUrl: "http://127.0.0.1:18789");
+
+        Assert.Equal(
+            "OPENAI_API_KEY=replace-me" + Environment.NewLine +
+            "OPENCLAW_AUTH_TOKEN=oc_test_token" + Environment.NewLine +
+            "OPENCLAW_BASE_URL=http://127.0.0.1:18789" + Environment.NewLine +
+            "OPENCLAW_WORKSPACE=/tmp/workspace" + Environment.NewLine,
+            text);
+    }
+
+    [Fact]
+    public void CreateProfileConfig_PublicProfileKeepsExistingHardenedDefaults()
+    {
+        var warnings = new List<string>();
+        var config = GatewaySetupProfileFactory.CreateProfileConfig(
+            profile: "public",
+            bindAddress: "0.0.0.0",
+            port: 18789,
+            authToken: "oc_test",
+            workspacePath: "/tmp/workspace",
+            memoryPath: "/tmp/memory",
+            provider: "openai",
+            model: "gpt-4o",
+            apiKey: "env:OPENAI_API_KEY",
+            warnings: warnings);
+
+        Assert.False(config.Tooling.AllowShell);
+        Assert.True(config.Tooling.RequireToolApproval);
+        Assert.True(config.Security.TrustForwardedHeaders);
+        Assert.True(config.Security.RequireRequesterMatchForHttpToolApproval);
+        Assert.False(config.Plugins.Enabled);
+        Assert.Contains(warnings, warning => warning.Contains("Public profile disables third-party bridge plugins", StringComparison.Ordinal));
+    }
+}

--- a/src/OpenClaw.Tests/InteractiveStartupRecoveryTests.cs
+++ b/src/OpenClaw.Tests/InteractiveStartupRecoveryTests.cs
@@ -17,16 +17,9 @@ public sealed class InteractiveStartupRecoveryTests
             config.Llm.Model = "gpt-4o";
         });
 
-        var root = Path.Combine(Path.GetTempPath(), "openclaw-recovery-tests", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(root);
-        var previousModelProviderKey = Environment.GetEnvironmentVariable("MODEL_PROVIDER_KEY");
-        var previousEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-        var previousWorkspace = Environment.GetEnvironmentVariable("OPENCLAW_WORKSPACE");
-        var previousBind = Environment.GetEnvironmentVariable("OpenClaw__BindAddress");
-        var previousPort = Environment.GetEnvironmentVariable("OpenClaw__Port");
-        var previousMemoryProvider = Environment.GetEnvironmentVariable("OpenClaw__Memory__Provider");
-        var previousMemoryPath = Environment.GetEnvironmentVariable("OpenClaw__Memory__StoragePath");
-        var previousRetention = Environment.GetEnvironmentVariable("OpenClaw__Memory__Retention__Enabled");
+        var root = CreateTempRoot();
+        var stateStore = new LocalStartupStateStore(Path.Combine(root, "state.json"));
+        var previous = CaptureEnvironment();
 
         try
         {
@@ -40,10 +33,14 @@ public sealed class InteractiveStartupRecoveryTests
                 environmentName: "Production",
                 currentDirectory: root,
                 canPrompt: true,
+                stateStore: stateStore,
+                suggestQuickstart: true,
                 input: input,
                 output: output);
 
-            Assert.Equal(StartupRecoveryResult.Recovered, result);
+            Assert.Equal(StartupRecoveryResult.Recovered, result.Result);
+            Assert.NotNull(result.Session);
+            Assert.Equal("recovery", result.Session!.Mode);
             Assert.Equal("Development", Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
             Assert.Equal("127.0.0.1", Environment.GetEnvironmentVariable("OpenClaw__BindAddress"));
             Assert.Equal("18789", Environment.GetEnvironmentVariable("OpenClaw__Port"));
@@ -51,17 +48,54 @@ public sealed class InteractiveStartupRecoveryTests
             Assert.Equal(Path.Combine(root, "memory"), Environment.GetEnvironmentVariable("OpenClaw__Memory__StoragePath"));
             Assert.Equal("false", Environment.GetEnvironmentVariable("OpenClaw__Memory__Retention__Enabled"));
             Assert.Equal(root, Environment.GetEnvironmentVariable("OPENCLAW_WORKSPACE"));
+            Assert.Contains("--quickstart", output.ToString(), StringComparison.Ordinal);
         }
         finally
         {
-            Environment.SetEnvironmentVariable("MODEL_PROVIDER_KEY", previousModelProviderKey);
-            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousEnvironment);
-            Environment.SetEnvironmentVariable("OPENCLAW_WORKSPACE", previousWorkspace);
-            Environment.SetEnvironmentVariable("OpenClaw__BindAddress", previousBind);
-            Environment.SetEnvironmentVariable("OpenClaw__Port", previousPort);
-            Environment.SetEnvironmentVariable("OpenClaw__Memory__Provider", previousMemoryProvider);
-            Environment.SetEnvironmentVariable("OpenClaw__Memory__StoragePath", previousMemoryPath);
-            Environment.SetEnvironmentVariable("OpenClaw__Memory__Retention__Enabled", previousRetention);
+            RestoreEnvironment(previous);
+            DeleteDirectoryBestEffort(root);
+        }
+    }
+
+    [Fact]
+    public void TryRecover_PortConflict_OffersNextPortAndUsesIt()
+    {
+        var startup = CreateStartupContext(config =>
+        {
+            config.BindAddress = "127.0.0.1";
+            config.Port = 18789;
+            config.Llm.Provider = "openai";
+            config.Llm.Model = "gpt-4o";
+        });
+
+        var root = CreateTempRoot();
+        var stateStore = new LocalStartupStateStore(Path.Combine(root, "state.json"));
+        var previous = CaptureEnvironment();
+
+        try
+        {
+            Environment.SetEnvironmentVariable("MODEL_PROVIDER_KEY", "test-key");
+            var input = new StringReader("y\ny\n\n\n\n");
+            using var output = new StringWriter();
+
+            var result = InteractiveStartupRecovery.TryRecover(
+                new IOException("address already in use"),
+                startup,
+                environmentName: "Development",
+                currentDirectory: root,
+                canPrompt: true,
+                stateStore: stateStore,
+                suggestQuickstart: false,
+                input: input,
+                output: output);
+
+            Assert.Equal(StartupRecoveryResult.Recovered, result.Result);
+            Assert.Equal("18790", Environment.GetEnvironmentVariable("OpenClaw__Port"));
+            Assert.Contains("Port 18789 is busy. Use 18790 instead?", output.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            RestoreEnvironment(previous);
             DeleteDirectoryBestEffort(root);
         }
     }
@@ -75,10 +109,9 @@ public sealed class InteractiveStartupRecoveryTests
             config.Llm.Model = "gpt-4o";
         });
 
-        var root = Path.Combine(Path.GetTempPath(), "openclaw-recovery-tests", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(root);
-        var previousModelProviderKey = Environment.GetEnvironmentVariable("MODEL_PROVIDER_KEY");
-        var previousOpenAiApiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        var root = CreateTempRoot();
+        var stateStore = new LocalStartupStateStore(Path.Combine(root, "state.json"));
+        var previous = CaptureEnvironment();
 
         try
         {
@@ -94,19 +127,94 @@ public sealed class InteractiveStartupRecoveryTests
                 environmentName: "Development",
                 currentDirectory: root,
                 canPrompt: true,
+                stateStore: stateStore,
+                suggestQuickstart: false,
                 input: input,
                 output: output);
 
-            Assert.Equal(StartupRecoveryResult.Recovered, result);
+            Assert.Equal(StartupRecoveryResult.Recovered, result.Result);
+            Assert.Equal("env:OPENAI_API_KEY", result.Session!.ApiKeyReference);
             Assert.Equal("sk-test-from-openai-env", Environment.GetEnvironmentVariable("MODEL_PROVIDER_KEY"));
             Assert.Contains("Using OPENAI_API_KEY from the current environment", output.ToString(), StringComparison.Ordinal);
         }
         finally
         {
-            Environment.SetEnvironmentVariable("MODEL_PROVIDER_KEY", previousModelProviderKey);
-            Environment.SetEnvironmentVariable("OPENAI_API_KEY", previousOpenAiApiKey);
+            RestoreEnvironment(previous);
             DeleteDirectoryBestEffort(root);
         }
+    }
+
+    [Fact]
+    public void TryQuickstart_UsesRememberedDefaults()
+    {
+        var root = CreateTempRoot();
+        var stateStore = new LocalStartupStateStore(Path.Combine(root, "state.json"));
+        var previous = CaptureEnvironment();
+
+        try
+        {
+            Assert.True(stateStore.TrySave(new LocalStartupState
+            {
+                WorkspacePath = Path.Combine(root, "remembered-workspace"),
+                MemoryPath = Path.Combine(root, "remembered-memory"),
+                Port = 18888,
+                Provider = "openai",
+                Model = "gpt-4.1",
+                BrowserPromptShown = false
+            }, out var saveError), saveError);
+
+            Environment.SetEnvironmentVariable("OPENAI_API_KEY", "sk-remembered");
+            Environment.SetEnvironmentVariable("MODEL_PROVIDER_KEY", null);
+            using var output = new StringWriter();
+
+            var result = InteractiveStartupRecovery.TryQuickstart(
+                currentDirectory: root,
+                stateStore: stateStore,
+                input: new StringReader(string.Empty),
+                output: output);
+
+            Assert.Equal(StartupRecoveryResult.Recovered, result.Result);
+            Assert.Equal("quickstart", result.Session!.Mode);
+            Assert.Equal(Path.Combine(root, "remembered-workspace"), result.Session.WorkspacePath);
+            Assert.Equal(Path.Combine(root, "remembered-memory"), result.Session.MemoryPath);
+            Assert.Equal(18888, result.Session.Port);
+            Assert.Equal("gpt-4.1", result.Session.Model);
+            Assert.Equal("env:OPENAI_API_KEY", result.Session.ApiKeyReference);
+            Assert.Equal("18888", Environment.GetEnvironmentVariable("OpenClaw__Port"));
+        }
+        finally
+        {
+            RestoreEnvironment(previous);
+            DeleteDirectoryBestEffort(root);
+        }
+    }
+
+    private static Dictionary<string, string?> CaptureEnvironment()
+        => new()
+        {
+            ["MODEL_PROVIDER_KEY"] = Environment.GetEnvironmentVariable("MODEL_PROVIDER_KEY"),
+            ["OPENAI_API_KEY"] = Environment.GetEnvironmentVariable("OPENAI_API_KEY"),
+            ["ASPNETCORE_ENVIRONMENT"] = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"),
+            ["OPENCLAW_WORKSPACE"] = Environment.GetEnvironmentVariable("OPENCLAW_WORKSPACE"),
+            ["OpenClaw__BindAddress"] = Environment.GetEnvironmentVariable("OpenClaw__BindAddress"),
+            ["OpenClaw__Port"] = Environment.GetEnvironmentVariable("OpenClaw__Port"),
+            ["OpenClaw__Memory__Provider"] = Environment.GetEnvironmentVariable("OpenClaw__Memory__Provider"),
+            ["OpenClaw__Memory__StoragePath"] = Environment.GetEnvironmentVariable("OpenClaw__Memory__StoragePath"),
+            ["OpenClaw__Memory__Retention__Enabled"] = Environment.GetEnvironmentVariable("OpenClaw__Memory__Retention__Enabled"),
+            ["MODEL_PROVIDER_ENDPOINT"] = Environment.GetEnvironmentVariable("MODEL_PROVIDER_ENDPOINT")
+        };
+
+    private static void RestoreEnvironment(IReadOnlyDictionary<string, string?> snapshot)
+    {
+        foreach (var (key, value) in snapshot)
+            Environment.SetEnvironmentVariable(key, value);
+    }
+
+    private static string CreateTempRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "openclaw-recovery-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
     }
 
     private static void DeleteDirectoryBestEffort(string path)

--- a/src/OpenClaw.Tests/LocalStartupPostReadyActionsTests.cs
+++ b/src/OpenClaw.Tests/LocalStartupPostReadyActionsTests.cs
@@ -1,0 +1,189 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenClaw.Core.Models;
+using OpenClaw.Gateway.Bootstrap;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class LocalStartupPostReadyActionsTests
+{
+    [Fact]
+    public async Task RunAsync_SaveAccepted_WritesConfigAndEnvExampleAndMarksPromptShown()
+    {
+        var root = CreateTempRoot();
+        var savePath = Path.Combine(root, "config", "openclaw.settings.json");
+        var stateStore = new LocalStartupStateStore(Path.Combine(root, "state.json"));
+        var startup = CreateStartupContext();
+        var session = CreateLocalSession();
+        var browserOpenCount = 0;
+        var previousConfigPath = Environment.GetEnvironmentVariable("OPENCLAW_CONFIG_PATH");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("OPENCLAW_CONFIG_PATH", null);
+            var launchOptions = StartupLaunchOptions.Parse([]);
+            using var output = new StringWriter();
+            await LocalStartupPostReadyActions.RunAsync(
+                startup,
+                launchOptions,
+                session,
+                stateStore,
+                NullLogger.Instance,
+                CancellationToken.None,
+                input: new StringReader("n\ny\n"),
+                output: output,
+                openBrowser: _ => browserOpenCount++,
+                saveConfigPathOverride: savePath);
+
+            Assert.Equal(0, browserOpenCount);
+            Assert.True(File.Exists(savePath));
+            Assert.True(File.Exists(Path.Combine(root, "config", "openclaw.settings.env.example")));
+
+            var state = stateStore.Load();
+            Assert.True(state.BrowserPromptShown);
+            Assert.Equal(savePath, state.LastSavedConfigPath);
+
+            using var document = JsonDocument.Parse(await File.ReadAllTextAsync(savePath));
+            var llm = document.RootElement.GetProperty("OpenClaw").GetProperty("llm");
+            Assert.Equal("env:OPENAI_API_KEY", llm.GetProperty("apiKey").GetString());
+
+            var envExample = await File.ReadAllTextAsync(Path.Combine(root, "config", "openclaw.settings.env.example"));
+            Assert.Contains("OPENAI_API_KEY=replace-me", envExample, StringComparison.Ordinal);
+            Assert.Contains("OPENCLAW_WORKSPACE=/tmp/workspace", envExample, StringComparison.Ordinal);
+            Assert.Contains("Saved config:", output.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OPENCLAW_CONFIG_PATH", previousConfigPath);
+            DeleteDirectoryBestEffort(root);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_SaveDeclined_DoesNotWriteConfig()
+    {
+        var root = CreateTempRoot();
+        var savePath = Path.Combine(root, "config", "openclaw.settings.json");
+        var stateStore = new LocalStartupStateStore(Path.Combine(root, "state.json"));
+        var previousConfigPath = Environment.GetEnvironmentVariable("OPENCLAW_CONFIG_PATH");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("OPENCLAW_CONFIG_PATH", null);
+            await LocalStartupPostReadyActions.RunAsync(
+                CreateStartupContext(),
+                StartupLaunchOptions.Parse([]),
+                CreateLocalSession(),
+                stateStore,
+                NullLogger.Instance,
+                CancellationToken.None,
+                input: new StringReader("n\nn\n"),
+                output: new StringWriter(),
+                openBrowser: _ => { },
+                saveConfigPathOverride: savePath);
+
+            Assert.False(File.Exists(savePath));
+            Assert.True(stateStore.Load().BrowserPromptShown);
+            Assert.Null(stateStore.Load().LastSavedConfigPath);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OPENCLAW_CONFIG_PATH", previousConfigPath);
+            DeleteDirectoryBestEffort(root);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_BrowserPromptIsOnlyShownOnce()
+    {
+        var root = CreateTempRoot();
+        var stateStore = new LocalStartupStateStore(Path.Combine(root, "state.json"));
+        var previousConfigPath = Environment.GetEnvironmentVariable("OPENCLAW_CONFIG_PATH");
+        Assert.True(stateStore.TrySave(new LocalStartupState
+        {
+            WorkspacePath = "/tmp/workspace",
+            MemoryPath = "/tmp/memory",
+            Port = 18789,
+            Provider = "openai",
+            Model = "gpt-4o",
+            BrowserPromptShown = true
+        }, out var saveError), saveError);
+        var browserOpenCount = 0;
+
+        try
+        {
+            Environment.SetEnvironmentVariable("OPENCLAW_CONFIG_PATH", null);
+            await LocalStartupPostReadyActions.RunAsync(
+                CreateStartupContext(),
+                StartupLaunchOptions.Parse(["--config", "./existing.json"]),
+                CreateLocalSession(),
+                stateStore,
+                NullLogger.Instance,
+                CancellationToken.None,
+                input: new StringReader(string.Empty),
+                output: new StringWriter(),
+                openBrowser: _ => browserOpenCount++);
+
+            Assert.Equal(0, browserOpenCount);
+            Assert.True(stateStore.Load().BrowserPromptShown);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OPENCLAW_CONFIG_PATH", previousConfigPath);
+            DeleteDirectoryBestEffort(root);
+        }
+    }
+
+    private static GatewayStartupContext CreateStartupContext()
+        => new()
+        {
+            Config = new GatewayConfig
+            {
+                Llm = new LlmProviderConfig
+                {
+                    Provider = "openai",
+                    Model = "gpt-4o"
+                }
+            },
+            RuntimeState = new GatewayRuntimeState
+            {
+                RequestedMode = "auto",
+                EffectiveMode = GatewayRuntimeMode.Aot,
+                DynamicCodeSupported = false
+            },
+            IsNonLoopbackBind = false
+        };
+
+    private static LocalStartupSession CreateLocalSession()
+        => new(
+            Mode: "quickstart",
+            WorkspacePath: "/tmp/workspace",
+            MemoryPath: "/tmp/memory",
+            Port: 18789,
+            Provider: "openai",
+            Model: "gpt-4o",
+            ApiKeyReference: "env:OPENAI_API_KEY",
+            Endpoint: null);
+
+    private static string CreateTempRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "openclaw-post-ready-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static void DeleteDirectoryBestEffort(string path)
+    {
+        if (!Directory.Exists(path))
+            return;
+
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/src/OpenClaw.Tests/StartupConsoleCoordinatorTests.cs
+++ b/src/OpenClaw.Tests/StartupConsoleCoordinatorTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Configuration;
+using OpenClaw.Gateway.Bootstrap;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class StartupConsoleCoordinatorTests
+{
+    [Fact]
+    public void WriteConfigurationSummary_IncludesEnvironmentSourcesAndSessionOverrides()
+    {
+        var configuration = new ConfigurationManager();
+        configuration.AddJsonFile("appsettings.json", optional: true);
+        configuration.AddJsonFile("appsettings.Production.json", optional: true);
+        configuration.AddJsonFile("custom/openclaw.settings.json", optional: true);
+        var coordinator = new StartupConsoleCoordinator();
+        var session = new LocalStartupSession(
+            Mode: "quickstart",
+            WorkspacePath: "/tmp/workspace",
+            MemoryPath: "/tmp/memory",
+            Port: 18789,
+            Provider: "openai",
+            Model: "gpt-4o",
+            ApiKeyReference: "env:OPENAI_API_KEY",
+            Endpoint: null);
+
+        using var output = new StringWriter();
+        coordinator.WriteConfigurationSummary(configuration, "Production", session, output);
+
+        var text = output.ToString();
+        Assert.Contains("Startup environment: Production", text, StringComparison.Ordinal);
+        Assert.Contains("- appsettings.json", text, StringComparison.Ordinal);
+        Assert.Contains("- appsettings.Production.json", text, StringComparison.Ordinal);
+        Assert.Contains("- custom/openclaw.settings.json", text, StringComparison.Ordinal);
+        Assert.Contains("- Session-only overrides: active (quickstart)", text, StringComparison.Ordinal);
+    }
+}

--- a/src/OpenClaw.Tests/StartupLaunchOptionsTests.cs
+++ b/src/OpenClaw.Tests/StartupLaunchOptionsTests.cs
@@ -1,0 +1,49 @@
+using OpenClaw.Gateway.Bootstrap;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class StartupLaunchOptionsTests
+{
+    [Fact]
+    public void ValidateQuickstart_RejectsDoctorMode()
+    {
+        var options = StartupLaunchOptions.Parse(["--quickstart", "--doctor"]);
+
+        Assert.Equal("--quickstart cannot be combined with --doctor.", options.ValidateQuickstart());
+    }
+
+    [Fact]
+    public void ValidateQuickstart_RejectsHealthCheckMode()
+    {
+        var options = StartupLaunchOptions.Parse(["--quickstart", "--health-check"]);
+
+        Assert.Equal("--quickstart cannot be combined with --health-check.", options.ValidateQuickstart());
+    }
+
+    [Fact]
+    public void ValidateQuickstart_RejectsExplicitConfigArgument()
+    {
+        var options = StartupLaunchOptions.Parse(["--quickstart", "--config", "./openclaw.settings.json"]);
+
+        Assert.Equal("--quickstart cannot be combined with --config.", options.ValidateQuickstart());
+    }
+
+    [Fact]
+    public void ValidateQuickstart_RejectsEnvironmentConfigOverride()
+    {
+        var previous = Environment.GetEnvironmentVariable("OPENCLAW_CONFIG_PATH");
+        try
+        {
+            Environment.SetEnvironmentVariable("OPENCLAW_CONFIG_PATH", "./openclaw.settings.json");
+
+            var options = StartupLaunchOptions.Parse(["--quickstart"]);
+
+            Assert.Equal("--quickstart cannot be used while OPENCLAW_CONFIG_PATH is set.", options.ValidateQuickstart());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OPENCLAW_CONFIG_PATH", previous);
+        }
+    }
+}

--- a/src/OpenClaw.Tests/StartupLaunchOptionsTests.cs
+++ b/src/OpenClaw.Tests/StartupLaunchOptionsTests.cs
@@ -30,6 +30,22 @@ public sealed class StartupLaunchOptionsTests
     }
 
     [Fact]
+    public void ValidateQuickstart_RejectsConfigFlagWithoutValue()
+    {
+        var options = StartupLaunchOptions.Parse(["--quickstart", "--config"]);
+
+        Assert.Equal("--quickstart cannot be combined with --config.", options.ValidateQuickstart());
+    }
+
+    [Fact]
+    public void ValidateQuickstart_RejectsEmptyConfigAssignment()
+    {
+        var options = StartupLaunchOptions.Parse(["--quickstart", "--config="]);
+
+        Assert.Equal("--quickstart cannot be combined with --config.", options.ValidateQuickstart());
+    }
+
+    [Fact]
     public void ValidateQuickstart_RejectsEnvironmentConfigOverride()
     {
         var previous = Environment.GetEnvironmentVariable("OPENCLAW_CONFIG_PATH");

--- a/src/OpenClaw.Tests/StartupReadyReporterTests.cs
+++ b/src/OpenClaw.Tests/StartupReadyReporterTests.cs
@@ -20,6 +20,9 @@ public sealed class StartupReadyReporterTests
         Assert.Contains("Admin UI: http://localhost:18789/admin", text, StringComparison.Ordinal);
         Assert.Contains("Doctor: http://localhost:18789/doctor/text", text, StringComparison.Ordinal);
         Assert.Contains("WebSocket: ws://localhost:18789/ws", text, StringComparison.Ordinal);
+        Assert.Contains("Ctrl-C to stop", text, StringComparison.Ordinal);
+        Assert.Contains("Next useful commands:", text, StringComparison.Ordinal);
+        Assert.Contains("openclaw models doctor", text, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -44,6 +47,28 @@ public sealed class StartupReadyReporterTests
         Assert.Contains("Listening on http://192.168.1.25:18789", text, StringComparison.Ordinal);
         Assert.Contains("Chat UI: http://192.168.1.25:18789/chat", text, StringComparison.Ordinal);
         Assert.Contains("Health: http://192.168.1.25:18789/health", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_IncludesStartupNoticesAndPersistedConfigCommand()
+    {
+        var startup = CreateStartupContext(config => config.BindAddress = "127.0.0.1");
+
+        var text = StartupReadyReporter.Render(
+            startup,
+            notices:
+            [
+                new StartupNoticeSnapshot("Disabled: browser tool is unavailable because no execution backend or sandbox route is configured.", 1),
+                new StartupNoticeSnapshot("Background job 'hourly-news-digest' is still running from an earlier trigger; this tick was skipped.", 2)
+            ],
+            knownConfigPath: "/Users/test/.openclaw/config/openclaw.settings.json");
+
+        Assert.Contains("Started with notices:", text, StringComparison.Ordinal);
+        Assert.Contains("Disabled: browser tool is unavailable", text, StringComparison.Ordinal);
+        Assert.Contains("Background job 'hourly-news-digest'", text, StringComparison.Ordinal);
+        Assert.Contains("(x2)", text, StringComparison.Ordinal);
+        Assert.Contains("openclaw setup verify --config /Users/test/.openclaw/config/openclaw.settings.json", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("openclaw models doctor", text, StringComparison.Ordinal);
     }
 
     private static GatewayStartupContext CreateStartupContext(Action<GatewayConfig>? configure = null)


### PR DESCRIPTION
## Summary
- overhaul local terminal startup so successful starts are explicit and common startup failures recover with guided local prompts instead of raw unhandled exceptions
- add gateway-side `--quickstart`, remembered non-secret local startup state, startup notices, and post-ready save/browser prompts for local loopback launches
- extract shared setup/config helpers into `OpenClaw.Core` and update docs/help text to match the new startup and recovery flow

## Why
Local first-run startup had several sharp edges:
- successful startup could look like a failure because warnings were the only visible terminal output
- common misconfigurations like missing provider config, public-bind auth requirements, read-only storage, and port conflicts surfaced as raw exception text
- direct gateway startup from a repo checkout had no short, supported path comparable to `openclaw setup launch`

## Impact
- local interactive startup now prints phases, a ready banner, explicit URLs, `Ctrl-C to stop`, and non-fatal notices under `Started with notices:`
- `--quickstart` provides a direct gateway bootstrap path for local terminal use and can save the working setup to `~/.openclaw/config/openclaw.settings.json`
- request-time provider credential/config failures now return sanitized user-facing messages and one-time operator guidance instead of leaking raw upstream error text
- the README, quickstart docs, getting-started guide, user guide, CLI help, and startup architecture doc now document the new behavior

## Validation
- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj --filter "SetupCommandTests|ChannelSetupCommandTests|StartupFailureReporterTests|StartupReadyReporterTests|InteractiveStartupRecoveryTests|GatewayBootstrapExtensionsTests|StartupConsoleCoordinatorTests|StartupLaunchOptionsTests|GatewaySetupArtifactsTests|LocalStartupPostReadyActionsTests|GatewayLlmExecutionServiceTests"`
