### PR TITLE
Add primary start flow and upgrade preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ git clone https://github.com/clawdotnet/openclaw.net
 cd openclaw.net
 
 export MODEL_PROVIDER_KEY="sk-..."
-dotnet run --project src/OpenClaw.Cli -c Release -- setup
-dotnet run --project src/OpenClaw.Cli -c Release -- setup launch --config ~/.openclaw/config/openclaw.settings.json
+dotnet run --project src/OpenClaw.Cli -c Release -- start
 ```
 
 When the gateway finishes startup it now prints explicit phase markers, a final `OpenClaw gateway ready.` block, the localhost URLs, `Ctrl-C to stop`, and any non-fatal startup notices under `Started with notices:`. Then open:
@@ -56,10 +55,12 @@ dotnet run --project src/OpenClaw.Gateway -c Release -- --quickstart
 If the CLI is already on your `PATH`, the same guided entrypoints are:
 
 ```bash
+openclaw start
 openclaw setup
 openclaw setup launch --config ~/.openclaw/config/openclaw.settings.json
 openclaw setup service --config ~/.openclaw/config/openclaw.settings.json --platform all
 openclaw setup status --config ~/.openclaw/config/openclaw.settings.json
+openclaw upgrade check --config ~/.openclaw/config/openclaw.settings.json
 ```
 
 Useful follow-up commands and surfaces:
@@ -67,6 +68,7 @@ Useful follow-up commands and surfaces:
 ```bash
 openclaw skills inspect ./skills/my-skill
 openclaw compatibility catalog
+openclaw upgrade check --config ~/.openclaw/config/openclaw.settings.json --offline
 openclaw migrate upstream --source ./upstream-agent --target-config ~/.openclaw/config/openclaw.settings.json
 ```
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -10,28 +10,22 @@ Follow this path end-to-end before branching into anything else. Ignore every "o
 
 **1. Install prerequisites.** .NET 10 SDK and Git. Nothing else is required for the first run.
 
-**2. Set a provider key and run setup.**
+**2. Set a provider key and run the primary start path.**
 
 ```bash
 export MODEL_PROVIDER_KEY="sk-..."
-dotnet run --project src/OpenClaw.Cli -c Release -- setup
+dotnet run --project src/OpenClaw.Cli -c Release -- start
 ```
 
-Accept the defaults. This writes `~/.openclaw/config/openclaw.settings.json`.
+Accept the defaults. If the config does not exist yet, `openclaw start` runs setup first, writes `~/.openclaw/config/openclaw.settings.json`, and then launches.
 
-**3. Launch the gateway.**
-
-```bash
-dotnet run --project src/OpenClaw.Cli -c Release -- setup launch --config ~/.openclaw/config/openclaw.settings.json
-```
+**3. Open the browser UI.**
 
 **Expected:** startup phase lines (`Loading configuration`, `Building services`, `Initializing runtime`, `Starting listener`) followed by an `OpenClaw gateway ready.` block listing the working URLs. If you see `Started with notices:`, the gateway is still up; those are non-fatal startup advisories. If you do not see the ready block, the gateway is not ready yet.
 
-**4. Open the browser UI.**
-
 Go to `http://127.0.0.1:18789/chat` (not `/`, not the root URL). You should see the chat interface. Send a message; you should get a reply.
 
-**5. If anything is wrong, run the doctor.**
+**4. If anything is wrong, run the doctor.**
 
 ```bash
 dotnet run --project src/OpenClaw.Gateway -c Release -- --config ~/.openclaw/config/openclaw.settings.json --doctor
@@ -70,6 +64,7 @@ For a first run from source, prefer the generated external config from `openclaw
 
 | Command | Use when |
 | --- | --- |
+| `openclaw start` | You want the one-command local path that uses an existing config if present or runs setup first and then launches. |
 | `openclaw setup` | You want the guided onboarding flow that writes config, prints launch commands, and gives you `--doctor` plus `admin posture` follow-ups. |
 | `dotnet run --project src/OpenClaw.Gateway -c Release -- --quickstart` | You want to start the gateway directly from a repo checkout and let the gateway recover into a safe local profile instead of preparing config first. |
 | `openclaw init` | You want raw bootstrap files to edit manually before running the gateway. |
@@ -82,14 +77,15 @@ For a first run from source, prefer the generated external config from `openclaw
 1. Run the guided setup flow:
 
 ```bash
-openclaw setup
+openclaw start
 ```
 
-2. Accept the local defaults or supply your preferred provider, model, API key reference, workspace path, and optional execution backend.
+2. Accept the local defaults or supply your preferred provider, model, API key reference, workspace path, and optional execution backend. If a config already exists, `openclaw start` skips setup and launches directly.
 
-3. Start the supported local launch runner for that config:
+3. If you want the explicit split flow instead of the one-command path, use:
 
 ```bash
+openclaw setup
 openclaw setup launch --config ~/.openclaw/config/openclaw.settings.json
 ```
 
@@ -109,6 +105,10 @@ dotnet run --project src/OpenClaw.Gateway -c Release -- --config ~/.openclaw/con
 
 ```bash
 OPENCLAW_BASE_URL=http://127.0.0.1:18789 OPENCLAW_AUTH_TOKEN=... openclaw admin posture
+```
+
+```bash
+openclaw upgrade check --config ~/.openclaw/config/openclaw.settings.json
 ```
 
 Default local endpoints:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -18,7 +18,7 @@ From a source checkout, use:
 dotnet run --project src/OpenClaw.Cli -c Release -- start
 ```
 
-Use `--profile public` when you are preparing a reverse-proxy or internet-facing deployment. The start/setup flow writes an external config file, a matching env example, and prints the exact gateway launch, `--doctor`, and `openclaw admin posture` commands for that config.
+Use `--profile public` when you are preparing a reverse-proxy or internet-facing deployment. If `openclaw start` finds an existing config, it reuses it; if it needs to run setup, the flow writes an external config file, a matching env example, and prints the exact gateway launch, `--doctor`, and `openclaw admin posture` commands for that config.
 
 Continue the supported bootstrap flow with:
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -9,23 +9,25 @@ Welcome to the **OpenClaw.NET** User Guide! This document will walk you through 
 Start with the guided setup path:
 
 ```bash
-openclaw setup
+openclaw start
 ```
 
 From a source checkout, use:
 
 ```bash
-dotnet run --project src/OpenClaw.Cli -c Release -- setup
+dotnet run --project src/OpenClaw.Cli -c Release -- start
 ```
 
-Use `--profile public` when you are preparing a reverse-proxy or internet-facing deployment. The setup flow writes an external config file, a matching env example, and prints the exact gateway launch, `--doctor`, and `openclaw admin posture` commands for that config.
+Use `--profile public` when you are preparing a reverse-proxy or internet-facing deployment. The start/setup flow writes an external config file, a matching env example, and prints the exact gateway launch, `--doctor`, and `openclaw admin posture` commands for that config.
 
 Continue the supported bootstrap flow with:
 
 ```bash
+openclaw start
 openclaw setup launch --config ~/.openclaw/config/openclaw.settings.json
 openclaw setup service --config ~/.openclaw/config/openclaw.settings.json --platform all
 openclaw setup status --config ~/.openclaw/config/openclaw.settings.json
+openclaw upgrade check --config ~/.openclaw/config/openclaw.settings.json
 ```
 
 If you start the gateway directly from a local terminal instead of using `setup launch`, the direct fallback is:
@@ -52,6 +54,7 @@ These wizards update the existing external config and keep the readiness and adm
 
 Important distinction:
 
+- `openclaw start` is the primary one-command local entrypoint
 - `openclaw setup` and `openclaw init` generate the supported onboarding configs
 - directly editing `src/OpenClaw.Gateway/appsettings.json` is a lower-level path and can expose optional features that are not part of the easiest first run
 - direct gateway startup now prints explicit startup phases and a ready banner with `/chat`, `/admin`, `/doctor/text`, `/health`, `/mcp`, and `/ws`

--- a/src/OpenClaw.Cli/Program.cs
+++ b/src/OpenClaw.Cli/Program.cs
@@ -23,11 +23,13 @@ internal static class Program
         {
             return command switch
             {
+                "start" => await StartAsync(rest),
                 "run" => await RunAsync(rest),
                 "chat" => await ChatAsync(rest),
                 "live" => await LiveAsync(rest),
                 "tui" => await TuiAsync(rest),
                 "setup" => await SetupAsync(rest),
+                "upgrade" => await UpgradeAsync(rest),
                 "init" => InitCommand.Run(rest),
                 "migrate" => await MigrateAsync(rest),
                 "heartbeat" => await HeartbeatAsync(rest),
@@ -76,12 +78,14 @@ internal static class Program
             openclaw — OpenClaw.NET CLI
 
             Usage:
+              openclaw start [options]
               openclaw run [options] <prompt>
               openclaw chat [options]
               openclaw live [options]
               openclaw tui [options]
               openclaw setup [options]
               openclaw setup <launch|service|status|verify|channel> [options]
+              openclaw upgrade <check> [options]
               openclaw init [options]
               openclaw migrate [options]
               openclaw migrate <legacy|upstream> [options]
@@ -114,6 +118,9 @@ internal static class Program
               /model <model>
 
             Examples:
+              openclaw start
+              openclaw start --with-companion --open-browser
+              openclaw start --non-interactive --profile local --workspace ./workspace --provider openai --model gpt-4o --api-key env:MODEL_PROVIDER_KEY
               openclaw run "summarize this README" --file ./README.md
               OPENCLAW_AUTH_TOKEN=... openclaw run "summarize this README" --file ./README.md
               cat error.log | openclaw run "what went wrong?"
@@ -121,6 +128,8 @@ internal static class Program
               openclaw live --model gemini-2.0-flash-live-001 --system "Be concise."
               openclaw tui
               openclaw setup
+              openclaw upgrade check
+              openclaw upgrade check --config ~/.openclaw/config/openclaw.settings.json --offline
               openclaw setup --non-interactive --profile local --workspace ./workspace --provider openai --model gpt-4o --api-key env:MODEL_PROVIDER_KEY
               openclaw setup verify --config ~/.openclaw/config/openclaw.settings.json
               openclaw setup launch --config ~/.openclaw/config/openclaw.settings.json --with-companion --open-browser
@@ -277,6 +286,7 @@ internal static class Program
               openclaw setup channel <telegram|slack|discord|teams|whatsapp> [--config <path>] [--non-interactive] [...]
 
             Notes:
+              - Prefer 'openclaw start' for the one-command local path.
               - Bare 'openclaw setup' launches a guided onboarding flow.
               - 'openclaw setup launch' starts the gateway in the current repo checkout, runs verification, and streams logs until Ctrl-C.
               - Use --with-companion to start Companion too.
@@ -288,6 +298,22 @@ internal static class Program
               - Use --non-interactive for automation or CI.
               - Writes an external JSON config file plus an adjacent env example.
               - Prints gateway, companion, doctor, and admin posture commands.
+            """);
+    }
+
+    private static void PrintUpgradeHelp()
+    {
+        Console.WriteLine(
+            """
+            openclaw upgrade
+
+            Usage:
+              openclaw upgrade check [--config <path>] [--offline]
+
+            Notes:
+              - Runs preflight checks before an upgrade.
+              - Combines setup verification, provider readiness, plugin compatibility,
+                skill compatibility, and migration-risk heuristics into one report.
             """);
     }
 
@@ -527,6 +553,24 @@ internal static class Program
         return await SetupCommand.RunAsync(args, Console.In, Console.Out, Console.Error, Directory.GetCurrentDirectory(), canPrompt: !Console.IsInputRedirected);
     }
 
+    private static async Task<int> StartAsync(string[] args)
+    {
+        var parsed = CliArgs.Parse(args);
+        if (parsed.ShowHelp)
+        {
+            StartCommand.WriteHelp(Console.Out);
+            return 0;
+        }
+
+        return await StartCommand.RunAsync(
+            args,
+            Console.In,
+            Console.Out,
+            Console.Error,
+            Directory.GetCurrentDirectory(),
+            canPrompt: !Console.IsInputRedirected);
+    }
+
     private static async Task<int> MigrateAsync(string[] args)
     {
         if (args.Length > 0 && string.Equals(args[0], "upstream", StringComparison.OrdinalIgnoreCase))
@@ -556,6 +600,17 @@ internal static class Program
         foreach (var item in migrated.Items)
             Console.WriteLine($"- {item.Id} | {item.Name} | {item.Schedule} | enabled={item.Enabled.ToString().ToLowerInvariant()} draft={item.IsDraft.ToString().ToLowerInvariant()}");
         return 0;
+    }
+
+    private static async Task<int> UpgradeAsync(string[] args)
+    {
+        if (args.Length == 0 || args[0] is "-h" or "--help" or "help")
+        {
+            PrintUpgradeHelp();
+            return 0;
+        }
+
+        return await UpgradeCommands.RunAsync(args, Console.Out, Console.Error, Directory.GetCurrentDirectory());
     }
 
     private static async Task<int> HeartbeatAsync(string[] args)

--- a/src/OpenClaw.Cli/SetupCommand.cs
+++ b/src/OpenClaw.Cli/SetupCommand.cs
@@ -21,17 +21,26 @@ internal static class SetupCommand
         TextWriter error,
         string currentDirectory,
         bool canPrompt)
+        => (await RunWithResultAsync(args, input, output, error, currentDirectory, canPrompt)).ExitCode;
+
+    internal static async Task<SetupCommandResult> RunWithResultAsync(
+        string[] args,
+        TextReader input,
+        TextWriter output,
+        TextWriter error,
+        string currentDirectory,
+        bool canPrompt)
     {
         if (args.Length > 0 && string.Equals(args[0], "launch", StringComparison.OrdinalIgnoreCase))
-            return await SetupLifecycleCommand.RunLaunchAsync(args[1..], output, error, currentDirectory);
+            return new SetupCommandResult { ExitCode = await SetupLifecycleCommand.RunLaunchAsync(args[1..], output, error, currentDirectory) };
         if (args.Length > 0 && string.Equals(args[0], "service", StringComparison.OrdinalIgnoreCase))
-            return await SetupLifecycleCommand.RunServiceAsync(args[1..], output, error, currentDirectory);
+            return new SetupCommandResult { ExitCode = await SetupLifecycleCommand.RunServiceAsync(args[1..], output, error, currentDirectory) };
         if (args.Length > 0 && string.Equals(args[0], "status", StringComparison.OrdinalIgnoreCase))
-            return SetupLifecycleCommand.RunStatus(args[1..], output, error);
+            return new SetupCommandResult { ExitCode = SetupLifecycleCommand.RunStatus(args[1..], output, error) };
         if (args.Length > 0 && string.Equals(args[0], "verify", StringComparison.OrdinalIgnoreCase))
-            return await SetupLifecycleCommand.RunVerifyAsync(args[1..], output, error);
+            return new SetupCommandResult { ExitCode = await SetupLifecycleCommand.RunVerifyAsync(args[1..], output, error) };
         if (args.Length > 0 && string.Equals(args[0], "channel", StringComparison.OrdinalIgnoreCase))
-            return await ChannelSetupCommand.RunAsync(args[1..], input, output, error, canPrompt);
+            return new SetupCommandResult { ExitCode = await ChannelSetupCommand.RunAsync(args[1..], input, output, error, canPrompt) };
 
         var parsed = CliArgs.Parse(args);
         var nonInteractive = parsed.HasFlag("--non-interactive");
@@ -40,7 +49,7 @@ internal static class SetupCommand
         if (requiresPrompt && !nonInteractive && !canPrompt)
         {
             error.WriteLine("Missing setup inputs and no interactive terminal is available. Re-run with --non-interactive and explicit values, or run 'openclaw setup' from a terminal.");
-            return 2;
+            return new SetupCommandResult { ExitCode = 2 };
         }
 
         SetupAnswers answers;
@@ -53,7 +62,7 @@ internal static class SetupCommand
         catch (ArgumentException ex)
         {
             error.WriteLine(ex.Message);
-            return 2;
+            return new SetupCommandResult { ExitCode = 2 };
         }
 
         var warnings = new List<string>();
@@ -64,7 +73,7 @@ internal static class SetupCommand
             error.WriteLine("Config validation failed:");
             foreach (var validationError in validationErrors)
                 error.WriteLine($"- {validationError}");
-            return 1;
+            return new SetupCommandResult { ExitCode = 1 };
         }
 
         Directory.CreateDirectory(answers.Workspace);
@@ -113,7 +122,11 @@ internal static class SetupCommand
         {
             output.WriteLine("Companion/public launch guidance: set OPENCLAW_BASE_URL and OPENCLAW_AUTH_TOKEN from the generated config or env file before starting the Companion app.");
         }
-        return 0;
+        return new SetupCommandResult
+        {
+            ExitCode = 0,
+            ConfigPath = answers.ConfigPath
+        };
     }
 
     private static bool RequiresPrompt(CliArgs parsed)
@@ -410,4 +423,11 @@ internal static class SetupCommand
         public string? SshUser { get; init; }
         public string? SshKey { get; init; }
     }
+}
+
+internal sealed class SetupCommandResult
+{
+    public int ExitCode { get; init; }
+
+    public string? ConfigPath { get; init; }
 }

--- a/src/OpenClaw.Cli/StartCommand.cs
+++ b/src/OpenClaw.Cli/StartCommand.cs
@@ -1,0 +1,110 @@
+using OpenClaw.Core.Setup;
+
+namespace OpenClaw.Cli;
+
+internal static class StartCommand
+{
+    private static readonly StartCommandHandlers DefaultHandlers = new();
+
+    public static async Task<int> RunAsync(
+        string[] args,
+        TextReader input,
+        TextWriter output,
+        TextWriter error,
+        string currentDirectory,
+        bool canPrompt,
+        StartCommandHandlers? handlers = null)
+    {
+        var parsed = CliArgs.Parse(args);
+        if (parsed.ShowHelp)
+        {
+            WriteHelp(output);
+            return 0;
+        }
+
+        handlers ??= DefaultHandlers;
+        var configPath = ResolveConfigPath(parsed);
+        var launchArgs = EnsureConfigArgument(args, configPath);
+
+        if (handlers.ConfigExists(configPath))
+        {
+            output.WriteLine($"Using config: {configPath}");
+            return await handlers.RunLaunchAsync(launchArgs, output, error, currentDirectory);
+        }
+
+        output.WriteLine(canPrompt
+            ? $"No config found at {configPath}. Running guided setup."
+            : $"No config found at {configPath}. Running setup with the provided arguments.");
+
+        var setupResult = await handlers.RunSetupAsync(args, input, output, error, currentDirectory, canPrompt);
+        if (setupResult.ExitCode != 0)
+            return setupResult.ExitCode;
+
+        output.WriteLine();
+        output.WriteLine("Setup completed. Launching gateway...");
+        var launchConfigPath = string.IsNullOrWhiteSpace(setupResult.ConfigPath) ? configPath : setupResult.ConfigPath;
+        return await handlers.RunLaunchAsync(EnsureConfigArgument(args, launchConfigPath), output, error, currentDirectory);
+    }
+
+    public static void WriteHelp(TextWriter output)
+    {
+        output.WriteLine(
+            """
+            openclaw start
+
+            Usage:
+              openclaw start [--config <path>] [--with-companion] [--open-browser] [--skip-verify] [--offline] [--require-provider]
+                              [--profile <local|public>] [--non-interactive]
+                              [--workspace <path>] [--provider <id>] [--model <id>] [--api-key <secret-or-envref>]
+                              [--bind <address>] [--port <n>] [--auth-token <token>]
+                              [--docker-image <image>] [--opensandbox-endpoint <url>] [--ssh-host <host>] [--ssh-user <user>] [--ssh-key <path>]
+
+            Notes:
+              - This is the primary supported local entrypoint.
+              - If the config already exists, it launches the gateway with verification.
+              - If the config is missing, it runs setup first and then launches.
+              - Use --non-interactive together with explicit setup inputs for automation or CI.
+            """);
+    }
+
+    private static string ResolveConfigPath(CliArgs parsed)
+        => Path.GetFullPath(GatewaySetupPaths.ExpandPath(parsed.GetOption("--config") ?? GatewaySetupPaths.DefaultConfigPath));
+
+    private static string[] EnsureConfigArgument(string[] args, string configPath)
+    {
+        var rewritten = new List<string>(args.Length + 2);
+        var foundConfigArgument = false;
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (string.Equals(args[i], "--config", StringComparison.Ordinal))
+            {
+                foundConfigArgument = true;
+                rewritten.Add("--config");
+                rewritten.Add(configPath);
+                if (i + 1 < args.Length)
+                    i++;
+                continue;
+            }
+
+            rewritten.Add(args[i]);
+        }
+
+        if (foundConfigArgument)
+            return [.. rewritten];
+
+        return ["--config", configPath, .. args];
+    }
+}
+
+internal sealed class StartCommandHandlers
+{
+    public Func<string, bool> ConfigExists { get; init; } = File.Exists;
+
+    public Func<string[], TextReader, TextWriter, TextWriter, string, bool, Task<SetupCommandResult>> RunSetupAsync { get; init; }
+        = static (args, input, output, error, currentDirectory, canPrompt)
+            => SetupCommand.RunWithResultAsync(args, input, output, error, currentDirectory, canPrompt);
+
+    public Func<string[], TextWriter, TextWriter, string, Task<int>> RunLaunchAsync { get; init; }
+        = static (args, output, error, currentDirectory)
+            => SetupLifecycleCommand.RunLaunchAsync(args, output, error, currentDirectory);
+}

--- a/src/OpenClaw.Cli/UpgradeCommands.cs
+++ b/src/OpenClaw.Cli/UpgradeCommands.cs
@@ -117,7 +117,7 @@ internal static class UpgradeCommands
 
         var summary = $"Setup verification reported {verification.Checks.Count} checks with overall status '{verification.OverallStatus}'.";
         if (offline)
-            summary += " Provider smoke ran in offline mode.";
+            summary += " Provider smoke was skipped because offline mode is enabled.";
 
         return new UpgradeCheckSummary(
             "Config and provider readiness",

--- a/src/OpenClaw.Cli/UpgradeCommands.cs
+++ b/src/OpenClaw.Cli/UpgradeCommands.cs
@@ -1,0 +1,474 @@
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Plugins;
+using OpenClaw.Core.Security;
+using OpenClaw.Core.Setup;
+using OpenClaw.Core.Skills;
+using OpenClaw.Core.Validation;
+
+namespace OpenClaw.Cli;
+
+internal static class UpgradeCommands
+{
+    public static async Task<int> RunAsync(string[] args, TextWriter output, TextWriter error, string currentDirectory)
+    {
+        if (args.Length == 0 || args[0] is "-h" or "--help" or "help")
+        {
+            PrintHelp(output);
+            return 0;
+        }
+
+        var subcommand = args[0].Trim().ToLowerInvariant();
+        var rest = args[1..];
+        return subcommand switch
+        {
+            "check" => await RunCheckAsync(rest, output, error, currentDirectory),
+            _ => UnknownSubcommand(subcommand, output, error)
+        };
+    }
+
+    private static async Task<int> RunCheckAsync(string[] args, TextWriter output, TextWriter error, string currentDirectory)
+    {
+        var parsed = CliArgs.Parse(args);
+        if (parsed.ShowHelp)
+        {
+            PrintHelp(output);
+            return 0;
+        }
+
+        var configPath = ResolveConfigPath(parsed);
+        GatewayConfig config;
+        try
+        {
+            config = GatewayConfigFile.Load(configPath);
+        }
+        catch (Exception ex)
+        {
+            error.WriteLine(ex.Message);
+            return 1;
+        }
+
+        var workspacePath = ResolveWorkspacePath(config);
+        var offline = parsed.HasFlag("--offline");
+        var verification = await EvaluateVerificationAsync(config, workspacePath, offline);
+        var plugins = EvaluatePlugins(config, workspacePath);
+        var skills = EvaluateSkills(config, workspacePath);
+        var migrationImpact = EvaluateMigrationImpact(configPath, config);
+
+        var overall = AggregateStatus(
+            verification.Status,
+            plugins.Status,
+            skills.Status,
+            migrationImpact.Status);
+
+        output.WriteLine("OpenClaw upgrade preflight");
+        output.WriteLine($"Config: {configPath}");
+        output.WriteLine($"Workspace: {workspacePath ?? "not configured"}");
+        output.WriteLine($"Overall result: {overall}");
+        output.WriteLine();
+        output.WriteLine("Checks:");
+        WriteCheck(output, verification);
+        WriteCheck(output, plugins);
+        WriteCheck(output, skills);
+        WriteCheck(output, migrationImpact);
+
+        var nextActions = verification.NextActions
+            .Concat(plugins.NextActions)
+            .Concat(skills.NextActions)
+            .Concat(migrationImpact.NextActions)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        if (nextActions.Length > 0)
+        {
+            output.WriteLine();
+            output.WriteLine("Recommended next actions:");
+            foreach (var action in nextActions)
+                output.WriteLine($"- {action}");
+        }
+
+        if (string.Equals(overall, SetupCheckStates.Fail, StringComparison.Ordinal))
+        {
+            output.WriteLine();
+            output.WriteLine("Upgrade preflight failed. Resolve the blocking issues before upgrading.");
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private static async Task<UpgradeCheckSummary> EvaluateVerificationAsync(GatewayConfig config, string? workspacePath, bool offline)
+    {
+        var localState = LocalSetupStateLoader.Load(config.Memory.StoragePath);
+        var verification = await SetupVerificationService.VerifyAsync(new SetupVerificationRequest
+        {
+            Config = config,
+            RuntimeState = RuntimeModeResolver.Resolve(config.Runtime),
+            Policy = localState.Policy,
+            OperatorAccountCount = localState.OperatorAccountCount,
+            Offline = offline,
+            RequireProvider = !offline,
+            WorkspacePath = workspacePath,
+            ModelDoctor = ModelDoctorEvaluator.Build(config)
+        }, CancellationToken.None);
+
+        var detail = new List<string>();
+        foreach (var check in verification.Checks.Where(static item => !string.Equals(item.Status, SetupCheckStates.Pass, StringComparison.Ordinal)))
+            detail.Add($"[{check.Status}] {check.Label}: {check.Summary}");
+
+        var summary = $"Setup verification reported {verification.Checks.Count} checks with overall status '{verification.OverallStatus}'.";
+        if (offline)
+            summary += " Provider smoke ran in offline mode.";
+
+        return new UpgradeCheckSummary(
+            "Config and provider readiness",
+            verification.OverallStatus,
+            summary,
+            detail,
+            verification.RecommendedNextActions);
+    }
+
+    private static UpgradeCheckSummary EvaluatePlugins(GatewayConfig config, string? workspacePath)
+    {
+        var result = PluginDiscovery.DiscoverWithDiagnostics(config.Plugins, workspacePath);
+        var details = new List<string>();
+        var nextActions = new List<string>();
+        var status = SetupCheckStates.Pass;
+
+        foreach (var report in result.Reports)
+        {
+            foreach (var diagnostic in report.Diagnostics)
+            {
+                var severity = NormalizeSeverity(diagnostic.Severity);
+                status = AggregateStatus(status, severity);
+                details.Add($"[{severity}] {report.PluginId}: {diagnostic.Message}");
+            }
+        }
+
+        foreach (var plugin in result.Plugins)
+        {
+            var manifestPath = Path.Combine(plugin.RootPath, "openclaw.plugin.json");
+            var packageJsonPath = Path.Combine(plugin.RootPath, "package.json");
+            if (File.Exists(manifestPath) || File.Exists(packageJsonPath))
+            {
+                var inspection = PluginCommands.InspectCandidate(plugin.RootPath, plugin.RootPath, sourceIsNpm: false);
+                if (!inspection.Success)
+                {
+                    status = AggregateStatus(status, SetupCheckStates.Fail);
+                    details.Add($"[{SetupCheckStates.Fail}] {plugin.Manifest.Id}: {inspection.ErrorMessage}");
+                    continue;
+                }
+
+                if (!inspection.CanInstall)
+                {
+                    status = AggregateStatus(status, SetupCheckStates.Fail);
+                    details.Add($"[{SetupCheckStates.Fail}] {inspection.PluginId}: compatibility inspection reported blocking errors.");
+                    foreach (var diagnostic in inspection.Diagnostics.Where(static item => string.Equals(item.Severity, "error", StringComparison.OrdinalIgnoreCase)))
+                        details.Add($"[{SetupCheckStates.Fail}] {inspection.PluginId}: [{diagnostic.Code}] {diagnostic.Message}");
+                    nextActions.Add($"Review plugin '{inspection.PluginId}' and resolve its compatibility errors before upgrading.");
+                    continue;
+                }
+
+                if (inspection.WarningCount > 0 || inspection.Warnings.Count > 0 || string.Equals(inspection.TrustLevel, "untrusted", StringComparison.Ordinal))
+                {
+                    status = AggregateStatus(status, SetupCheckStates.Warn);
+                    details.Add($"[{SetupCheckStates.Warn}] {inspection.PluginId}: trust={inspection.TrustLevel}, warnings={inspection.WarningCount + inspection.Warnings.Count}.");
+                }
+            }
+            else
+            {
+                status = AggregateStatus(status, SetupCheckStates.Warn);
+                details.Add($"[{SetupCheckStates.Warn}] {plugin.Manifest.Id}: entry-only plugin without a structured manifest-backed compatibility surface.");
+            }
+        }
+
+        if (details.Count == 0)
+            details.Add("No blocking plugin compatibility issues were detected.");
+
+        if (string.Equals(status, SetupCheckStates.Warn, StringComparison.Ordinal))
+            nextActions.Add("Review entry-only or warning-level plugins before upgrading the gateway/runtime.");
+
+        var summary = result.Plugins.Count == 0 && result.Reports.Count == 0
+            ? "No workspace, global, or configured plugins were discovered."
+            : $"Inspected {result.Plugins.Count} plugin(s) with {result.Reports.Count} discovery diagnostic report(s).";
+
+        return new UpgradeCheckSummary("Plugin compatibility", status, summary, details, nextActions);
+    }
+
+    private static UpgradeCheckSummary EvaluateSkills(GatewayConfig config, string? workspacePath)
+    {
+        var details = new List<string>();
+        var nextActions = new List<string>();
+        var status = SetupCheckStates.Pass;
+        var totalInspected = 0;
+
+        foreach (var root in EnumerateSkillRoots(config, workspacePath))
+        {
+            foreach (var inspection in SkillInspector.InspectInstalledRoot(root.Path, root.Source))
+            {
+                totalInspected++;
+                if (!inspection.Success || inspection.Definition is null)
+                {
+                    status = AggregateStatus(status, SetupCheckStates.Fail);
+                    details.Add($"[{SetupCheckStates.Fail}] {root.Path}: {inspection.ErrorMessage ?? "Failed to inspect skill."}");
+                    continue;
+                }
+
+                var requirementIssues = EvaluateSkillRequirements(config, inspection.Definition);
+                if (requirementIssues.Count > 0)
+                {
+                    status = AggregateStatus(status, SetupCheckStates.Warn);
+                    foreach (var issue in requirementIssues)
+                        details.Add($"[{SetupCheckStates.Warn}] {inspection.Definition.Name}: {issue}");
+                }
+            }
+        }
+
+        if (details.Count == 0)
+            details.Add("No blocking skill compatibility issues were detected.");
+
+        if (string.Equals(status, SetupCheckStates.Warn, StringComparison.Ordinal))
+            nextActions.Add("Resolve missing skill requirements before upgrading so post-upgrade validation stays green.");
+
+        var summary = totalInspected == 0
+            ? "No managed, workspace, or extra skill directories were discovered."
+            : $"Inspected {totalInspected} skill package(s) across the configured roots.";
+
+        return new UpgradeCheckSummary("Skill compatibility", status, summary, details, nextActions);
+    }
+
+    private static UpgradeCheckSummary EvaluateMigrationImpact(string configPath, GatewayConfig config)
+    {
+        var details = new List<string>();
+        var nextActions = new List<string>();
+        var status = SetupCheckStates.Pass;
+
+        if (configPath.Contains($"{Path.DirectorySeparatorChar}src{Path.DirectorySeparatorChar}OpenClaw.Gateway{Path.DirectorySeparatorChar}appsettings", StringComparison.OrdinalIgnoreCase))
+        {
+            status = AggregateStatus(status, SetupCheckStates.Warn);
+            details.Add($"[{SetupCheckStates.Warn}] Config points at a checked-in gateway appsettings file. Upgrades are safer when you use an external config generated by setup.");
+            nextActions.Add("Move to an external config file generated by 'openclaw setup' before upgrading.");
+        }
+
+        if (!string.Equals(RuntimeModeResolver.Normalize(config.Runtime.Mode), "auto", StringComparison.Ordinal))
+        {
+            status = AggregateStatus(status, SetupCheckStates.Warn);
+            details.Add($"[{SetupCheckStates.Warn}] Runtime mode is pinned to '{RuntimeModeResolver.Normalize(config.Runtime.Mode)}', which narrows the supported upgrade lane.");
+        }
+
+        if (!string.Equals(RuntimeOrchestrator.Normalize(config.Runtime.Orchestrator), RuntimeOrchestrator.Native, StringComparison.Ordinal))
+        {
+            status = AggregateStatus(status, SetupCheckStates.Warn);
+            details.Add($"[{SetupCheckStates.Warn}] Runtime orchestrator is '{RuntimeOrchestrator.Normalize(config.Runtime.Orchestrator)}' instead of the default native path.");
+        }
+
+        if (config.Plugins.DynamicNative.Enabled)
+        {
+            status = AggregateStatus(status, SetupCheckStates.Warn);
+            details.Add($"[{SetupCheckStates.Warn}] Dynamic native plugins are enabled, which increases upgrade compatibility risk.");
+        }
+
+        if (config.Plugins.Mcp.Enabled)
+        {
+            status = AggregateStatus(status, SetupCheckStates.Warn);
+            details.Add($"[{SetupCheckStates.Warn}] MCP plugin bridges are enabled. Re-check bridge compatibility after the upgrade.");
+        }
+
+        if (config.Plugins.Load.Paths.Length > 0)
+        {
+            status = AggregateStatus(status, SetupCheckStates.Warn);
+            details.Add($"[{SetupCheckStates.Warn}] Custom plugin load paths are configured: {string.Join(", ", config.Plugins.Load.Paths)}");
+        }
+
+        if (config.Skills.Load.ExtraDirs.Length > 0)
+        {
+            status = AggregateStatus(status, SetupCheckStates.Warn);
+            details.Add($"[{SetupCheckStates.Warn}] Extra skill directories are configured: {string.Join(", ", config.Skills.Load.ExtraDirs)}");
+        }
+
+        if (details.Count == 0)
+            details.Add("Config uses the default native runtime/orchestrator lane with no extra compatibility-surface overrides.");
+        else
+            nextActions.Add("Treat this install as an elevated-risk upgrade lane and rerun setup verification immediately after upgrading.");
+
+        return new UpgradeCheckSummary(
+            "Migration impact",
+            status,
+            "Estimates how much the current install relies on non-default or expanded compatibility surfaces.",
+            details,
+            nextActions);
+    }
+
+    private static IEnumerable<(string Path, SkillSource Source)> EnumerateSkillRoots(GatewayConfig config, string? workspacePath)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        if (config.Skills.Load.IncludeManaged)
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var managed = Path.Combine(home, ".openclaw", "skills");
+            if (seen.Add(managed))
+                yield return (managed, SkillSource.Managed);
+        }
+
+        if (config.Skills.Load.IncludeWorkspace && !string.IsNullOrWhiteSpace(workspacePath))
+        {
+            var workspaceSkills = Path.Combine(workspacePath, "skills");
+            if (seen.Add(workspaceSkills))
+                yield return (workspaceSkills, SkillSource.Workspace);
+        }
+
+        foreach (var extraDir in config.Skills.Load.ExtraDirs)
+        {
+            var resolved = ResolveConfiguredPath(extraDir);
+            if (!string.IsNullOrWhiteSpace(resolved) && seen.Add(resolved))
+                yield return (resolved, SkillSource.Extra);
+        }
+    }
+
+    private static IReadOnlyList<string> EvaluateSkillRequirements(GatewayConfig config, SkillDefinition definition)
+    {
+        var issues = new List<string>();
+        config.Skills.Entries.TryGetValue(definition.Metadata.SkillKey ?? definition.Name, out var entry);
+        if (entry is null)
+            config.Skills.Entries.TryGetValue(definition.Name, out entry);
+
+        foreach (var env in definition.Metadata.RequireEnv)
+        {
+            var fromEntry = entry?.Env.ContainsKey(env) == true;
+            var fromApiKey = string.Equals(definition.Metadata.PrimaryEnv, env, StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(entry?.ApiKey);
+            if (!fromEntry && !fromApiKey && string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(env)))
+                issues.Add($"required env '{env}' is not set.");
+        }
+
+        foreach (var binary in definition.Metadata.RequireBins)
+        {
+            if (!IsBinaryAvailable(binary))
+                issues.Add($"required binary '{binary}' is not available on PATH.");
+        }
+
+        if (definition.Metadata.RequireAnyBins.Length > 0 &&
+            !definition.Metadata.RequireAnyBins.Any(IsBinaryAvailable))
+        {
+            issues.Add($"none of the required fallback binaries are available on PATH: {string.Join(", ", definition.Metadata.RequireAnyBins)}");
+        }
+
+        foreach (var configKey in definition.Metadata.RequireConfig)
+        {
+            if (entry?.Config.TryGetValue(configKey, out var value) != true || string.IsNullOrWhiteSpace(value))
+                issues.Add($"required skills.entries config '{configKey}' is not configured.");
+        }
+
+        return issues;
+    }
+
+    private static bool IsBinaryAvailable(string binaryName)
+    {
+        if (string.IsNullOrWhiteSpace(binaryName))
+            return false;
+
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        var candidates = OperatingSystem.IsWindows()
+            ? new[] { binaryName, binaryName + ".exe", binaryName + ".cmd", binaryName + ".bat" }
+            : new[] { binaryName };
+
+        foreach (var directory in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var candidate in candidates)
+            {
+                var fullPath = Path.Combine(directory, candidate);
+                if (File.Exists(fullPath))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void WriteCheck(TextWriter output, UpgradeCheckSummary check)
+    {
+        output.WriteLine($"- [{check.Status}] {check.Label}: {check.Summary}");
+        foreach (var detail in check.Details)
+            output.WriteLine($"  {detail}");
+    }
+
+    private static string AggregateStatus(params string[] statuses)
+    {
+        var normalized = statuses.Select(NormalizeStatus).ToArray();
+        if (normalized.Contains(SetupCheckStates.Fail, StringComparer.Ordinal))
+            return SetupCheckStates.Fail;
+        if (normalized.Contains(SetupCheckStates.Warn, StringComparer.Ordinal) || normalized.Contains(SetupCheckStates.Skip, StringComparer.Ordinal))
+            return SetupCheckStates.Warn;
+        return SetupCheckStates.Pass;
+    }
+
+    private static string NormalizeSeverity(string severity)
+        => string.Equals(severity, "error", StringComparison.OrdinalIgnoreCase)
+            ? SetupCheckStates.Fail
+            : SetupCheckStates.Warn;
+
+    private static string NormalizeStatus(string status)
+        => status.Trim().ToLowerInvariant() switch
+        {
+            var value when value == SetupCheckStates.Fail => SetupCheckStates.Fail,
+            var value when value == SetupCheckStates.Warn => SetupCheckStates.Warn,
+            var value when value == SetupCheckStates.Skip => SetupCheckStates.Skip,
+            _ => SetupCheckStates.Pass
+        };
+
+    private static string ResolveConfigPath(CliArgs parsed)
+        => Path.GetFullPath(GatewaySetupPaths.ExpandPath(parsed.GetOption("--config") ?? GatewaySetupPaths.DefaultConfigPath));
+
+    private static string? ResolveWorkspacePath(GatewayConfig config)
+    {
+        var workspace = config.Tooling.WorkspaceRoot;
+        if (string.IsNullOrWhiteSpace(workspace))
+            return null;
+
+        var resolved = SecretResolver.Resolve(workspace) ?? workspace;
+        return Path.IsPathRooted(resolved) ? resolved : Path.GetFullPath(resolved);
+    }
+
+    private static string? ResolveConfiguredPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        var expanded = Environment.ExpandEnvironmentVariables(path);
+        expanded = GatewaySetupPaths.ExpandPath(expanded);
+        return Path.IsPathRooted(expanded) ? expanded : Path.GetFullPath(expanded);
+    }
+
+    private static int UnknownSubcommand(string subcommand, TextWriter output, TextWriter error)
+    {
+        error.WriteLine($"Unknown upgrade subcommand: {subcommand}");
+        PrintHelp(output);
+        return 2;
+    }
+
+    private static void PrintHelp(TextWriter output)
+    {
+        output.WriteLine(
+            """
+            openclaw upgrade
+
+            Usage:
+              openclaw upgrade check [--config <path>] [--offline]
+
+            Notes:
+              - Runs preflight checks before an upgrade.
+              - Combines setup verification, provider readiness, plugin compatibility,
+                skill compatibility, and migration-risk heuristics into one report.
+              - Returns a non-zero exit code when blocking issues are found.
+            """);
+    }
+
+    private sealed record UpgradeCheckSummary(
+        string Label,
+        string Status,
+        string Summary,
+        IReadOnlyList<string> Details,
+        IReadOnlyList<string> NextActions);
+}

--- a/src/OpenClaw.Tests/StartCommandTests.cs
+++ b/src/OpenClaw.Tests/StartCommandTests.cs
@@ -1,0 +1,254 @@
+using OpenClaw.Cli;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class StartCommandTests
+{
+    [Fact]
+    public async Task RunAsync_ExistingConfig_LaunchesWithoutSetup()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var configPath = Path.Combine(root, "config", "openclaw.settings.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+            await File.WriteAllTextAsync(configPath, "{}");
+
+            var setupCalls = 0;
+            var launchCalls = 0;
+            string[]? launchArgs = null;
+            using var output = new StringWriter();
+            using var error = new StringWriter();
+
+            var exitCode = await StartCommand.RunAsync(
+                ["--config", configPath, "--with-companion"],
+                new StringReader(string.Empty),
+                output,
+                error,
+                root,
+                canPrompt: false,
+                new StartCommandHandlers
+                {
+                    ConfigExists = path => string.Equals(path, configPath, StringComparison.Ordinal),
+                    RunSetupAsync = (_, _, _, _, _, _) =>
+                    {
+                        setupCalls++;
+                        return Task.FromResult(new SetupCommandResult { ExitCode = 0, ConfigPath = configPath });
+                    },
+                    RunLaunchAsync = (args, _, _, _) =>
+                    {
+                        launchCalls++;
+                        launchArgs = args;
+                        return Task.FromResult(0);
+                    }
+                });
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(0, setupCalls);
+            Assert.Equal(1, launchCalls);
+            Assert.NotNull(launchArgs);
+            Assert.Equal(["--config", configPath, "--with-companion"], launchArgs);
+            Assert.Contains($"Using config: {configPath}", output.ToString(), StringComparison.Ordinal);
+            Assert.Equal(string.Empty, error.ToString());
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_MissingConfig_RunsSetupThenLaunch()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var configPath = Path.Combine(root, "config", "openclaw.settings.json");
+            var setupCalls = 0;
+            var launchCalls = 0;
+            string[]? launchArgs = null;
+            using var output = new StringWriter();
+            using var error = new StringWriter();
+
+            var exitCode = await StartCommand.RunAsync(
+                [
+                    "--config", configPath,
+                    "--profile", "local",
+                    "--workspace", Path.Combine(root, "workspace"),
+                    "--provider", "openai",
+                    "--model", "gpt-4o",
+                    "--api-key", "env:OPENAI_API_KEY",
+                    "--open-browser"
+                ],
+                new StringReader(string.Empty),
+                output,
+                error,
+                root,
+                canPrompt: true,
+                new StartCommandHandlers
+                {
+                    ConfigExists = _ => false,
+                    RunSetupAsync = (_, _, _, _, _, _) =>
+                    {
+                        setupCalls++;
+                        return Task.FromResult(new SetupCommandResult { ExitCode = 0, ConfigPath = configPath });
+                    },
+                    RunLaunchAsync = (args, _, _, _) =>
+                    {
+                        launchCalls++;
+                        launchArgs = args;
+                        return Task.FromResult(0);
+                    }
+                });
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(1, setupCalls);
+            Assert.Equal(1, launchCalls);
+            Assert.NotNull(launchArgs);
+            Assert.Equal(
+                [
+                    "--config", configPath,
+                    "--profile", "local",
+                    "--workspace", Path.Combine(root, "workspace"),
+                    "--provider", "openai",
+                    "--model", "gpt-4o",
+                    "--api-key", "env:OPENAI_API_KEY",
+                    "--open-browser"
+                ],
+                launchArgs);
+
+            var stdout = output.ToString();
+            Assert.Contains($"No config found at {configPath}. Running guided setup.", stdout, StringComparison.Ordinal);
+            Assert.Contains("Setup completed. Launching gateway...", stdout, StringComparison.Ordinal);
+            Assert.Equal(string.Empty, error.ToString());
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_SetupFailure_DoesNotLaunch()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var configPath = Path.Combine(root, "config", "openclaw.settings.json");
+            var launchCalls = 0;
+            using var output = new StringWriter();
+            using var error = new StringWriter();
+
+            var exitCode = await StartCommand.RunAsync(
+                ["--config", configPath, "--non-interactive"],
+                new StringReader(string.Empty),
+                output,
+                error,
+                root,
+                canPrompt: false,
+                new StartCommandHandlers
+                {
+                    ConfigExists = _ => false,
+                    RunSetupAsync = (_, _, _, writer, _, _) =>
+                    {
+                        writer.WriteLine("setup failed");
+                        return Task.FromResult(new SetupCommandResult { ExitCode = 2 });
+                    },
+                    RunLaunchAsync = (_, _, _, _) =>
+                    {
+                        launchCalls++;
+                        return Task.FromResult(0);
+                    }
+                });
+
+            Assert.Equal(2, exitCode);
+            Assert.Equal(0, launchCalls);
+            Assert.Contains($"No config found at {configPath}. Running setup with the provided arguments.", output.ToString(), StringComparison.Ordinal);
+            Assert.Contains("setup failed", error.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("Setup completed. Launching gateway...", output.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_SetupChoosesDifferentConfigPath_LaunchesUsingReturnedPath()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var requestedConfigPath = Path.Combine(root, "config", "requested.json");
+            var selectedConfigPath = Path.Combine(root, "custom", "starter.json");
+            string[]? launchArgs = null;
+            using var output = new StringWriter();
+            using var error = new StringWriter();
+
+            var exitCode = await StartCommand.RunAsync(
+                ["--config", requestedConfigPath],
+                new StringReader(string.Empty),
+                output,
+                error,
+                root,
+                canPrompt: true,
+                new StartCommandHandlers
+                {
+                    ConfigExists = _ => false,
+                    RunSetupAsync = (_, _, _, _, _, _) =>
+                        Task.FromResult(new SetupCommandResult { ExitCode = 0, ConfigPath = selectedConfigPath }),
+                    RunLaunchAsync = (args, _, _, _) =>
+                    {
+                        launchArgs = args;
+                        return Task.FromResult(0);
+                    }
+                });
+
+            Assert.Equal(0, exitCode);
+            Assert.NotNull(launchArgs);
+            Assert.Equal(["--config", selectedConfigPath], launchArgs);
+            Assert.Equal(string.Empty, error.ToString());
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_Help_PrintsHelpWithoutRunningHandlers()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+        var handlerCalled = false;
+
+        var exitCode = await StartCommand.RunAsync(
+            ["--help"],
+            new StringReader(string.Empty),
+            output,
+            error,
+            Directory.GetCurrentDirectory(),
+            canPrompt: true,
+            new StartCommandHandlers
+            {
+                ConfigExists = _ =>
+                {
+                    handlerCalled = true;
+                    return false;
+                }
+            });
+
+        Assert.Equal(0, exitCode);
+        Assert.False(handlerCalled);
+        Assert.Contains("openclaw start", output.ToString(), StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    private static string CreateTempRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "openclaw-start-tests", Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+}

--- a/src/OpenClaw.Tests/UpgradeCommandsTests.cs
+++ b/src/OpenClaw.Tests/UpgradeCommandsTests.cs
@@ -26,6 +26,7 @@ public sealed class UpgradeCommandsTests
             Assert.Contains("[pass] Plugin compatibility", text, StringComparison.Ordinal);
             Assert.Contains("[pass] Skill compatibility", text, StringComparison.Ordinal);
             Assert.Contains("[pass] Migration impact", text, StringComparison.Ordinal);
+            Assert.Contains("Provider smoke was skipped because offline mode is enabled.", text, StringComparison.Ordinal);
         });
     }
 

--- a/src/OpenClaw.Tests/UpgradeCommandsTests.cs
+++ b/src/OpenClaw.Tests/UpgradeCommandsTests.cs
@@ -1,0 +1,161 @@
+using OpenClaw.Cli;
+using OpenClaw.Core.Models;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class UpgradeCommandsTests
+{
+    [Fact]
+    public async Task RunAsync_Check_WithHealthyOfflineConfig_Passes()
+    {
+        await WithIsolatedHomeAsync(async root =>
+        {
+            var (configPath, _) = await CreateBaseConfigAsync(root);
+            using var output = new StringWriter();
+            using var error = new StringWriter();
+
+            var exitCode = await UpgradeCommands.RunAsync(["check", "--config", configPath, "--offline"], output, error, root);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(string.Empty, error.ToString());
+            var text = output.ToString();
+            Assert.Contains("OpenClaw upgrade preflight", text, StringComparison.Ordinal);
+            Assert.Contains("Overall result: pass", text, StringComparison.Ordinal);
+            Assert.Contains("[pass] Config and provider readiness", text, StringComparison.Ordinal);
+            Assert.Contains("[pass] Plugin compatibility", text, StringComparison.Ordinal);
+            Assert.Contains("[pass] Skill compatibility", text, StringComparison.Ordinal);
+            Assert.Contains("[pass] Migration impact", text, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public async Task RunAsync_Check_WithPluginCompatibilityErrors_Fails()
+    {
+        await WithIsolatedHomeAsync(async root =>
+        {
+            var (configPath, workspace) = await CreateBaseConfigAsync(root);
+            var pluginRoot = Path.Combine(workspace, ".openclaw", "extensions", "schema-plugin");
+            Directory.CreateDirectory(pluginRoot);
+            await File.WriteAllTextAsync(
+                Path.Combine(pluginRoot, "openclaw.plugin.json"),
+                """
+                {
+                  "id": "schema-plugin",
+                  "name": "Schema Plugin",
+                  "configSchema": {
+                    "type": "object",
+                    "$ref": "#/definitions/unsupported"
+                  }
+                }
+                """);
+            await File.WriteAllTextAsync(Path.Combine(pluginRoot, "index.js"), "export default {};");
+
+            using var output = new StringWriter();
+            using var error = new StringWriter();
+
+            var exitCode = await UpgradeCommands.RunAsync(["check", "--config", configPath, "--offline"], output, error, root);
+
+            Assert.Equal(1, exitCode);
+            Assert.Equal(string.Empty, error.ToString());
+            var text = output.ToString();
+            Assert.Contains("Overall result: fail", text, StringComparison.Ordinal);
+            Assert.Contains("[fail] Plugin compatibility", text, StringComparison.Ordinal);
+            Assert.Contains("unsupported_schema_keyword", text, StringComparison.Ordinal);
+            Assert.Contains("Upgrade preflight failed.", text, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public async Task RunAsync_Check_WithExpandedCompatibilitySurface_Warns()
+    {
+        await WithIsolatedHomeAsync(async root =>
+        {
+            var (configPath, _) = await CreateBaseConfigAsync(root);
+            var config = GatewayConfigFile.Load(configPath);
+            config.Plugins.Load.Paths = [Path.Combine(root, "plugins-extra")];
+            config.Skills.Load.ExtraDirs = [Path.Combine(root, "skills-extra")];
+            await GatewayConfigFile.SaveAsync(config, configPath);
+
+            using var output = new StringWriter();
+            using var error = new StringWriter();
+
+            var exitCode = await UpgradeCommands.RunAsync(["check", "--config", configPath, "--offline"], output, error, root);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(string.Empty, error.ToString());
+            var text = output.ToString();
+            Assert.Contains("Overall result: warn", text, StringComparison.Ordinal);
+            Assert.Contains("[warn] Migration impact", text, StringComparison.Ordinal);
+            Assert.Contains("Custom plugin load paths are configured", text, StringComparison.Ordinal);
+            Assert.Contains("Extra skill directories are configured", text, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public async Task RunAsync_Help_PrintsUsage()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var exitCode = await UpgradeCommands.RunAsync(["--help"], output, error, Directory.GetCurrentDirectory());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Empty, error.ToString());
+        Assert.Contains("openclaw upgrade", output.ToString(), StringComparison.Ordinal);
+    }
+
+    private static async Task<(string ConfigPath, string Workspace)> CreateBaseConfigAsync(string root)
+    {
+        var configPath = Path.Combine(root, "config", "openclaw.settings.json");
+        var workspace = Path.Combine(root, "workspace");
+        using var setupOutput = new StringWriter();
+        using var setupError = new StringWriter();
+        var exitCode = await SetupCommand.RunAsync(
+            [
+                "--non-interactive",
+                "--profile", "local",
+                "--config", configPath,
+                "--workspace", workspace,
+                "--provider", "openai",
+                "--model", "gpt-4o",
+                "--api-key", "env:OPENAI_API_KEY"
+            ],
+            new StringReader(string.Empty),
+            setupOutput,
+            setupError,
+            root,
+            canPrompt: false);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Empty, setupError.ToString());
+
+        var config = GatewayConfigFile.Load(configPath);
+        config.Skills.Load.IncludeManaged = false;
+        await GatewayConfigFile.SaveAsync(config, configPath);
+        return (configPath, workspace);
+    }
+
+    private static async Task WithIsolatedHomeAsync(Func<string, Task> callback)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "openclaw-upgrade-tests", Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(root);
+        var home = Path.Combine(root, "home");
+        Directory.CreateDirectory(home);
+
+        var previousHome = Environment.GetEnvironmentVariable("HOME");
+        var previousUserProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+        try
+        {
+            Environment.SetEnvironmentVariable("HOME", home);
+            Environment.SetEnvironmentVariable("USERPROFILE", home);
+            await callback(root);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("HOME", previousHome);
+            Environment.SetEnvironmentVariable("USERPROFILE", previousUserProfile);
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `openclaw start` as the primary local entrypoint that reuses setup and launch
- add `openclaw upgrade check` to run config, provider, plugin, skill, and migration-risk preflight checks
- update onboarding docs to point users at the new supported start and upgrade-check flows

## Testing
- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj --filter "DocsConsistencyTests|StartCommandTests|UpgradeCommandsTests|SetupCommandTests"`
- `dotnet run --project src/OpenClaw.Cli -c Release -- start --help`
- `dotnet run --project src/OpenClaw.Cli -c Release -- upgrade check --help`
