### PR TITLE
Improve local model support and operator maintenance UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ openclaw upgrade rollback --config ~/.openclaw/config/openclaw.settings.json --o
 Useful follow-up commands and surfaces:
 
 ```bash
+openclaw models presets
+openclaw models doctor
+openclaw maintenance scan --config ~/.openclaw/config/openclaw.settings.json
+openclaw maintenance fix --config ~/.openclaw/config/openclaw.settings.json --dry-run
 openclaw skills inspect ./skills/my-skill
 openclaw compatibility catalog
 openclaw upgrade check --config ~/.openclaw/config/openclaw.settings.json --offline
@@ -75,9 +79,18 @@ openclaw migrate upstream --source ./upstream-agent --target-config ~/.openclaw/
 ```
 
 - Skill inventory: `/admin/skills`
+- Maintenance report: `/admin/maintenance`
 - Observability summary: `/admin/observability/summary`
 - Audit export: `/admin/audit/export`
 - Compatibility matrix: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)
+
+For local Ollama setups, prefer the native root endpoint and an explicit preset:
+
+```bash
+openclaw setup --non-interactive --profile local --workspace ./workspace --provider ollama --model llama3.2 --model-preset ollama-general
+```
+
+OpenClaw.NET now treats Ollama as a first-class native provider at `http://127.0.0.1:11434`. Older `/v1` endpoints still work for one compatibility cycle, but `openclaw models doctor` will flag them so you can migrate cleanly.
 
 > **Breaking change**: browser admin usage is account/session-first. Use named operator accounts for `/admin`, and use operator account tokens for Companion, CLI, API, and websocket clients.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -117,6 +117,29 @@ That preflight now also captures a last-known-good snapshot of the generated con
 openclaw upgrade rollback --config ~/.openclaw/config/openclaw.settings.json --offline
 ```
 
+For a local Ollama-first setup, keep the native root endpoint and choose an explicit preset instead of the legacy `/v1` shim:
+
+```bash
+openclaw setup --non-interactive \
+  --profile local \
+  --workspace ./workspace \
+  --provider ollama \
+  --model llama3.2 \
+  --model-preset ollama-general
+
+openclaw models presets
+openclaw models doctor
+```
+
+The doctor now warns when an Ollama profile still points at `/v1` or when a local agentic profile is missing a deterministic fallback.
+
+After the first successful run, use the maintenance surface to keep the install healthy without touching user-authored prompt files:
+
+```bash
+openclaw maintenance scan --config ~/.openclaw/config/openclaw.settings.json
+openclaw maintenance fix --config ~/.openclaw/config/openclaw.settings.json --dry-run
+```
+
 Default local endpoints:
 
 - Web UI: `http://127.0.0.1:18789/chat`
@@ -131,6 +154,7 @@ Important:
 - the browser chat UI is `/chat`, not the root URL
 - the admin UI is `http://127.0.0.1:18789/admin`
 - the ready banner also prints `Ctrl-C to stop`, startup notices, and follow-up commands
+- operational sessions can use `/concise on|off|auto` to control terse repair and automation-style responses
 
 ## Public / Reverse Proxy Start
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -31,6 +31,17 @@ openclaw upgrade check --config ~/.openclaw/config/openclaw.settings.json
 openclaw upgrade rollback --config ~/.openclaw/config/openclaw.settings.json --offline
 ```
 
+For local-model installs, the supported path is now:
+
+```bash
+openclaw setup --non-interactive --profile local --workspace ./workspace --provider ollama --model llama3.2 --model-preset ollama-general
+openclaw models presets
+openclaw models doctor
+openclaw maintenance scan --config ~/.openclaw/config/openclaw.settings.json
+```
+
+That gives you an explicit local preset, native Ollama routing, doctor guidance for compatibility or fallback gaps, and a maintenance scan that reports storage drift, prompt budget pressure, and top operator actions.
+
 If you start the gateway directly from a local terminal instead of using `setup launch`, the direct fallback is:
 
 ```bash
@@ -148,8 +159,9 @@ OpenClaw supports native routing for several providers out-of-the-box. Change th
 #### 3. Ollama (Local AI)
 - **Provider**: `"ollama"`
 - **Required**: `Model` (e.g., `"llama3"` or `"mistral"`)
-- **Default Endpoint**: `http://localhost:11434/v1`
-- **Notes**: OpenClaw connects to Ollama's OpenAI-compatible endpoint automatically.
+- **Default Endpoint**: `http://127.0.0.1:11434`
+- **Recommended Setup**: choose an explicit preset such as `ollama-general`, `ollama-agentic`, or `ollama-vision`
+- **Notes**: OpenClaw uses Ollama's native `/api/chat` and `/api/embed` endpoints. Legacy `/v1` compatibility URLs still load, but `openclaw models doctor` warns so you can migrate to the native base URL.
 
 #### 4. Claude / Anthropic
 - **Provider**: `"anthropic"` or `"claude"`
@@ -317,6 +329,39 @@ WebChat token details:
 - Tokens are stored in `sessionStorage` by default.
 - Enable the **Remember** checkbox to also store `openclaw_token` in `localStorage`.
 WebChat includes a **Doctor** button which fetches `GET /doctor/text` and prints a diagnostics report (helpful for onboarding and debugging).
+
+### Concise Operational Responses
+
+Operational runs such as automations, heartbeat-style workflows, and contract-governed repair/status flows default to a terse operator format. The runtime keeps ordinary chat unchanged, but for the current session you can override the behavior with:
+
+```text
+/concise on
+/concise off
+/concise auto
+```
+
+- `on` forces the concise operational format
+- `off` disables it for the current session
+- `auto` restores the default behavior, where only operational workflows become concise
+
+This is separate from `/verbose on|off`, which only controls the extra token and tool-call footer.
+
+### Maintenance And Reliability
+
+Use the maintenance surface to understand long-run drift and remove only safe generated artifacts:
+
+```bash
+openclaw maintenance scan --config ~/.openclaw/config/openclaw.settings.json
+openclaw maintenance fix --config ~/.openclaw/config/openclaw.settings.json --dry-run
+```
+
+The report now includes:
+
+- storage cleanup candidates such as orphaned session metadata, model evaluation artifacts, and managed prompt-cache traces
+- prompt budget pressure from recent turns plus large `AGENTS.md` or `SOUL.md` files
+- a reliability score with concrete next commands such as `openclaw models doctor` or `openclaw setup verify --require-provider`
+
+The gateway also exposes the same data in `/admin/maintenance`, `/admin/setup/status`, and the integration dashboard.
 
 ### Admin operator surfaces
 

--- a/src/OpenClaw.Agent/AgentRuntime.cs
+++ b/src/OpenClaw.Agent/AgentRuntime.cs
@@ -1376,6 +1376,8 @@ public sealed class AgentRuntime : IAgentRuntime
             systemPrompt = _systemPrompt;
         }
 
+        systemPrompt = AgentSystemPromptBuilder.ApplyResponseMode(systemPrompt, session.ResponseMode);
+
         if (string.IsNullOrWhiteSpace(session.SystemPromptOverride))
             return systemPrompt;
 

--- a/src/OpenClaw.Agent/AgentSystemPromptBuilder.cs
+++ b/src/OpenClaw.Agent/AgentSystemPromptBuilder.cs
@@ -5,6 +5,17 @@ namespace OpenClaw.Agent;
 
 internal static class AgentSystemPromptBuilder
 {
+    private const string ConciseOperationalInstructions =
+        """
+        [Operational Response Mode]
+        For this run, respond in a concise operator-facing format:
+        - state the action taken
+        - state the proof or verification result
+        - state any unresolved blocker
+        - include the next step only when needed
+        Avoid long rationale unless the user explicitly asks for it.
+        """;
+
     public static string BuildSystemPrompt(IReadOnlyList<SkillDefinition> skills, bool requireApproval)
     {
         var basePrompt = BuildBaseSystemPrompt(requireApproval);
@@ -84,5 +95,13 @@ internal static class AgentSystemPromptBuilder
         AppendOptionalPromptFile(ref basePrompt, "Agent Personality (SOUL.md)", soulFile, PromptFileMaxChars);
 
         return basePrompt;
+    }
+
+    public static string ApplyResponseMode(string prompt, string? responseMode)
+    {
+        if (!string.Equals(responseMode, OpenClaw.Core.Models.SessionResponseModes.ConciseOps, StringComparison.Ordinal))
+            return prompt;
+
+        return prompt + "\n\n" + ConciseOperationalInstructions;
     }
 }

--- a/src/OpenClaw.Cli/BootstrapConfigFactory.cs
+++ b/src/OpenClaw.Cli/BootstrapConfigFactory.cs
@@ -15,6 +15,7 @@ internal static class BootstrapConfigFactory
         string provider,
         string model,
         string apiKey,
+        string? modelPresetId = null,
         List<string>? warnings = null)
     {
         return CoreGatewaySetupProfileFactory.CreateProfileConfig(
@@ -27,6 +28,7 @@ internal static class BootstrapConfigFactory
             provider,
             model,
             apiKey,
+            modelPresetId,
             warnings);
     }
 

--- a/src/OpenClaw.Cli/MaintenanceCommands.cs
+++ b/src/OpenClaw.Cli/MaintenanceCommands.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Setup;
+using OpenClaw.Core.Validation;
+
+namespace OpenClaw.Cli;
+
+internal static class MaintenanceCommands
+{
+    public static async Task<int> RunAsync(string[] args, TextWriter output, TextWriter error)
+    {
+        var subcommand = args[0].Trim().ToLowerInvariant();
+        var parsed = CliArgs.Parse(args.Skip(1).ToArray());
+        var configPath = Path.GetFullPath(GatewayConfigFile.ExpandPath(parsed.GetOption("--config") ?? GatewaySetupPaths.DefaultConfigPath));
+
+        GatewayConfig config;
+        try
+        {
+            config = GatewayConfigFile.Load(configPath);
+        }
+        catch (Exception ex)
+        {
+            error.WriteLine(ex.Message);
+            return 1;
+        }
+
+        var status = SetupLifecycleCommand.BuildStatus(configPath, config);
+        var inputs = new MaintenanceScanInputs
+        {
+            ConfigPath = configPath,
+            SetupStatus = status,
+            ModelDoctor = ModelDoctorEvaluator.Build(config)
+        };
+
+        if (subcommand == "scan")
+        {
+            var report = await MaintenanceCoordinator.ScanAsync(config, inputs, CancellationToken.None);
+            if (parsed.HasFlag("--json"))
+                output.WriteLine(JsonSerializer.Serialize(report, CoreJsonContext.Default.MaintenanceReportResponse));
+            else
+                WriteReport(output, report);
+            return string.Equals(report.OverallStatus, SetupCheckStates.Fail, StringComparison.OrdinalIgnoreCase) ? 1 : 0;
+        }
+
+        if (subcommand == "fix")
+        {
+            var response = await MaintenanceCoordinator.FixAsync(config, new MaintenanceFixRequest
+            {
+                DryRun = parsed.HasFlag("--dry-run"),
+                Apply = parsed.GetOption("--apply") ?? "all"
+            }, inputs, CancellationToken.None);
+
+            if (parsed.HasFlag("--json"))
+                output.WriteLine(JsonSerializer.Serialize(response, CoreJsonContext.Default.MaintenanceFixResponse));
+            else
+                WriteFixResponse(output, response);
+
+            return response.Success ? 0 : 1;
+        }
+
+        output.WriteLine("Usage: openclaw maintenance <scan|fix> [options]");
+        return 2;
+    }
+
+    private static void WriteReport(TextWriter output, MaintenanceReportResponse report)
+    {
+        output.WriteLine($"Maintenance status: {report.OverallStatus}");
+        output.WriteLine($"Generated at: {report.GeneratedAtUtc:O}");
+        output.WriteLine($"Reliability: {report.Reliability.Score}/100 ({report.Reliability.Status})");
+        output.WriteLine($"Storage: memory={report.Storage.MemoryBytes:N0}B archive={report.Storage.ArchiveBytes:N0}B orphaned_metadata={report.Storage.OrphanedSessionMetadataEntries} model_eval_artifacts={report.Storage.ModelEvaluationArtifacts} trace_artifacts={report.Storage.PromptCacheTraceArtifacts}");
+        output.WriteLine($"Prompt budget: recent_turns={report.PromptBudget.RecentTurnsAnalyzed} p50={report.PromptBudget.P50InputTokens:N0} p95={report.PromptBudget.P95InputTokens:N0} agents_bytes={report.PromptBudget.AgentsFileBytes:N0} soul_bytes={report.PromptBudget.SoulFileBytes:N0} skills={report.PromptBudget.LoadedSkillCount}");
+        output.WriteLine($"Drift: retries={report.Drift.ProviderRetries:N0} errors={report.Drift.ProviderErrors:N0} degraded_automations={report.Drift.DegradedAutomations} quarantined_automations={report.Drift.QuarantinedAutomations} retention_failures={report.Drift.RetentionFailures:N0} prompt_p95_delta={report.Drift.PromptP95Delta:N0}");
+
+        if (report.Findings.Count > 0)
+        {
+            output.WriteLine();
+            output.WriteLine("Findings:");
+            foreach (var finding in report.Findings)
+            {
+                output.WriteLine($"- [{finding.Severity}] {finding.Summary}");
+                if (!string.IsNullOrWhiteSpace(finding.RecommendedCommand))
+                    output.WriteLine($"  command: {finding.RecommendedCommand}");
+            }
+        }
+
+        if (report.Reliability.Recommendations.Count > 0)
+        {
+            output.WriteLine();
+            output.WriteLine("Top recommendations:");
+            foreach (var recommendation in report.Reliability.Recommendations)
+                output.WriteLine($"- {recommendation.Summary}: {recommendation.Command}");
+        }
+    }
+
+    private static void WriteFixResponse(TextWriter output, MaintenanceFixResponse response)
+    {
+        output.WriteLine(response.DryRun ? "Maintenance dry-run:" : "Maintenance fix:");
+        foreach (var action in response.Actions)
+            output.WriteLine($"- {action.Id}: {action.Summary}");
+
+        if (response.Warnings.Count > 0)
+        {
+            output.WriteLine();
+            output.WriteLine("Warnings:");
+            foreach (var warning in response.Warnings)
+                output.WriteLine($"- {warning}");
+        }
+
+        output.WriteLine();
+        output.WriteLine($"Reliability: {response.Reliability.Score}/100 ({response.Reliability.Status})");
+    }
+}

--- a/src/OpenClaw.Cli/Program.cs
+++ b/src/OpenClaw.Cli/Program.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using OpenClaw.Core.Models;
+using OpenClaw.Core.Setup;
 
 namespace OpenClaw.Cli;
 
@@ -30,6 +31,7 @@ internal static class Program
                 "tui" => await TuiAsync(rest),
                 "setup" => await SetupAsync(rest),
                 "upgrade" => await UpgradeAsync(rest),
+                "maintenance" => await MaintenanceAsync(rest),
                 "init" => InitCommand.Run(rest),
                 "migrate" => await MigrateAsync(rest),
                 "heartbeat" => await HeartbeatAsync(rest),
@@ -90,7 +92,8 @@ internal static class Program
               openclaw migrate [options]
               openclaw migrate <legacy|upstream> [options]
               openclaw heartbeat <wizard|preview|status> [options]
-              openclaw models <list|doctor> [options]
+              openclaw models <list|doctor|presets> [options]
+              openclaw maintenance <scan|fix> [options]
               openclaw eval <run|compare> [options]
               openclaw accounts <list|add|remove|probe> [options]
               openclaw backends <list|probe|run|session send> [options]
@@ -121,6 +124,7 @@ internal static class Program
               openclaw start
               openclaw start --with-companion --open-browser
               openclaw start --non-interactive --profile local --workspace ./workspace --provider openai --model gpt-4o --api-key env:MODEL_PROVIDER_KEY
+              openclaw start --non-interactive --profile local --workspace ./workspace --provider ollama --model llama3.2 --model-preset ollama-general
               openclaw run "summarize this README" --file ./README.md
               OPENCLAW_AUTH_TOKEN=... openclaw run "summarize this README" --file ./README.md
               cat error.log | openclaw run "what went wrong?"
@@ -132,6 +136,7 @@ internal static class Program
               openclaw upgrade check --config ~/.openclaw/config/openclaw.settings.json --offline
               openclaw upgrade rollback --config ~/.openclaw/config/openclaw.settings.json --offline
               openclaw setup --non-interactive --profile local --workspace ./workspace --provider openai --model gpt-4o --api-key env:MODEL_PROVIDER_KEY
+              openclaw setup --non-interactive --profile local --workspace ./workspace --provider ollama --model llama3.2 --model-preset ollama-general
               openclaw setup verify --config ~/.openclaw/config/openclaw.settings.json
               openclaw setup launch --config ~/.openclaw/config/openclaw.settings.json --with-companion --open-browser
               openclaw setup service --config ~/.openclaw/config/openclaw.settings.json --platform all
@@ -141,7 +146,10 @@ internal static class Program
               openclaw migrate upstream --source ./upstream-agent --target-config ~/.openclaw/config/openclaw.settings.json --report ./migration-report.json
               openclaw heartbeat status
               openclaw models list
+              openclaw models presets
               openclaw models doctor
+              openclaw maintenance scan
+              openclaw maintenance fix --dry-run
               openclaw eval run --profile gemma4-prod
               openclaw eval compare --profiles gemma4-prod,frontier-tools
               openclaw accounts list
@@ -225,6 +233,19 @@ internal static class Program
             Usage:
               openclaw models list [--url <url>] [--token <token>]
               openclaw models doctor [--url <url>] [--token <token>]
+              openclaw models presets
+            """);
+    }
+
+    private static void PrintMaintenanceHelp()
+    {
+        Console.WriteLine(
+            """
+            openclaw maintenance
+
+            Usage:
+              openclaw maintenance scan [--config <path>] [--json]
+              openclaw maintenance fix [--config <path>] [--dry-run] [--json] [--apply <all|retention|metadata|artifacts>]
             """);
     }
 
@@ -277,7 +298,7 @@ internal static class Program
 
             Usage:
               openclaw setup [--profile <local|public>] [--non-interactive]
-                              [--config <path>] [--workspace <path>] [--provider <id>] [--model <id>] [--api-key <secret-or-envref>]
+                              [--config <path>] [--workspace <path>] [--provider <id>] [--model <id>] [--model-preset <id>] [--api-key <secret-or-envref>]
                               [--bind <address>] [--port <n>] [--auth-token <token>]
                               [--docker-image <image>] [--opensandbox-endpoint <url>] [--ssh-host <host>] [--ssh-user <user>] [--ssh-key <path>]
               openclaw setup launch [--config <path>] [--with-companion] [--open-browser] [--skip-verify] [--offline] [--require-provider]
@@ -618,6 +639,17 @@ internal static class Program
         return await UpgradeCommands.RunAsync(args, Console.Out, Console.Error, Directory.GetCurrentDirectory());
     }
 
+    private static async Task<int> MaintenanceAsync(string[] args)
+    {
+        if (args.Length == 0 || args[0] is "-h" or "--help" or "help")
+        {
+            PrintMaintenanceHelp();
+            return 0;
+        }
+
+        return await MaintenanceCommands.RunAsync(args, Console.Out, Console.Error);
+    }
+
     private static async Task<int> HeartbeatAsync(string[] args)
     {
         if (args.Length == 0 || args[0] is "-h" or "--help" or "help")
@@ -725,6 +757,14 @@ internal static class Program
 
         var subcommand = args[0].Trim().ToLowerInvariant();
         var parsed = CliArgs.Parse(args.Skip(1).ToArray());
+
+        if (subcommand == "presets")
+        {
+            foreach (var preset in LocalModelPresetCatalog.List())
+                Console.WriteLine($"- {preset.Id} | {preset.Label} | tags={string.Join(",", preset.Tags)} | {preset.Description}");
+            return 0;
+        }
+
         var baseUrl = parsed.GetOption("--url") ?? Environment.GetEnvironmentVariable(EnvBaseUrl) ?? DefaultBaseUrl;
         var token = ResolveAuthToken(parsed, Console.Error);
         using var client = new OpenClawHttpClient(baseUrl, token);
@@ -735,7 +775,9 @@ internal static class Program
             Console.WriteLine($"default_profile={response.DefaultProfileId ?? "none"}");
             foreach (var profile in response.Profiles)
             {
-                Console.WriteLine($"- {profile.Id} | {profile.ProviderId}/{profile.ModelId} | default={profile.IsDefault.ToString().ToLowerInvariant()} | tags={string.Join(",", profile.Tags)}");
+                Console.WriteLine($"- {profile.Id} | {profile.ProviderId}/{profile.ModelId} | default={profile.IsDefault.ToString().ToLowerInvariant()} | preset={profile.PresetId ?? "none"} | tags={string.Join(",", profile.Tags)}");
+                if (profile.CompatibilityNotes.Count > 0)
+                    Console.WriteLine($"  notes: {string.Join("; ", profile.CompatibilityNotes)}");
                 if (profile.ValidationIssues.Length > 0)
                     Console.WriteLine($"  issues: {string.Join("; ", profile.ValidationIssues)}");
             }
@@ -752,7 +794,7 @@ internal static class Program
             foreach (var warning in response.Warnings)
                 Console.WriteLine($"WARN: {warning}");
             foreach (var profile in response.Profiles)
-                Console.WriteLine($"- {profile.Id} | available={profile.IsAvailable.ToString().ToLowerInvariant()} | {profile.ProviderId}/{profile.ModelId}");
+                Console.WriteLine($"- {profile.Id} | available={profile.IsAvailable.ToString().ToLowerInvariant()} | preset={profile.PresetId ?? "none"} | compatibility={profile.UsesCompatibilityTransport.ToString().ToLowerInvariant()} | {profile.ProviderId}/{profile.ModelId}");
             return response.Errors.Count > 0 ? 1 : 0;
         }
 

--- a/src/OpenClaw.Cli/SetupCommand.cs
+++ b/src/OpenClaw.Cli/SetupCommand.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
+using System.Net.Http;
 using System.Security.Cryptography;
+using System.Text.Json;
 using OpenClaw.Core.Models;
 using OpenClaw.Core.Setup;
 using OpenClaw.Core.Security;
@@ -12,6 +14,7 @@ internal static class SetupCommand
     private const string DefaultConfigPath = "~/.openclaw/config/openclaw.settings.json";
     private const string DefaultApiKeyRef = "env:MODEL_PROVIDER_KEY";
     private const string DefaultProvider = "openai";
+    private const string DefaultOllamaPresetId = "ollama-general";
     private const string DefaultBackendChoice = "none";
 
     internal static async Task<int> RunAsync(
@@ -136,11 +139,14 @@ internal static class SetupCommand
             "--profile",
             "--workspace",
             "--provider",
-            "--model",
-            "--api-key"
+            "--model"
         };
 
-        return required.Any(option => string.IsNullOrWhiteSpace(parsed.GetOption(option)));
+        if (required.Any(option => string.IsNullOrWhiteSpace(parsed.GetOption(option))))
+            return true;
+
+        return ProviderRequiresApiKey(parsed.GetOption("--provider")) &&
+               string.IsNullOrWhiteSpace(parsed.GetOption("--api-key"));
     }
 
     private static SetupAnswers PromptForAnswers(CliArgs parsed, TextReader input, TextWriter output, string currentDirectory)
@@ -148,9 +154,23 @@ internal static class SetupCommand
         var profile = BootstrapConfigFactory.NormalizeProfile(Prompt(output, input, "Deployment profile (local|public)", parsed.GetOption("--profile") ?? "local"));
         var configPath = Path.GetFullPath(GatewayConfigFile.ExpandPath(Prompt(output, input, "Config path", parsed.GetOption("--config") ?? DefaultConfigPath)));
         var workspace = Path.GetFullPath(GatewayConfigFile.ExpandPath(Prompt(output, input, "Workspace path", parsed.GetOption("--workspace") ?? Path.Combine(currentDirectory, "workspace"))));
-        var provider = Prompt(output, input, "Provider", parsed.GetOption("--provider") ?? DefaultProvider);
-        var model = Prompt(output, input, "Model", parsed.GetOption("--model") ?? new GatewayConfig().Llm.Model);
-        var apiKey = Prompt(output, input, "API key or env: reference", parsed.GetOption("--api-key") ?? DefaultApiKeyRef);
+        var discoveredOllama = TryDiscoverOllamaModels();
+        if (discoveredOllama.Models.Count > 0)
+            output.WriteLine($"Detected Ollama models: {string.Join(", ", discoveredOllama.Models)}");
+
+        var providerDefault = parsed.GetOption("--provider") ?? (discoveredOllama.IsAvailable ? "ollama" : DefaultProvider);
+        var provider = Prompt(output, input, "Provider", providerDefault);
+        var modelPresetId = string.Equals(provider, "ollama", StringComparison.OrdinalIgnoreCase)
+            ? Prompt(output, input, "Model preset", parsed.GetOption("--model-preset") ?? DefaultOllamaPresetId)
+            : null;
+        var modelDefault = parsed.GetOption("--model")
+            ?? (string.Equals(provider, "ollama", StringComparison.OrdinalIgnoreCase) && discoveredOllama.Models.Count > 0
+                ? discoveredOllama.Models[0]
+                : new GatewayConfig().Llm.Model);
+        var model = Prompt(output, input, "Model", modelDefault);
+        var apiKey = ProviderRequiresApiKey(provider)
+            ? Prompt(output, input, "API key or env: reference", parsed.GetOption("--api-key") ?? DefaultApiKeyRef)
+            : parsed.GetOption("--api-key");
 
         var bindDefault = parsed.GetOption("--bind") ?? GetDefaultBindAddress(profile);
         var bindAddress = Prompt(output, input, "Bind address", bindDefault);
@@ -189,8 +209,9 @@ internal static class SetupCommand
             ConfigPath = configPath,
             Workspace = workspace,
             Provider = provider,
+            ModelPresetId = string.IsNullOrWhiteSpace(modelPresetId) ? null : modelPresetId.Trim(),
             Model = model,
-            ApiKey = apiKey,
+            ApiKey = string.IsNullOrWhiteSpace(apiKey) ? null : apiKey.Trim(),
             BindAddress = bindAddress,
             Port = port,
             AuthToken = authToken,
@@ -216,8 +237,11 @@ internal static class SetupCommand
             ConfigPath = Path.GetFullPath(GatewayConfigFile.ExpandPath(parsed.GetOption("--config") ?? DefaultConfigPath)),
             Workspace = Path.GetFullPath(GatewayConfigFile.ExpandPath(parsed.GetOption("--workspace") ?? Path.Combine(currentDirectory, "workspace"))),
             Provider = parsed.GetOption("--provider") ?? DefaultProvider,
+            ModelPresetId = parsed.GetOption("--model-preset"),
             Model = parsed.GetOption("--model") ?? new GatewayConfig().Llm.Model,
-            ApiKey = parsed.GetOption("--api-key") ?? DefaultApiKeyRef,
+            ApiKey = ProviderRequiresApiKey(parsed.GetOption("--provider"))
+                ? parsed.GetOption("--api-key") ?? DefaultApiKeyRef
+                : parsed.GetOption("--api-key"),
             BindAddress = parsed.GetOption("--bind") ?? GetDefaultBindAddress(profile),
             Port = ParsePort(parsed.GetOption("--port") ?? "18789"),
             AuthToken = parsed.GetOption("--auth-token") ?? GenerateAuthToken(),
@@ -244,7 +268,8 @@ internal static class SetupCommand
             memoryRoot,
             answers.Provider,
             answers.Model,
-            answers.ApiKey,
+            answers.ApiKey ?? string.Empty,
+            answers.ModelPresetId,
             warnings);
 
         ApplyBackend(config, answers, warnings);
@@ -405,14 +430,57 @@ internal static class SetupCommand
         return [failureMessage];
     }
 
+    private static bool ProviderRequiresApiKey(string? provider)
+        => !string.Equals(provider?.Trim(), "ollama", StringComparison.OrdinalIgnoreCase);
+
+    private static OllamaDiscoveryResult TryDiscoverOllamaModels()
+    {
+        try
+        {
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+            var payload = http.GetStringAsync($"{OllamaEndpointNormalizer.DefaultBaseUrl}/api/tags").GetAwaiter().GetResult();
+            using var document = JsonDocument.Parse(payload);
+            if (!document.RootElement.TryGetProperty("models", out var modelsElement) ||
+                modelsElement.ValueKind != JsonValueKind.Array)
+            {
+                return OllamaDiscoveryResult.Empty;
+            }
+
+            var models = new List<string>();
+            foreach (var model in modelsElement.EnumerateArray())
+            {
+                if (model.TryGetProperty("name", out var nameElement) &&
+                    nameElement.ValueKind == JsonValueKind.String &&
+                    !string.IsNullOrWhiteSpace(nameElement.GetString()))
+                {
+                    models.Add(nameElement.GetString()!);
+                }
+            }
+
+            return new OllamaDiscoveryResult
+            {
+                IsAvailable = true,
+                Models = models
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(static item => item, StringComparer.OrdinalIgnoreCase)
+                    .ToArray()
+            };
+        }
+        catch
+        {
+            return OllamaDiscoveryResult.Empty;
+        }
+    }
+
     private sealed class SetupAnswers
     {
         public required string Profile { get; init; }
         public required string ConfigPath { get; init; }
         public required string Workspace { get; init; }
         public required string Provider { get; init; }
+        public string? ModelPresetId { get; init; }
         public required string Model { get; init; }
-        public required string ApiKey { get; init; }
+        public string? ApiKey { get; init; }
         public required string BindAddress { get; init; }
         public required int Port { get; init; }
         public required string AuthToken { get; init; }
@@ -422,6 +490,14 @@ internal static class SetupCommand
         public string? SshHost { get; init; }
         public string? SshUser { get; init; }
         public string? SshKey { get; init; }
+    }
+
+    private sealed class OllamaDiscoveryResult
+    {
+        public static OllamaDiscoveryResult Empty { get; } = new();
+
+        public bool IsAvailable { get; init; }
+        public IReadOnlyList<string> Models { get; init; } = [];
     }
 }
 

--- a/src/OpenClaw.Cli/SetupLifecycleCommand.cs
+++ b/src/OpenClaw.Cli/SetupLifecycleCommand.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using OpenClaw.Core.Models;
+using OpenClaw.Core.Setup;
 using OpenClaw.Core.Security;
 using OpenClaw.Core.Validation;
 
@@ -233,7 +234,7 @@ internal static class SetupLifecycleCommand
         if (string.IsNullOrWhiteSpace(config.AuthToken))
             warnings.Add("No auth token is configured.");
 
-        return new SetupStatusResponse
+        var status = new SetupStatusResponse
         {
             Profile = publicBind ? "public" : "local",
             BindAddress = config.BindAddress,
@@ -271,6 +272,48 @@ internal static class SetupLifecycleCommand
             ChannelReadiness = [],
             Artifacts = BuildArtifactItems(GetDeployDirectory(configPath)),
             Warnings = warnings
+        };
+
+        var maintenance = MaintenanceCoordinator.ScanAsync(config, new MaintenanceScanInputs
+        {
+            ConfigPath = configPath,
+            SetupStatus = status,
+            ModelDoctor = modelDoctor
+        }, CancellationToken.None).GetAwaiter().GetResult();
+
+        return new SetupStatusResponse
+        {
+            Profile = status.Profile,
+            BindAddress = status.BindAddress,
+            Port = status.Port,
+            PublicBind = status.PublicBind,
+            AuthTokenConfigured = status.AuthTokenConfigured,
+            BootstrapTokenEnabled = status.BootstrapTokenEnabled,
+            AllowedAuthModes = status.AllowedAuthModes,
+            MinimumPluginTrustLevel = status.MinimumPluginTrustLevel,
+            ReverseProxyRecommended = status.ReverseProxyRecommended,
+            ReachableBaseUrl = status.ReachableBaseUrl,
+            WorkspacePath = status.WorkspacePath,
+            WorkspaceExists = status.WorkspaceExists,
+            HasOperatorAccounts = status.HasOperatorAccounts,
+            OperatorAccountCount = status.OperatorAccountCount,
+            ProviderConfigured = status.ProviderConfigured,
+            ProviderSmokeStatus = status.ProviderSmokeStatus,
+            ModelDoctorStatus = status.ModelDoctorStatus,
+            BrowserToolRegistered = status.BrowserToolRegistered,
+            BrowserExecutionBackendConfigured = status.BrowserExecutionBackendConfigured,
+            BrowserCapabilityReason = status.BrowserCapabilityReason,
+            LastVerificationAtUtc = status.LastVerificationAtUtc,
+            LastVerificationSource = status.LastVerificationSource,
+            LastVerificationStatus = status.LastVerificationStatus,
+            LastVerificationHasFailures = status.LastVerificationHasFailures,
+            LastVerificationHasWarnings = status.LastVerificationHasWarnings,
+            BootstrapGuidanceState = status.BootstrapGuidanceState,
+            RecommendedNextActions = status.RecommendedNextActions,
+            ChannelReadiness = status.ChannelReadiness,
+            Artifacts = status.Artifacts,
+            Warnings = status.Warnings,
+            Reliability = maintenance.Reliability
         };
     }
 
@@ -592,6 +635,7 @@ internal static class SetupLifecycleCommand
         output.WriteLine($"Operator accounts: {status.OperatorAccountCount}");
         output.WriteLine($"Provider configured: {status.ProviderConfigured.ToString().ToLowerInvariant()} smoke={status.ProviderSmokeStatus}");
         output.WriteLine($"Model doctor: {status.ModelDoctorStatus}");
+        output.WriteLine($"Reliability: {status.Reliability.Score}/100 ({status.Reliability.Status})");
         output.WriteLine($"Browser tool: registered={status.BrowserToolRegistered.ToString().ToLowerInvariant()} backend_configured={status.BrowserExecutionBackendConfigured.ToString().ToLowerInvariant()} reason={status.BrowserCapabilityReason}");
         output.WriteLine($"Last verification: {(status.LastVerificationAtUtc.HasValue ? $"{status.LastVerificationStatus} at {status.LastVerificationAtUtc:O} via {status.LastVerificationSource}" : SetupCheckStates.NotRun)}");
         output.WriteLine($"Bootstrap guidance: {status.BootstrapGuidanceState}");
@@ -607,6 +651,14 @@ internal static class SetupLifecycleCommand
             output.WriteLine("Recommended next actions:");
             foreach (var action in status.RecommendedNextActions)
                 output.WriteLine($"- {action}");
+        }
+
+        if (status.Reliability.Recommendations.Count > 0)
+        {
+            output.WriteLine();
+            output.WriteLine("Reliability recommendations:");
+            foreach (var recommendation in status.Reliability.Recommendations)
+                output.WriteLine($"- {recommendation.Summary}: {recommendation.Command}");
         }
 
         if (status.Warnings.Count > 0)

--- a/src/OpenClaw.Cli/StartCommand.cs
+++ b/src/OpenClaw.Cli/StartCommand.cs
@@ -55,7 +55,7 @@ internal static class StartCommand
             Usage:
               openclaw start [--config <path>] [--with-companion] [--open-browser] [--skip-verify] [--offline] [--require-provider]
                               [--profile <local|public>] [--non-interactive]
-                              [--workspace <path>] [--provider <id>] [--model <id>] [--api-key <secret-or-envref>]
+                              [--workspace <path>] [--provider <id>] [--model <id>] [--model-preset <id>] [--api-key <secret-or-envref>]
                               [--bind <address>] [--port <n>] [--auth-token <token>]
                               [--docker-image <image>] [--opensandbox-endpoint <url>] [--ssh-host <host>] [--ssh-user <user>] [--ssh-key <path>]
 

--- a/src/OpenClaw.Core/Abstractions/IModelProfiles.cs
+++ b/src/OpenClaw.Core/Abstractions/IModelProfiles.cs
@@ -17,6 +17,8 @@ public sealed class ModelSelectionRequest
     public required IReadOnlyList<ChatMessage> Messages { get; init; }
     public ChatOptions? Options { get; init; }
     public bool Streaming { get; init; }
+    public long? EstimatedInputTokens { get; init; }
+    public int? ReservedOutputTokens { get; init; }
 }
 
 public sealed class ModelSelectionCandidate

--- a/src/OpenClaw.Core/Models/AdminApiModels.cs
+++ b/src/OpenClaw.Core/Models/AdminApiModels.cs
@@ -191,6 +191,7 @@ public sealed class AdminSummaryResponse
     public required AdminSummaryPlugins Plugins { get; init; }
     public required AdminSummaryUsage Usage { get; init; }
     public required OperatorDashboardSnapshot Dashboard { get; init; }
+    public ReliabilitySnapshot Reliability { get; init; } = new();
 }
 
 public sealed class AdminSummaryAuth

--- a/src/OpenClaw.Core/Models/AutomationModels.cs
+++ b/src/OpenClaw.Core/Models/AutomationModels.cs
@@ -63,6 +63,7 @@ public sealed class AutomationDefinition
     public string? Timezone { get; init; }
     public string Prompt { get; init; } = "";
     public string? ModelId { get; init; }
+    public string ResponseMode { get; init; } = SessionResponseModes.Default;
     public bool RunOnStartup { get; init; }
     public string? SessionId { get; init; }
     public string DeliveryChannelId { get; init; } = "cron";

--- a/src/OpenClaw.Core/Models/LocalModelExperienceModels.cs
+++ b/src/OpenClaw.Core/Models/LocalModelExperienceModels.cs
@@ -1,0 +1,165 @@
+namespace OpenClaw.Core.Models;
+
+public static class SessionResponseModes
+{
+    public const string Default = "default";
+    public const string ConciseOps = "concise_ops";
+    public const string Full = "full";
+}
+
+public sealed class LocalModelPresetDefinition
+{
+    public required string Id { get; init; }
+    public string Label { get; init; } = "";
+    public string Description { get; init; } = "";
+    public string Provider { get; init; } = "ollama";
+    public string DefaultBaseUrl { get; init; } = "http://127.0.0.1:11434";
+    public IReadOnlyList<string> Tags { get; init; } = [];
+    public required ModelCapabilities Capabilities { get; init; }
+    public int RecommendedContextTokens { get; init; }
+    public int RecommendedOutputTokens { get; init; }
+    public IReadOnlyList<string> CompatibilityNotes { get; init; } = [];
+    public IReadOnlyList<string> DoctorExpectations { get; init; } = [];
+}
+
+public sealed class LocalModelPresetListResponse
+{
+    public IReadOnlyList<LocalModelPresetDefinition> Items { get; init; } = [];
+}
+
+public static class MaintenanceFindingSeverities
+{
+    public const string Info = "info";
+    public const string Warn = "warn";
+    public const string Fail = "fail";
+}
+
+public static class MaintenanceFindingCategories
+{
+    public const string Storage = "storage";
+    public const string PromptBudget = "prompt_budget";
+    public const string Drift = "drift";
+    public const string Reliability = "reliability";
+}
+
+public sealed class MaintenanceFinding
+{
+    public required string Id { get; init; }
+    public string Category { get; init; } = MaintenanceFindingCategories.Storage;
+    public string Severity { get; init; } = MaintenanceFindingSeverities.Info;
+    public string Summary { get; init; } = "";
+    public string? Detail { get; init; }
+    public string? Recommendation { get; init; }
+    public string? RecommendedCommand { get; init; }
+    public long NumericValue { get; init; }
+}
+
+public sealed class MaintenancePromptBudgetSnapshot
+{
+    public long RecentTurnsAnalyzed { get; init; }
+    public long P50InputTokens { get; init; }
+    public long P95InputTokens { get; init; }
+    public long SystemPromptTokens { get; init; }
+    public long SkillsTokens { get; init; }
+    public long HistoryTokens { get; init; }
+    public long ToolOutputsTokens { get; init; }
+    public long UserInputTokens { get; init; }
+    public int AgentsFileBytes { get; init; }
+    public int SoulFileBytes { get; init; }
+    public int LoadedSkillCount { get; init; }
+}
+
+public sealed class MaintenanceStorageSnapshot
+{
+    public long MemoryBytes { get; init; }
+    public long ArchiveBytes { get; init; }
+    public int OrphanedSessionMetadataEntries { get; init; }
+    public int ModelEvaluationArtifacts { get; init; }
+    public int PromptCacheTraceArtifacts { get; init; }
+}
+
+public sealed class MaintenanceDriftSnapshot
+{
+    public long ProviderRetries { get; init; }
+    public long ProviderErrors { get; init; }
+    public int DegradedAutomations { get; init; }
+    public int QuarantinedAutomations { get; init; }
+    public long RetentionFailures { get; init; }
+    public int ChannelDriftCount { get; init; }
+    public int PluginWarningCount { get; init; }
+    public int PluginErrorCount { get; init; }
+    public long PromptP95Delta { get; init; }
+}
+
+public sealed class MaintenanceReportResponse
+{
+    public DateTimeOffset GeneratedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+    public string OverallStatus { get; init; } = SetupCheckStates.Pass;
+    public MaintenanceStorageSnapshot Storage { get; init; } = new();
+    public MaintenancePromptBudgetSnapshot PromptBudget { get; init; } = new();
+    public MaintenanceDriftSnapshot Drift { get; init; } = new();
+    public IReadOnlyList<MaintenanceFinding> Findings { get; init; } = [];
+    public ReliabilitySnapshot Reliability { get; init; } = new();
+}
+
+public sealed class MaintenanceFixRequest
+{
+    public bool DryRun { get; init; } = true;
+    public string Apply { get; init; } = "all";
+}
+
+public sealed class MaintenanceFixAction
+{
+    public required string Id { get; init; }
+    public bool Applied { get; init; }
+    public string Summary { get; init; } = "";
+    public long NumericValue { get; init; }
+}
+
+public sealed class MaintenanceFixResponse
+{
+    public bool DryRun { get; init; } = true;
+    public bool Success { get; init; }
+    public IReadOnlyList<MaintenanceFixAction> Actions { get; init; } = [];
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+    public ReliabilitySnapshot Reliability { get; init; } = new();
+}
+
+public static class ReliabilityStates
+{
+    public const string Healthy = "healthy";
+    public const string Watch = "watch";
+    public const string ActionNeeded = "action_needed";
+}
+
+public sealed class ReliabilityFactor
+{
+    public required string Id { get; init; }
+    public string Label { get; init; } = "";
+    public int Weight { get; init; }
+    public int Score { get; init; }
+    public string Status { get; init; } = ReliabilityStates.Healthy;
+    public IReadOnlyList<string> Findings { get; init; } = [];
+}
+
+public sealed class ReliabilityRecommendation
+{
+    public required string Id { get; init; }
+    public string Summary { get; init; } = "";
+    public string Command { get; init; } = "";
+    public int Priority { get; init; }
+}
+
+public sealed class ReliabilitySnapshot
+{
+    public int Score { get; init; }
+    public string Status { get; init; } = ReliabilityStates.Healthy;
+    public IReadOnlyList<ReliabilityFactor> Factors { get; init; } = [];
+    public IReadOnlyList<ReliabilityRecommendation> Recommendations { get; init; } = [];
+}
+
+public sealed class MaintenanceHistorySnapshot
+{
+    public DateTimeOffset GeneratedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+    public MaintenanceReportResponse Report { get; init; } = new();
+}

--- a/src/OpenClaw.Core/Models/ModelProfiles.cs
+++ b/src/OpenClaw.Core/Models/ModelProfiles.cs
@@ -9,6 +9,7 @@ public sealed class ModelsConfig
 public sealed class ModelProfileConfig
 {
     public string Id { get; set; } = "";
+    public string? PresetId { get; set; }
     public string Provider { get; set; } = "";
     public string Model { get; set; } = "";
     public string? BaseUrl { get; set; }
@@ -59,6 +60,7 @@ public sealed class ModelSelectionRequirements
 public sealed class ModelProfile
 {
     public required string Id { get; init; }
+    public string? PresetId { get; init; }
     public required string ProviderId { get; init; }
     public required string ModelId { get; init; }
     public string? BaseUrl { get; init; }
@@ -74,6 +76,7 @@ public sealed class ModelProfile
 public sealed class ModelProfileStatus
 {
     public required string Id { get; init; }
+    public string? PresetId { get; init; }
     public required string ProviderId { get; init; }
     public required string ModelId { get; init; }
     public bool IsDefault { get; init; }
@@ -85,6 +88,8 @@ public sealed class ModelProfileStatus
     public string[] ValidationIssues { get; init; } = [];
     public string[] FallbackProfileIds { get; init; } = [];
     public string[] FallbackModels { get; init; } = [];
+    public IReadOnlyList<string> CompatibilityNotes { get; init; } = [];
+    public bool UsesCompatibilityTransport { get; init; }
 }
 
 public sealed class ModelSelectionDescriptor

--- a/src/OpenClaw.Core/Models/OperatorDashboardModels.cs
+++ b/src/OpenClaw.Core/Models/OperatorDashboardModels.cs
@@ -10,6 +10,7 @@ public sealed class OperatorDashboardSnapshot
     public required DashboardDelegationSummary Delegation { get; init; }
     public required DashboardChannelSummary Channels { get; init; }
     public required DashboardPluginSummary Plugins { get; init; }
+    public ReliabilitySnapshot Reliability { get; init; } = new();
 }
 
 public sealed class DashboardNamedMetric

--- a/src/OpenClaw.Core/Models/OperatorGovernanceModels.cs
+++ b/src/OpenClaw.Core/Models/OperatorGovernanceModels.cs
@@ -229,6 +229,7 @@ public sealed class SetupStatusResponse
     public IReadOnlyList<ChannelReadinessDto> ChannelReadiness { get; init; } = [];
     public IReadOnlyList<SetupArtifactStatusItem> Artifacts { get; init; } = [];
     public IReadOnlyList<string> Warnings { get; init; } = [];
+    public ReliabilitySnapshot Reliability { get; init; } = new();
 }
 
 public sealed class SetupVerificationCheck

--- a/src/OpenClaw.Core/Models/Session.cs
+++ b/src/OpenClaw.Core/Models/Session.cs
@@ -57,6 +57,9 @@ public sealed class Session
     /// <summary>When true, shows tool calls and token counts in responses. Set via /verbose command.</summary>
     public bool VerboseMode { get; set; }
 
+    /// <summary>Response style preference for this session.</summary>
+    public string ResponseMode { get; set; } = SessionResponseModes.Default;
+
     /// <summary>Total input tokens consumed across all turns in this session.</summary>
     public long TotalInputTokens
     {
@@ -226,6 +229,9 @@ public sealed class SessionDelegationChildSummary
 [JsonSerializable(typeof(DiagnosticsConfig))]
 [JsonSerializable(typeof(PromptCacheTraceConfig))]
 [JsonSerializable(typeof(ModelsConfig))]
+[JsonSerializable(typeof(LocalModelPresetDefinition))]
+[JsonSerializable(typeof(List<LocalModelPresetDefinition>))]
+[JsonSerializable(typeof(LocalModelPresetListResponse))]
 [JsonSerializable(typeof(ModelProfileConfig))]
 [JsonSerializable(typeof(List<ModelProfileConfig>))]
 [JsonSerializable(typeof(ModelCapabilities))]
@@ -639,6 +645,23 @@ public sealed class SessionDelegationChildSummary
 [JsonSerializable(typeof(List<SetupArtifactStatusItem>))]
 [JsonSerializable(typeof(BrowserToolCapabilitySummary))]
 [JsonSerializable(typeof(SetupStatusResponse))]
+[JsonSerializable(typeof(MaintenanceFinding))]
+[JsonSerializable(typeof(List<MaintenanceFinding>))]
+[JsonSerializable(typeof(MaintenancePromptBudgetSnapshot))]
+[JsonSerializable(typeof(MaintenanceStorageSnapshot))]
+[JsonSerializable(typeof(MaintenanceDriftSnapshot))]
+[JsonSerializable(typeof(MaintenanceReportResponse))]
+[JsonSerializable(typeof(MaintenanceFixRequest))]
+[JsonSerializable(typeof(MaintenanceFixAction))]
+[JsonSerializable(typeof(List<MaintenanceFixAction>))]
+[JsonSerializable(typeof(MaintenanceFixResponse))]
+[JsonSerializable(typeof(ReliabilityFactor))]
+[JsonSerializable(typeof(List<ReliabilityFactor>))]
+[JsonSerializable(typeof(ReliabilityRecommendation))]
+[JsonSerializable(typeof(List<ReliabilityRecommendation>))]
+[JsonSerializable(typeof(ReliabilitySnapshot))]
+[JsonSerializable(typeof(MaintenanceHistorySnapshot))]
+[JsonSerializable(typeof(List<MaintenanceHistorySnapshot>))]
 [JsonSerializable(typeof(SetupVerificationCheck))]
 [JsonSerializable(typeof(List<SetupVerificationCheck>))]
 [JsonSerializable(typeof(SetupVerificationResponse))]

--- a/src/OpenClaw.Core/Pipeline/ChatCommandProcessor.cs
+++ b/src/OpenClaw.Core/Pipeline/ChatCommandProcessor.cs
@@ -27,6 +27,7 @@ public sealed class ChatCommandProcessor
         "/usage",
         "/think",
         "/compact",
+        "/concise",
         "/verbose",
         "/help"
     }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
@@ -163,8 +164,40 @@ public sealed class ChatCommandProcessor
                 }
                 return (true, "Usage: /verbose on|off");
 
+            case "/concise":
+                if (string.IsNullOrWhiteSpace(args))
+                {
+                    var currentMode = session.ResponseMode switch
+                    {
+                        SessionResponseModes.ConciseOps => "on",
+                        SessionResponseModes.Full => "off",
+                        _ => "auto"
+                    };
+                    return (true, $"Concise mode: {currentMode}\nUsage: /concise on|off|auto");
+                }
+
+                if (args.Equals("on", StringComparison.OrdinalIgnoreCase))
+                {
+                    session.ResponseMode = SessionResponseModes.ConciseOps;
+                    await _sessionManager.PersistAsync(session, ct);
+                    return (true, "Concise operational mode enabled.");
+                }
+                if (args.Equals("off", StringComparison.OrdinalIgnoreCase))
+                {
+                    session.ResponseMode = SessionResponseModes.Full;
+                    await _sessionManager.PersistAsync(session, ct);
+                    return (true, "Concise operational mode disabled for this session.");
+                }
+                if (args.Equals("auto", StringComparison.OrdinalIgnoreCase))
+                {
+                    session.ResponseMode = SessionResponseModes.Default;
+                    await _sessionManager.PersistAsync(session, ct);
+                    return (true, "Concise mode reset to automatic behavior.");
+                }
+                return (true, "Usage: /concise on|off|auto");
+
             case "/help":
-                return (true, "Available commands:\n/status - Show session details\n/new (or /reset) - Clear conversation history\n/model <name> - Override the LLM model for this session\n/model reset - Clear model override\n/usage - Show token counts\n/think <level> - Set reasoning effort (off/low/medium/high)\n/compact - Compact conversation history\n/verbose on|off - Toggle verbose output\n/help - Show this message");
+                return (true, "Available commands:\n/status - Show session details\n/new (or /reset) - Clear conversation history\n/model <name> - Override the LLM model for this session\n/model reset - Clear model override\n/usage - Show token counts\n/think <level> - Set reasoning effort (off/low/medium/high)\n/compact - Compact conversation history\n/concise on|off|auto - Control concise operational responses\n/verbose on|off - Toggle verbose output\n/help - Show this message");
 
             default:
                 if (_dynamicCommands.TryGetValue(command, out var dynamicHandler))

--- a/src/OpenClaw.Core/Setup/GatewaySetupArtifacts.cs
+++ b/src/OpenClaw.Core/Setup/GatewaySetupArtifacts.cs
@@ -4,15 +4,15 @@ namespace OpenClaw.Core.Setup;
 
 public static class GatewaySetupArtifacts
 {
-    public static string BuildEnvExample(string apiKeyRef, string authToken, string workspacePath, string baseUrl)
+    public static string BuildEnvExample(string? apiKeyRef, string authToken, string workspacePath, string baseUrl)
     {
-        var lines = new List<string>
-        {
-            $"{ResolveProviderEnvVariable(apiKeyRef)}=replace-me",
-            $"OPENCLAW_AUTH_TOKEN={authToken}",
-            $"OPENCLAW_BASE_URL={baseUrl}",
-            $"OPENCLAW_WORKSPACE={workspacePath}"
-        };
+        var lines = new List<string>();
+        if (!string.IsNullOrWhiteSpace(apiKeyRef))
+            lines.Add($"{ResolveProviderEnvVariable(apiKeyRef)}=replace-me");
+
+        lines.Add($"OPENCLAW_AUTH_TOKEN={authToken}");
+        lines.Add($"OPENCLAW_BASE_URL={baseUrl}");
+        lines.Add($"OPENCLAW_WORKSPACE={workspacePath}");
 
         return string.Join(Environment.NewLine, lines) + Environment.NewLine;
     }

--- a/src/OpenClaw.Core/Setup/GatewaySetupProfileFactory.cs
+++ b/src/OpenClaw.Core/Setup/GatewaySetupProfileFactory.cs
@@ -1,4 +1,5 @@
 using OpenClaw.Core.Models;
+using OpenClaw.Core.Validation;
 
 namespace OpenClaw.Core.Setup;
 
@@ -14,9 +15,11 @@ public static class GatewaySetupProfileFactory
         string provider,
         string model,
         string apiKey,
+        string? modelPresetId = null,
         List<string>? warnings = null)
     {
         var normalizedProfile = NormalizeProfile(profile);
+        var normalizedProvider = provider.Trim();
         var config = new GatewayConfig
         {
             BindAddress = bindAddress,
@@ -24,9 +27,9 @@ public static class GatewaySetupProfileFactory
             AuthToken = authToken,
             Llm = new LlmProviderConfig
             {
-                Provider = provider,
+                Provider = normalizedProvider,
                 Model = model,
-                ApiKey = apiKey
+                ApiKey = string.IsNullOrWhiteSpace(apiKey) ? null : apiKey
             },
             Memory = new MemoryConfig
             {
@@ -54,14 +57,20 @@ public static class GatewaySetupProfileFactory
             }
         };
 
+        ConfigureModelProfiles(config, normalizedProvider, model, modelPresetId, warnings);
+
         if (normalizedProfile == "public")
         {
             config.Plugins.Enabled = false;
             warnings?.Add("Public profile disables third-party bridge plugins by default. Re-enable them only after you have a proxy, TLS, and explicit public-bind trust settings in place.");
         }
 
-        if (normalizedProfile == "public" && !apiKey.StartsWith("env:", StringComparison.OrdinalIgnoreCase))
+        if (normalizedProfile == "public" &&
+            !string.IsNullOrWhiteSpace(apiKey) &&
+            !apiKey.StartsWith("env:", StringComparison.OrdinalIgnoreCase))
+        {
             warnings?.Add("Public profile is using a direct API key value in the config file. Prefer env:... references or OS-backed secret storage.");
+        }
 
         return config;
     }
@@ -73,4 +82,72 @@ public static class GatewaySetupProfileFactory
             throw new ArgumentException("Invalid value for --profile (expected: local|public).");
         return normalized;
     }
+
+    private static void ConfigureModelProfiles(
+        GatewayConfig config,
+        string provider,
+        string model,
+        string? modelPresetId,
+        List<string>? warnings)
+    {
+        if (!provider.Equals("ollama", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!string.IsNullOrWhiteSpace(modelPresetId))
+                warnings?.Add($"Ignoring model preset '{modelPresetId}' because native local presets currently apply only to the Ollama provider.");
+            return;
+        }
+
+        config.Llm.Endpoint = OllamaEndpointNormalizer.DefaultBaseUrl;
+        config.Models.DefaultProfile = "local-primary";
+
+        LocalModelPresetDefinition? preset = null;
+        if (!string.IsNullOrWhiteSpace(modelPresetId) &&
+            !LocalModelPresetCatalog.TryGet(modelPresetId, out preset))
+        {
+            warnings?.Add($"Unknown model preset '{modelPresetId}'. Falling back to inferred local capabilities.");
+        }
+
+        var capabilities = preset?.Capabilities ?? new ModelCapabilities
+        {
+            SupportsStreaming = true,
+            SupportsSystemMessages = true,
+            MaxContextTokens = 32768,
+            MaxOutputTokens = 4096
+        };
+
+        config.Models.Profiles =
+        [
+            new ModelProfileConfig
+            {
+                Id = "local-primary",
+                PresetId = preset?.Id,
+                Provider = "ollama",
+                Model = model,
+                BaseUrl = OllamaEndpointNormalizer.DefaultBaseUrl,
+                Tags = preset?.Tags?.ToArray() ?? ["local", "private"],
+                Capabilities = CloneCapabilities(capabilities)
+            }
+        ];
+    }
+
+    private static ModelCapabilities CloneCapabilities(ModelCapabilities source)
+        => new()
+        {
+            SupportsTools = source.SupportsTools,
+            SupportsVision = source.SupportsVision,
+            SupportsJsonSchema = source.SupportsJsonSchema,
+            SupportsStructuredOutputs = source.SupportsStructuredOutputs,
+            SupportsStreaming = source.SupportsStreaming,
+            SupportsParallelToolCalls = source.SupportsParallelToolCalls,
+            SupportsReasoningEffort = source.SupportsReasoningEffort,
+            SupportsSystemMessages = source.SupportsSystemMessages,
+            SupportsImageInput = source.SupportsImageInput,
+            SupportsAudioInput = source.SupportsAudioInput,
+            SupportsPromptCaching = source.SupportsPromptCaching,
+            SupportsExplicitCacheRetention = source.SupportsExplicitCacheRetention,
+            ReportsCacheReadTokens = source.ReportsCacheReadTokens,
+            ReportsCacheWriteTokens = source.ReportsCacheWriteTokens,
+            MaxContextTokens = source.MaxContextTokens,
+            MaxOutputTokens = source.MaxOutputTokens
+        };
 }

--- a/src/OpenClaw.Core/Setup/LocalModelPresetCatalog.cs
+++ b/src/OpenClaw.Core/Setup/LocalModelPresetCatalog.cs
@@ -1,0 +1,124 @@
+using OpenClaw.Core.Models;
+
+namespace OpenClaw.Core.Setup;
+
+public static class LocalModelPresetCatalog
+{
+    private static readonly LocalModelPresetDefinition[] Presets =
+    [
+        new()
+        {
+            Id = "ollama-general",
+            Label = "Ollama General",
+            Description = "Balanced local preset for everyday chat and mixed tasks.",
+            Tags = ["local", "private", "generalist"],
+            Capabilities = new ModelCapabilities
+            {
+                SupportsTools = false,
+                SupportsVision = false,
+                SupportsJsonSchema = false,
+                SupportsStructuredOutputs = false,
+                SupportsStreaming = true,
+                SupportsParallelToolCalls = false,
+                SupportsReasoningEffort = false,
+                SupportsSystemMessages = true,
+                SupportsImageInput = false,
+                SupportsAudioInput = false,
+                MaxContextTokens = 32768,
+                MaxOutputTokens = 4096
+            },
+            RecommendedContextTokens = 32768,
+            RecommendedOutputTokens = 4096,
+            CompatibilityNotes =
+            [
+                "Use native Ollama endpoints instead of the OpenAI-compatible /v1 shim.",
+                "Add a fallback profile for tool-heavy routes."
+            ],
+            DoctorExpectations =
+            [
+                "Warn when this preset is selected for routes that require tools or structured outputs.",
+                "Warn when recent prompt usage routinely approaches the preset context limit."
+            ]
+        },
+        new()
+        {
+            Id = "ollama-agentic",
+            Label = "Ollama Agentic",
+            Description = "Local-first preset for tool calling with deterministic cloud fallback.",
+            Tags = ["local", "private", "agentic"],
+            Capabilities = new ModelCapabilities
+            {
+                SupportsTools = true,
+                SupportsVision = false,
+                SupportsJsonSchema = false,
+                SupportsStructuredOutputs = false,
+                SupportsStreaming = true,
+                SupportsParallelToolCalls = false,
+                SupportsReasoningEffort = false,
+                SupportsSystemMessages = true,
+                SupportsImageInput = false,
+                SupportsAudioInput = false,
+                MaxContextTokens = 65536,
+                MaxOutputTokens = 8192
+            },
+            RecommendedContextTokens = 65536,
+            RecommendedOutputTokens = 8192,
+            CompatibilityNotes =
+            [
+                "Best paired with a stronger fallback profile for structured outputs and long-context repairs.",
+                "Recent prompt budget drift should be monitored more aggressively for this preset."
+            ],
+            DoctorExpectations =
+            [
+                "Warn when a route requires JSON schema or parallel tool calling.",
+                "Warn when no fallback profile is configured for tool-heavy routes."
+            ]
+        },
+        new()
+        {
+            Id = "ollama-vision",
+            Label = "Ollama Vision",
+            Description = "Local preset optimized for image-aware interactions with conservative tool expectations.",
+            Tags = ["local", "private", "vision"],
+            Capabilities = new ModelCapabilities
+            {
+                SupportsTools = false,
+                SupportsVision = true,
+                SupportsJsonSchema = false,
+                SupportsStructuredOutputs = false,
+                SupportsStreaming = true,
+                SupportsParallelToolCalls = false,
+                SupportsReasoningEffort = false,
+                SupportsSystemMessages = true,
+                SupportsImageInput = true,
+                SupportsAudioInput = false,
+                MaxContextTokens = 65536,
+                MaxOutputTokens = 8192
+            },
+            RecommendedContextTokens = 65536,
+            RecommendedOutputTokens = 8192,
+            CompatibilityNotes =
+            [
+                "Prefer explicit fallback for structured extraction and multi-tool routes.",
+                "Large inline images can exhaust prompt budget quickly."
+            ],
+            DoctorExpectations =
+            [
+                "Warn when image-heavy recent turns exceed expected context headroom.",
+                "Warn when vision is enabled but the configured local model appears text-only."
+            ]
+        }
+    ];
+
+    public static IReadOnlyList<LocalModelPresetDefinition> List()
+        => Presets;
+
+    public static bool TryGet(string? presetId, out LocalModelPresetDefinition? preset)
+    {
+        preset = Presets.FirstOrDefault(item => string.Equals(item.Id, presetId, StringComparison.OrdinalIgnoreCase));
+        return preset is not null;
+    }
+
+    public static LocalModelPresetDefinition? GetForProfile(ModelProfile profile)
+        => TryGet(profile.PresetId, out var preset) ? preset : null;
+}

--- a/src/OpenClaw.Core/Setup/MaintenanceCoordinator.cs
+++ b/src/OpenClaw.Core/Setup/MaintenanceCoordinator.cs
@@ -1,0 +1,1083 @@
+using System.Text.Json;
+using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Features;
+using OpenClaw.Core.Memory;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Observability;
+using OpenClaw.Core.Skills;
+using OpenClaw.Core.Validation;
+
+namespace OpenClaw.Core.Setup;
+
+public sealed class MaintenanceScanInputs
+{
+    public string? ConfigPath { get; init; }
+    public SetupStatusResponse? SetupStatus { get; init; }
+    public ModelSelectionDoctorResponse? ModelDoctor { get; init; }
+    public IReadOnlyList<ProviderTurnUsageEntry> RecentTurns { get; init; } = [];
+    public IReadOnlyList<ProviderRouteHealthSnapshot> ProviderRoutes { get; init; } = [];
+    public IReadOnlyList<AutomationRunState> AutomationRunStates { get; init; } = [];
+    public MetricsSnapshot? RuntimeMetrics { get; init; }
+    public IReadOnlyList<SkillDefinition> LoadedSkills { get; init; } = [];
+    public int ChannelDriftCount { get; init; }
+    public int PluginWarningCount { get; init; }
+    public int PluginErrorCount { get; init; }
+}
+
+public static class MaintenanceCoordinator
+{
+    private const int MaintenanceHistoryRetention = 20;
+    private const int MaxModelEvaluationGroupsToKeep = 20;
+    private const int PromptSizeWarningBytes = 12_000;
+    private static readonly HashSet<string> ProtectedRetentionTags = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "keep",
+        "pinned",
+        "retain",
+        "retention-exempt"
+    };
+
+    public static async Task<MaintenanceReportResponse> ScanAsync(
+        GatewayConfig config,
+        MaintenanceScanInputs? inputs,
+        CancellationToken ct)
+    {
+        inputs ??= new MaintenanceScanInputs();
+        var memoryRoot = Path.GetFullPath(config.Memory.StoragePath);
+        Directory.CreateDirectory(memoryRoot);
+        var adminRoot = Path.Combine(memoryRoot, "admin");
+        Directory.CreateDirectory(adminRoot);
+
+        var modelDoctor = inputs.ModelDoctor ?? ModelDoctorEvaluator.Build(config);
+        var automationStates = inputs.AutomationRunStates.Count > 0
+            ? inputs.AutomationRunStates
+            : await LoadAutomationRunStatesAsync(config, ct);
+        var sessionIds = await LoadPersistedSessionIdsAsync(config, ct);
+        var metadata = LoadSessionMetadata(memoryRoot);
+        var orphanedMetadata = metadata.Count(item => !sessionIds.Contains(item.SessionId));
+        var storage = new MaintenanceStorageSnapshot
+        {
+            MemoryBytes = GetDirectorySize(memoryRoot),
+            ArchiveBytes = GetDirectorySize(PathFor(config.Memory.Retention.ArchivePath, memoryRoot)),
+            OrphanedSessionMetadataEntries = orphanedMetadata,
+            ModelEvaluationArtifacts = CountModelEvaluationArtifacts(adminRoot),
+            PromptCacheTraceArtifacts = CountPromptCacheTraceArtifacts(config, memoryRoot)
+        };
+
+        var promptBudget = BuildPromptBudgetSnapshot(
+            inputs.RecentTurns,
+            inputs.LoadedSkills,
+            ResolveWorkspacePromptPath(config.Tooling.WorkspaceRoot, "AGENTS.md"),
+            ResolveWorkspacePromptPath(config.Tooling.WorkspaceRoot, "SOUL.md"));
+
+        var previous = LoadPreviousSnapshot(memoryRoot);
+        var drift = BuildDriftSnapshot(inputs, automationStates, promptBudget, previous);
+        var findings = BuildFindings(inputs, modelDoctor, storage, promptBudget, drift);
+        var partial = new MaintenanceReportResponse
+        {
+            GeneratedAtUtc = DateTimeOffset.UtcNow,
+            OverallStatus = DetermineOverallStatus(findings),
+            Storage = storage,
+            PromptBudget = promptBudget,
+            Drift = drift,
+            Findings = findings
+        };
+
+        var reliability = ReliabilityScorer.Build(config, inputs, partial, modelDoctor, automationStates);
+        var report = new MaintenanceReportResponse
+        {
+            GeneratedAtUtc = partial.GeneratedAtUtc,
+            OverallStatus = partial.OverallStatus,
+            Storage = partial.Storage,
+            PromptBudget = partial.PromptBudget,
+            Drift = partial.Drift,
+            Findings = partial.Findings,
+            Reliability = reliability
+        };
+
+        SaveSnapshot(memoryRoot, report);
+        return report;
+    }
+
+    public static async Task<MaintenanceFixResponse> FixAsync(
+        GatewayConfig config,
+        MaintenanceFixRequest request,
+        MaintenanceScanInputs? inputs,
+        CancellationToken ct)
+    {
+        inputs ??= new MaintenanceScanInputs();
+        var memoryRoot = Path.GetFullPath(config.Memory.StoragePath);
+        Directory.CreateDirectory(memoryRoot);
+        var actions = new List<MaintenanceFixAction>();
+        var warnings = new List<string>();
+        var applyMode = NormalizeApply(request.Apply);
+
+        if (applyMode is "all" or "retention")
+        {
+            try
+            {
+                var retentionAction = await RunRetentionFixAsync(config, request.DryRun, ct);
+                actions.Add(retentionAction);
+            }
+            catch (Exception ex)
+            {
+                warnings.Add($"Retention sweep could not run: {ex.Message}");
+            }
+        }
+
+        if (applyMode is "all" or "metadata")
+        {
+            var metadataAction = await PruneOrphanedMetadataAsync(config, request.DryRun, ct);
+            actions.Add(metadataAction);
+        }
+
+        if (applyMode is "all" or "artifacts")
+        {
+            actions.Add(PruneModelEvaluationArtifacts(config, request.DryRun));
+            var traceAction = PrunePromptCacheTraceArtifacts(config, request.DryRun);
+            if (traceAction is not null)
+                actions.Add(traceAction);
+        }
+
+        var report = await ScanAsync(config, inputs, ct);
+        return new MaintenanceFixResponse
+        {
+            DryRun = request.DryRun,
+            Success = warnings.Count == 0,
+            Actions = actions,
+            Warnings = warnings,
+            Reliability = report.Reliability
+        };
+    }
+
+    private static string NormalizeApply(string? apply)
+    {
+        var normalized = (apply ?? "all").Trim().ToLowerInvariant();
+        return normalized is "all" or "retention" or "metadata" or "artifacts"
+            ? normalized
+            : "all";
+    }
+
+    private static MaintenancePromptBudgetSnapshot BuildPromptBudgetSnapshot(
+        IReadOnlyList<ProviderTurnUsageEntry> recentTurns,
+        IReadOnlyList<SkillDefinition> loadedSkills,
+        string agentsPath,
+        string soulPath)
+    {
+        var sortedInputs = recentTurns
+            .Select(static item => item.InputTokens)
+            .OrderBy(static item => item)
+            .ToArray();
+        var median = Percentile(sortedInputs, 0.50);
+        var p95 = Percentile(sortedInputs, 0.95);
+
+        var components = recentTurns.Count == 0
+            ? new InputTokenComponentEstimate()
+            : new InputTokenComponentEstimate
+            {
+                SystemPrompt = (long)Math.Round(recentTurns.Average(static item => (double)item.EstimatedInputTokensByComponent.SystemPrompt)),
+                Skills = (long)Math.Round(recentTurns.Average(static item => (double)item.EstimatedInputTokensByComponent.Skills)),
+                History = (long)Math.Round(recentTurns.Average(static item => (double)item.EstimatedInputTokensByComponent.History)),
+                ToolOutputs = (long)Math.Round(recentTurns.Average(static item => (double)item.EstimatedInputTokensByComponent.ToolOutputs)),
+                UserInput = (long)Math.Round(recentTurns.Average(static item => (double)item.EstimatedInputTokensByComponent.UserInput))
+            };
+
+        return new MaintenancePromptBudgetSnapshot
+        {
+            RecentTurnsAnalyzed = recentTurns.Count,
+            P50InputTokens = median,
+            P95InputTokens = p95,
+            SystemPromptTokens = components.SystemPrompt,
+            SkillsTokens = components.Skills,
+            HistoryTokens = components.History,
+            ToolOutputsTokens = components.ToolOutputs,
+            UserInputTokens = components.UserInput,
+            AgentsFileBytes = File.Exists(agentsPath) ? (int)Math.Min(int.MaxValue, new FileInfo(agentsPath).Length) : 0,
+            SoulFileBytes = File.Exists(soulPath) ? (int)Math.Min(int.MaxValue, new FileInfo(soulPath).Length) : 0,
+            LoadedSkillCount = loadedSkills.Count
+        };
+    }
+
+    private static MaintenanceDriftSnapshot BuildDriftSnapshot(
+        MaintenanceScanInputs inputs,
+        IReadOnlyList<AutomationRunState> automationStates,
+        MaintenancePromptBudgetSnapshot promptBudget,
+        MaintenanceHistorySnapshot? previous)
+    {
+        var providerRetries = inputs.ProviderRoutes.Sum(static item => item.Retries);
+        var providerErrors = inputs.ProviderRoutes.Sum(static item => item.Errors);
+        var degradedAutomations = automationStates.Count(static item =>
+            string.Equals(item.HealthState, AutomationHealthStates.Degraded, StringComparison.OrdinalIgnoreCase));
+        var quarantinedAutomations = automationStates.Count(static item =>
+            string.Equals(item.HealthState, AutomationHealthStates.Quarantined, StringComparison.OrdinalIgnoreCase));
+        var promptDelta = previous is null
+            ? 0
+            : promptBudget.P95InputTokens - previous.Report.PromptBudget.P95InputTokens;
+
+        return new MaintenanceDriftSnapshot
+        {
+            ProviderRetries = providerRetries,
+            ProviderErrors = providerErrors,
+            DegradedAutomations = degradedAutomations,
+            QuarantinedAutomations = quarantinedAutomations,
+            RetentionFailures = inputs.RuntimeMetrics?.RetentionSweepFailures ?? 0,
+            ChannelDriftCount = inputs.ChannelDriftCount,
+            PluginWarningCount = inputs.PluginWarningCount,
+            PluginErrorCount = inputs.PluginErrorCount,
+            PromptP95Delta = promptDelta
+        };
+    }
+
+    private static IReadOnlyList<MaintenanceFinding> BuildFindings(
+        MaintenanceScanInputs inputs,
+        ModelSelectionDoctorResponse modelDoctor,
+        MaintenanceStorageSnapshot storage,
+        MaintenancePromptBudgetSnapshot promptBudget,
+        MaintenanceDriftSnapshot drift)
+    {
+        var findings = new List<MaintenanceFinding>();
+
+        if (storage.OrphanedSessionMetadataEntries > 0)
+        {
+            findings.Add(new MaintenanceFinding
+            {
+                Id = "orphaned-session-metadata",
+                Category = MaintenanceFindingCategories.Storage,
+                Severity = MaintenanceFindingSeverities.Warn,
+                Summary = $"{storage.OrphanedSessionMetadataEntries} orphaned session metadata entries can be pruned.",
+                Recommendation = "Run a maintenance fix to remove stale admin metadata.",
+                RecommendedCommand = BuildConfigAwareCommand("openclaw maintenance fix --dry-run", inputs.ConfigPath),
+                NumericValue = storage.OrphanedSessionMetadataEntries
+            });
+        }
+
+        if (storage.ModelEvaluationArtifacts > MaxModelEvaluationGroupsToKeep * 2)
+        {
+            findings.Add(new MaintenanceFinding
+            {
+                Id = "model-evaluation-artifacts",
+                Category = MaintenanceFindingCategories.Storage,
+                Severity = MaintenanceFindingSeverities.Warn,
+                Summary = $"{storage.ModelEvaluationArtifacts} model evaluation artifacts are stored under memory/admin/model-evaluations.",
+                Recommendation = "Prune older evaluation artifacts if you no longer need historical comparison runs.",
+                RecommendedCommand = BuildConfigAwareCommand("openclaw maintenance fix --dry-run --apply artifacts", inputs.ConfigPath),
+                NumericValue = storage.ModelEvaluationArtifacts
+            });
+        }
+
+        if (storage.PromptCacheTraceArtifacts > 0)
+        {
+            findings.Add(new MaintenanceFinding
+            {
+                Id = "prompt-cache-traces",
+                Category = MaintenanceFindingCategories.Storage,
+                Severity = MaintenanceFindingSeverities.Info,
+                Summary = $"{storage.PromptCacheTraceArtifacts} prompt-cache trace artifact(s) are consuming managed storage.",
+                Recommendation = "Remove trace artifacts once prompt-cache investigation is complete.",
+                RecommendedCommand = BuildConfigAwareCommand("openclaw maintenance fix --dry-run --apply artifacts", inputs.ConfigPath),
+                NumericValue = storage.PromptCacheTraceArtifacts
+            });
+        }
+
+        if (promptBudget.AgentsFileBytes > PromptSizeWarningBytes)
+        {
+            findings.Add(new MaintenanceFinding
+            {
+                Id = "agents-file-size",
+                Category = MaintenanceFindingCategories.PromptBudget,
+                Severity = MaintenanceFindingSeverities.Warn,
+                Summary = $"AGENTS.md is {promptBudget.AgentsFileBytes:N0} bytes and may be inflating every turn.",
+                Recommendation = "Trim AGENTS.md or move infrequently needed guidance into conditional skills.",
+                RecommendedCommand = "openclaw maintenance scan",
+                NumericValue = promptBudget.AgentsFileBytes
+            });
+        }
+
+        if (promptBudget.SoulFileBytes > PromptSizeWarningBytes)
+        {
+            findings.Add(new MaintenanceFinding
+            {
+                Id = "soul-file-size",
+                Category = MaintenanceFindingCategories.PromptBudget,
+                Severity = MaintenanceFindingSeverities.Warn,
+                Summary = $"SOUL.md is {promptBudget.SoulFileBytes:N0} bytes and may be reducing local-model headroom.",
+                Recommendation = "Keep SOUL.md concise, especially for local models with tight context budgets.",
+                RecommendedCommand = "openclaw maintenance scan",
+                NumericValue = promptBudget.SoulFileBytes
+            });
+        }
+
+        if (promptBudget.RecentTurnsAnalyzed > 0 && drift.PromptP95Delta > 4_000)
+        {
+            findings.Add(new MaintenanceFinding
+            {
+                Id = "prompt-growth",
+                Category = MaintenanceFindingCategories.Drift,
+                Severity = MaintenanceFindingSeverities.Warn,
+                Summary = $"Recent prompt p95 grew by {drift.PromptP95Delta:N0} tokens since the last maintenance scan.",
+                Recommendation = "Review prompt contributors before latency and local-model reliability degrade further.",
+                RecommendedCommand = "openclaw models doctor",
+                NumericValue = drift.PromptP95Delta
+            });
+        }
+
+        if (drift.ProviderErrors > 0 || drift.ProviderRetries >= 5)
+        {
+            findings.Add(new MaintenanceFinding
+            {
+                Id = "provider-instability",
+                Category = MaintenanceFindingCategories.Drift,
+                Severity = drift.ProviderErrors > 0 ? MaintenanceFindingSeverities.Warn : MaintenanceFindingSeverities.Info,
+                Summary = $"Provider routes reported {drift.ProviderErrors:N0} errors and {drift.ProviderRetries:N0} retries.",
+                Recommendation = "Run model doctor and inspect provider health before changing model routing.",
+                RecommendedCommand = "openclaw models doctor",
+                NumericValue = drift.ProviderErrors + drift.ProviderRetries
+            });
+        }
+
+        if (drift.QuarantinedAutomations > 0 || drift.DegradedAutomations > 0)
+        {
+            findings.Add(new MaintenanceFinding
+            {
+                Id = "automation-health",
+                Category = MaintenanceFindingCategories.Reliability,
+                Severity = drift.QuarantinedAutomations > 0 ? MaintenanceFindingSeverities.Fail : MaintenanceFindingSeverities.Warn,
+                Summary = $"{drift.DegradedAutomations:N0} degraded and {drift.QuarantinedAutomations:N0} quarantined automations need attention.",
+                Recommendation = "Review automation health and replay or clear quarantine after fixing the underlying issue.",
+                RecommendedCommand = "openclaw maintenance scan",
+                NumericValue = drift.DegradedAutomations + drift.QuarantinedAutomations
+            });
+        }
+
+        if (drift.RetentionFailures > 0)
+        {
+            findings.Add(new MaintenanceFinding
+            {
+                Id = "retention-failures",
+                Category = MaintenanceFindingCategories.Reliability,
+                Severity = MaintenanceFindingSeverities.Fail,
+                Summary = $"Retention reported {drift.RetentionFailures:N0} recent failures.",
+                Recommendation = "Run a dry-run maintenance fix and inspect storage permissions before enabling more cleanup.",
+                RecommendedCommand = BuildConfigAwareCommand("openclaw maintenance fix --dry-run --apply retention", inputs.ConfigPath),
+                NumericValue = drift.RetentionFailures
+            });
+        }
+
+        if (modelDoctor.Errors.Count > 0 || modelDoctor.Warnings.Count > 0)
+        {
+            findings.Add(new MaintenanceFinding
+            {
+                Id = "model-doctor",
+                Category = MaintenanceFindingCategories.Reliability,
+                Severity = modelDoctor.Errors.Count > 0 ? MaintenanceFindingSeverities.Fail : MaintenanceFindingSeverities.Warn,
+                Summary = $"Model doctor reported {modelDoctor.Errors.Count} error(s) and {modelDoctor.Warnings.Count} warning(s).",
+                Recommendation = "Resolve model doctor findings before relying on local-first routing.",
+                RecommendedCommand = "openclaw models doctor",
+                NumericValue = modelDoctor.Errors.Count + modelDoctor.Warnings.Count
+            });
+        }
+
+        return findings
+            .OrderByDescending(static item => SeverityRank(item.Severity))
+            .ThenByDescending(static item => item.NumericValue)
+            .ToArray();
+    }
+
+    private static string DetermineOverallStatus(IReadOnlyList<MaintenanceFinding> findings)
+    {
+        if (findings.Any(static item => string.Equals(item.Severity, MaintenanceFindingSeverities.Fail, StringComparison.OrdinalIgnoreCase)))
+            return SetupCheckStates.Fail;
+        if (findings.Any(static item => string.Equals(item.Severity, MaintenanceFindingSeverities.Warn, StringComparison.OrdinalIgnoreCase)))
+            return SetupCheckStates.Warn;
+        return SetupCheckStates.Pass;
+    }
+
+    private static int SeverityRank(string severity)
+        => severity switch
+        {
+            MaintenanceFindingSeverities.Fail => 3,
+            MaintenanceFindingSeverities.Warn => 2,
+            _ => 1
+        };
+
+    private static string BuildConfigAwareCommand(string command, string? configPath)
+        => string.IsNullOrWhiteSpace(configPath)
+            ? command
+            : $"{command} --config {GatewaySetupPaths.QuoteIfNeeded(configPath)}";
+
+    private static long Percentile(long[] sortedValues, double percentile)
+    {
+        if (sortedValues.Length == 0)
+            return 0;
+
+        var index = (int)Math.Ceiling((sortedValues.Length - 1) * percentile);
+        return sortedValues[Math.Clamp(index, 0, sortedValues.Length - 1)];
+    }
+
+    private static async ValueTask<IReadOnlyList<AutomationRunState>> LoadAutomationRunStatesAsync(GatewayConfig config, CancellationToken ct)
+    {
+        var store = CreateAutomationStore(config);
+        try
+        {
+            var automations = await store.ListAutomationsAsync(ct);
+            var states = new List<AutomationRunState>(automations.Count);
+            foreach (var automation in automations)
+            {
+                var state = await store.GetRunStateAsync(automation.Id, ct);
+                if (state is not null)
+                    states.Add(state);
+            }
+
+            return states;
+        }
+        finally
+        {
+            DisposeIfNeeded(store);
+        }
+    }
+
+    private static async ValueTask<HashSet<string>> LoadPersistedSessionIdsAsync(GatewayConfig config, CancellationToken ct)
+    {
+        var store = CreateMemoryStore(config);
+        try
+        {
+            if (store is not ISessionAdminStore adminStore)
+                return [];
+
+            var sessionIds = new HashSet<string>(StringComparer.Ordinal);
+            for (var page = 1; page <= 100; page++)
+            {
+                var result = await adminStore.ListSessionsAsync(page, 500, new SessionListQuery(), ct);
+                foreach (var item in result.Items)
+                    sessionIds.Add(item.Id);
+
+                if (!result.HasMore)
+                    break;
+            }
+
+            return sessionIds;
+        }
+        finally
+        {
+            await DisposeIfNeededAsync(store);
+        }
+    }
+
+    private static List<SessionMetadataSnapshot> LoadSessionMetadata(string memoryRoot)
+    {
+        var path = Path.Combine(memoryRoot, "admin", "session-metadata.json");
+        if (!File.Exists(path))
+            return [];
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize(json, CoreJsonContext.Default.ListSessionMetadataSnapshot) ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static void SaveSessionMetadata(string memoryRoot, IReadOnlyList<SessionMetadataSnapshot> metadata)
+    {
+        var path = Path.Combine(memoryRoot, "admin", "session-metadata.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, JsonSerializer.Serialize(metadata.ToList(), CoreJsonContext.Default.ListSessionMetadataSnapshot));
+    }
+
+    private static MaintenanceHistorySnapshot? LoadPreviousSnapshot(string memoryRoot)
+    {
+        var path = Path.Combine(memoryRoot, "admin", "maintenance-history.json");
+        if (!File.Exists(path))
+            return null;
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            var items = JsonSerializer.Deserialize(json, CoreJsonContext.Default.ListMaintenanceHistorySnapshot) ?? [];
+            return items.OrderByDescending(static item => item.GeneratedAtUtc).FirstOrDefault();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void SaveSnapshot(string memoryRoot, MaintenanceReportResponse report)
+    {
+        var path = Path.Combine(memoryRoot, "admin", "maintenance-history.json");
+        var items = new List<MaintenanceHistorySnapshot>();
+        if (File.Exists(path))
+        {
+            try
+            {
+                var existing = JsonSerializer.Deserialize(File.ReadAllText(path), CoreJsonContext.Default.ListMaintenanceHistorySnapshot) ?? [];
+                items.AddRange(existing);
+            }
+            catch
+            {
+            }
+        }
+
+        items.Add(new MaintenanceHistorySnapshot { GeneratedAtUtc = report.GeneratedAtUtc, Report = report });
+        items = items
+            .OrderByDescending(static item => item.GeneratedAtUtc)
+            .Take(MaintenanceHistoryRetention)
+            .ToList();
+
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, JsonSerializer.Serialize(items, CoreJsonContext.Default.ListMaintenanceHistorySnapshot));
+    }
+
+    private static long GetDirectorySize(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+            return 0;
+
+        return Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories)
+            .Select(file =>
+            {
+                try { return new FileInfo(file).Length; }
+                catch { return 0L; }
+            })
+            .Sum();
+    }
+
+    private static int CountModelEvaluationArtifacts(string adminRoot)
+    {
+        var path = Path.Combine(adminRoot, "model-evaluations");
+        return Directory.Exists(path)
+            ? Directory.EnumerateFiles(path, "*", SearchOption.TopDirectoryOnly).Count()
+            : 0;
+    }
+
+    private static int CountPromptCacheTraceArtifacts(GatewayConfig config, string memoryRoot)
+    {
+        var path = ResolvePromptCacheTracePath(config, memoryRoot);
+        if (!IsUnderRoot(path, memoryRoot))
+            return 0;
+        if (File.Exists(path))
+            return 1;
+        if (Directory.Exists(path))
+            return Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories).Count();
+        return 0;
+    }
+
+    private static string ResolveWorkspacePromptPath(string? workspaceRoot, string fileName)
+    {
+        var workspace = string.IsNullOrWhiteSpace(workspaceRoot)
+            ? Directory.GetCurrentDirectory()
+            : Path.GetFullPath(workspaceRoot);
+        return Path.Combine(workspace, fileName);
+    }
+
+    private static string ResolvePromptCacheTracePath(GatewayConfig config, string memoryRoot)
+    {
+        var raw = config.Llm.PromptCaching.TraceFilePath
+            ?? config.Diagnostics.CacheTrace.FilePath
+            ?? Path.Combine(memoryRoot, "logs", "cache-trace.jsonl");
+        return PathFor(raw, memoryRoot);
+    }
+
+    private static string PathFor(string? configuredPath, string basePath)
+    {
+        if (string.IsNullOrWhiteSpace(configuredPath))
+            return Path.GetFullPath(basePath);
+
+        return Path.IsPathRooted(configuredPath)
+            ? Path.GetFullPath(configuredPath)
+            : Path.GetFullPath(Path.Combine(basePath, configuredPath));
+    }
+
+    private static bool IsUnderRoot(string path, string root)
+        => path.StartsWith(Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+           || string.Equals(Path.GetFullPath(path), Path.GetFullPath(root), StringComparison.Ordinal);
+
+    private static async Task<MaintenanceFixAction> RunRetentionFixAsync(GatewayConfig config, bool dryRun, CancellationToken ct)
+    {
+        var store = CreateMemoryStore(config);
+        try
+        {
+            if (store is not IMemoryRetentionStore retentionStore)
+            {
+                return new MaintenanceFixAction
+                {
+                    Id = "retention",
+                    Applied = false,
+                    Summary = "Current memory store does not support retention sweeps."
+                };
+            }
+
+            var metadata = LoadSessionMetadata(Path.GetFullPath(config.Memory.StoragePath));
+            var protectedSessions = metadata
+                .Where(static item => item.Starred || item.Tags.Any(static tag => ProtectedRetentionTags.Contains(tag)))
+                .Select(static item => item.SessionId)
+                .ToHashSet(StringComparer.Ordinal);
+            var request = new RetentionSweepRequest
+            {
+                DryRun = dryRun,
+                NowUtc = DateTimeOffset.UtcNow,
+                SessionExpiresBeforeUtc = DateTimeOffset.UtcNow.AddDays(-Math.Max(1, config.Memory.Retention.SessionTtlDays)),
+                BranchExpiresBeforeUtc = DateTimeOffset.UtcNow.AddDays(-Math.Max(1, config.Memory.Retention.BranchTtlDays)),
+                ArchivePath = PathFor(config.Memory.Retention.ArchivePath, config.Memory.StoragePath),
+                ArchiveEnabled = config.Memory.Retention.ArchiveEnabled,
+                ArchiveRetentionDays = Math.Max(1, config.Memory.Retention.ArchiveRetentionDays),
+                MaxItems = Math.Max(10, config.Memory.Retention.MaxItemsPerSweep)
+            };
+
+            var result = await retentionStore.SweepAsync(request, protectedSessions, ct);
+            return new MaintenanceFixAction
+            {
+                Id = "retention",
+                Applied = !dryRun,
+                Summary = dryRun
+                    ? $"Retention dry-run found {result.TotalEligible} eligible item(s)."
+                    : $"Retention archived {result.TotalArchived} and deleted {result.TotalDeleted} item(s).",
+                NumericValue = result.TotalEligible
+            };
+        }
+        finally
+        {
+            await DisposeIfNeededAsync(store);
+        }
+    }
+
+    private static async Task<MaintenanceFixAction> PruneOrphanedMetadataAsync(GatewayConfig config, bool dryRun, CancellationToken ct)
+    {
+        var memoryRoot = Path.GetFullPath(config.Memory.StoragePath);
+        var metadata = LoadSessionMetadata(memoryRoot);
+        var sessionIds = await LoadPersistedSessionIdsAsync(config, ct);
+        var orphaned = metadata.Where(item => !sessionIds.Contains(item.SessionId)).ToArray();
+
+        if (!dryRun && orphaned.Length > 0)
+        {
+            var retained = metadata.Where(item => sessionIds.Contains(item.SessionId)).ToArray();
+            SaveSessionMetadata(memoryRoot, retained);
+        }
+
+        return new MaintenanceFixAction
+        {
+            Id = "metadata",
+            Applied = !dryRun && orphaned.Length > 0,
+            Summary = orphaned.Length == 0
+                ? "No orphaned session metadata entries were found."
+                : dryRun
+                    ? $"Would remove {orphaned.Length} orphaned session metadata entr{(orphaned.Length == 1 ? "y" : "ies")}."
+                    : $"Removed {orphaned.Length} orphaned session metadata entr{(orphaned.Length == 1 ? "y" : "ies")}.",
+            NumericValue = orphaned.Length
+        };
+    }
+
+    private static MaintenanceFixAction PruneModelEvaluationArtifacts(GatewayConfig config, bool dryRun)
+    {
+        var path = Path.Combine(Path.GetFullPath(config.Memory.StoragePath), "admin", "model-evaluations");
+        if (!Directory.Exists(path))
+        {
+            return new MaintenanceFixAction
+            {
+                Id = "model-evaluations",
+                Applied = false,
+                Summary = "No model evaluation artifacts were found."
+            };
+        }
+
+        var groups = Directory.EnumerateFiles(path, "*", SearchOption.TopDirectoryOnly)
+            .GroupBy(static file => Path.GetFileNameWithoutExtension(file), StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(static group => group.Max(File.GetLastWriteTimeUtc))
+            .ToList();
+        var removable = groups.Skip(MaxModelEvaluationGroupsToKeep).SelectMany(static group => group).ToArray();
+
+        if (!dryRun)
+        {
+            foreach (var file in removable)
+            {
+                try { File.Delete(file); } catch { }
+            }
+        }
+
+        return new MaintenanceFixAction
+        {
+            Id = "model-evaluations",
+            Applied = !dryRun && removable.Length > 0,
+            Summary = removable.Length == 0
+                ? "Model evaluation artifacts are already within the retention window."
+                : dryRun
+                    ? $"Would remove {removable.Length} old model evaluation artifact(s)."
+                    : $"Removed {removable.Length} old model evaluation artifact(s).",
+            NumericValue = removable.Length
+        };
+    }
+
+    private static MaintenanceFixAction? PrunePromptCacheTraceArtifacts(GatewayConfig config, bool dryRun)
+    {
+        var memoryRoot = Path.GetFullPath(config.Memory.StoragePath);
+        var path = ResolvePromptCacheTracePath(config, memoryRoot);
+        if (!IsUnderRoot(path, memoryRoot))
+            return null;
+
+        var removable = File.Exists(path)
+            ? [path]
+            : Directory.Exists(path)
+                ? Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories).ToArray()
+                : [];
+
+        if (!dryRun)
+        {
+            foreach (var file in removable)
+            {
+                try { File.Delete(file); } catch { }
+            }
+        }
+
+        return new MaintenanceFixAction
+        {
+            Id = "prompt-cache-traces",
+            Applied = !dryRun && removable.Length > 0,
+            Summary = removable.Length == 0
+                ? "No managed prompt-cache trace artifacts were found."
+                : dryRun
+                    ? $"Would remove {removable.Length} managed prompt-cache trace artifact(s)."
+                    : $"Removed {removable.Length} managed prompt-cache trace artifact(s).",
+            NumericValue = removable.Length
+        };
+    }
+
+    private static IMemoryStore CreateMemoryStore(GatewayConfig config)
+    {
+        if (string.Equals(config.Memory.Provider, "sqlite", StringComparison.OrdinalIgnoreCase))
+        {
+            var dbPath = Path.IsPathRooted(config.Memory.Sqlite.DbPath)
+                ? config.Memory.Sqlite.DbPath
+                : Path.Combine(Path.GetFullPath(config.Memory.StoragePath), config.Memory.Sqlite.DbPath);
+            return new SqliteMemoryStore(Path.GetFullPath(dbPath), config.Memory.Sqlite.EnableFts, null, enableVectors: false);
+        }
+
+        return new FileMemoryStore(Path.GetFullPath(config.Memory.StoragePath));
+    }
+
+    private static IAutomationStore CreateAutomationStore(GatewayConfig config)
+    {
+        if (string.Equals(config.Memory.Provider, "sqlite", StringComparison.OrdinalIgnoreCase))
+        {
+            var dbPath = Path.IsPathRooted(config.Memory.Sqlite.DbPath)
+                ? config.Memory.Sqlite.DbPath
+                : Path.Combine(Path.GetFullPath(config.Memory.StoragePath), config.Memory.Sqlite.DbPath);
+            return new SqliteFeatureStore(Path.GetFullPath(dbPath));
+        }
+
+        return new FileFeatureStore(Path.GetFullPath(config.Memory.StoragePath));
+    }
+
+    private static async ValueTask DisposeIfNeededAsync(object store)
+    {
+        switch (store)
+        {
+            case IAsyncDisposable asyncDisposable:
+                await asyncDisposable.DisposeAsync();
+                break;
+            case IDisposable disposable:
+                disposable.Dispose();
+                break;
+        }
+    }
+
+    private static void DisposeIfNeeded(object store)
+    {
+        if (store is IDisposable disposable)
+            disposable.Dispose();
+    }
+}
+
+public static class ReliabilityScorer
+{
+    public static ReliabilitySnapshot Build(
+        GatewayConfig config,
+        MaintenanceScanInputs? inputs,
+        MaintenanceReportResponse? maintenanceReport,
+        ModelSelectionDoctorResponse? modelDoctor = null,
+        IReadOnlyList<AutomationRunState>? automationStates = null)
+    {
+        inputs ??= new MaintenanceScanInputs();
+        modelDoctor ??= inputs.ModelDoctor ?? ModelDoctorEvaluator.Build(config);
+        automationStates ??= inputs.AutomationRunStates;
+
+        var factors = new List<ReliabilityFactor>();
+        var recommendations = new List<ReliabilityRecommendation>();
+
+        factors.Add(BuildReadinessFactor(config, inputs.SetupStatus, recommendations, inputs.ConfigPath));
+        factors.Add(BuildModelFactor(modelDoctor, inputs.ProviderRoutes, recommendations));
+        factors.Add(BuildAutomationFactor(automationStates, recommendations));
+        factors.Add(BuildMaintenanceFactor(maintenanceReport, recommendations, inputs.ConfigPath));
+        factors.Add(BuildOperatorFactor(inputs, recommendations));
+
+        var score = factors.Sum(static item => item.Score);
+        return new ReliabilitySnapshot
+        {
+            Score = score,
+            Status = score >= 90
+                ? ReliabilityStates.Healthy
+                : score >= 70
+                    ? ReliabilityStates.Watch
+                    : ReliabilityStates.ActionNeeded,
+            Factors = factors,
+            Recommendations = recommendations
+                .GroupBy(static item => item.Id, StringComparer.OrdinalIgnoreCase)
+                .Select(static group => group.OrderByDescending(item => item.Priority).First())
+                .OrderByDescending(static item => item.Priority)
+                .Take(6)
+                .ToArray()
+        };
+    }
+
+    private static ReliabilityFactor BuildReadinessFactor(
+        GatewayConfig config,
+        SetupStatusResponse? setupStatus,
+        List<ReliabilityRecommendation> recommendations,
+        string? configPath)
+    {
+        var weight = 25;
+        var findings = new List<string>();
+        var score = weight;
+        var publicBind = setupStatus?.PublicBind ?? IsNonLoopbackBind(config.BindAddress);
+        var workspacePath = setupStatus?.WorkspacePath ?? config.Tooling.WorkspaceRoot;
+        var workspaceExists = setupStatus?.WorkspaceExists ?? (!string.IsNullOrWhiteSpace(workspacePath) && Directory.Exists(workspacePath));
+        var providerConfigured = setupStatus?.ProviderConfigured ?? ProviderSmokeProbe.IsProviderConfigured(config.Llm);
+
+        if (publicBind && string.IsNullOrWhiteSpace(config.AuthToken))
+        {
+            score -= 10;
+            findings.Add("Public bind is missing an auth token.");
+            recommendations.Add(new ReliabilityRecommendation
+            {
+                Id = "verify-provider",
+                Summary = "Re-run setup verification with provider requirements.",
+                Command = BuildConfigAwareCommand("openclaw setup verify --require-provider", configPath),
+                Priority = 100
+            });
+        }
+
+        if (!workspaceExists)
+        {
+            score -= 8;
+            findings.Add("Configured workspace path does not exist.");
+            recommendations.Add(new ReliabilityRecommendation
+            {
+                Id = "verify-workspace",
+                Summary = "Confirm the configured workspace and setup posture.",
+                Command = BuildConfigAwareCommand("openclaw setup status", configPath),
+                Priority = 85
+            });
+        }
+
+        if (!providerConfigured)
+        {
+            score -= 7;
+            findings.Add("No provider is configured.");
+            recommendations.Add(new ReliabilityRecommendation
+            {
+                Id = "require-provider",
+                Summary = "Finish provider configuration before relying on the gateway.",
+                Command = BuildConfigAwareCommand("openclaw setup verify --require-provider", configPath),
+                Priority = 95
+            });
+        }
+
+        return BuildFactor("readiness", "Readiness & posture", weight, score, findings);
+    }
+
+    private static ReliabilityFactor BuildModelFactor(
+        ModelSelectionDoctorResponse modelDoctor,
+        IReadOnlyList<ProviderRouteHealthSnapshot> routes,
+        List<ReliabilityRecommendation> recommendations)
+    {
+        var weight = 25;
+        var findings = new List<string>();
+        var score = weight;
+
+        if (modelDoctor.Errors.Count > 0)
+        {
+            score -= Math.Min(15, modelDoctor.Errors.Count * 5);
+            findings.Add($"{modelDoctor.Errors.Count} model-doctor error(s) are unresolved.");
+        }
+
+        if (modelDoctor.Warnings.Count > 0)
+        {
+            score -= Math.Min(8, modelDoctor.Warnings.Count * 2);
+            findings.Add($"{modelDoctor.Warnings.Count} model-doctor warning(s) are active.");
+        }
+
+        var compatibilityCount = modelDoctor.Profiles.Count(static item => item.UsesCompatibilityTransport);
+        if (compatibilityCount > 0)
+        {
+            score -= Math.Min(6, compatibilityCount * 2);
+            findings.Add($"{compatibilityCount} profile(s) still rely on compatibility transport.");
+        }
+
+        var routeErrors = routes.Sum(static item => item.Errors);
+        if (routeErrors > 0)
+        {
+            score -= Math.Min(6, (int)routeErrors);
+            findings.Add($"{routeErrors} recent provider route error(s) were recorded.");
+        }
+
+        if (findings.Count > 0)
+        {
+            recommendations.Add(new ReliabilityRecommendation
+            {
+                Id = "model-doctor",
+                Summary = "Resolve model and provider routing issues.",
+                Command = "openclaw models doctor",
+                Priority = 90
+            });
+        }
+
+        return BuildFactor("model_health", "Model & provider health", weight, score, findings);
+    }
+
+    private static ReliabilityFactor BuildAutomationFactor(
+        IReadOnlyList<AutomationRunState> automationStates,
+        List<ReliabilityRecommendation> recommendations)
+    {
+        var weight = 20;
+        var findings = new List<string>();
+        var score = weight;
+        var degraded = automationStates.Count(static item => string.Equals(item.HealthState, AutomationHealthStates.Degraded, StringComparison.OrdinalIgnoreCase));
+        var quarantined = automationStates.Count(static item => string.Equals(item.HealthState, AutomationHealthStates.Quarantined, StringComparison.OrdinalIgnoreCase));
+
+        if (degraded > 0)
+        {
+            score -= Math.Min(8, degraded * 2);
+            findings.Add($"{degraded} automation(s) are degraded.");
+        }
+
+        if (quarantined > 0)
+        {
+            score -= Math.Min(12, quarantined * 4);
+            findings.Add($"{quarantined} automation(s) are quarantined.");
+        }
+
+        if (findings.Count > 0)
+        {
+            recommendations.Add(new ReliabilityRecommendation
+            {
+                Id = "maintenance-scan",
+                Summary = "Review automation health before trusting scheduled runs.",
+                Command = "openclaw maintenance scan",
+                Priority = quarantined > 0 ? 88 : 70
+            });
+        }
+
+        return BuildFactor("automation_health", "Automation health", weight, score, findings);
+    }
+
+    private static ReliabilityFactor BuildMaintenanceFactor(
+        MaintenanceReportResponse? maintenanceReport,
+        List<ReliabilityRecommendation> recommendations,
+        string? configPath)
+    {
+        var weight = 20;
+        var findings = new List<string>();
+        var score = weight;
+
+        if (maintenanceReport is not null)
+        {
+            var failCount = maintenanceReport.Findings.Count(static item => string.Equals(item.Severity, MaintenanceFindingSeverities.Fail, StringComparison.OrdinalIgnoreCase));
+            var warnCount = maintenanceReport.Findings.Count(static item => string.Equals(item.Severity, MaintenanceFindingSeverities.Warn, StringComparison.OrdinalIgnoreCase));
+            score -= Math.Min(12, failCount * 4);
+            score -= Math.Min(8, warnCount * 2);
+
+            if (maintenanceReport.Storage.OrphanedSessionMetadataEntries > 0)
+                findings.Add($"{maintenanceReport.Storage.OrphanedSessionMetadataEntries} orphaned metadata entries remain.");
+            if (maintenanceReport.Drift.RetentionFailures > 0)
+                findings.Add($"{maintenanceReport.Drift.RetentionFailures} retention failure(s) were observed.");
+            if (maintenanceReport.Drift.PromptP95Delta > 0)
+                findings.Add($"Prompt p95 drift is +{maintenanceReport.Drift.PromptP95Delta:N0} tokens.");
+        }
+
+        if (findings.Count > 0)
+        {
+            recommendations.Add(new ReliabilityRecommendation
+            {
+                Id = "maintenance-fix",
+                Summary = "Run a dry-run maintenance fix and apply only the safe cleanup you want.",
+                Command = BuildConfigAwareCommand("openclaw maintenance fix --dry-run", configPath),
+                Priority = 80
+            });
+        }
+
+        return BuildFactor("maintenance_drift", "Maintenance & drift", weight, score, findings);
+    }
+
+    private static ReliabilityFactor BuildOperatorFactor(
+        MaintenanceScanInputs inputs,
+        List<ReliabilityRecommendation> recommendations)
+    {
+        var weight = 10;
+        var findings = new List<string>();
+        var score = weight;
+
+        if (inputs.PluginErrorCount > 0)
+        {
+            score -= Math.Min(6, inputs.PluginErrorCount * 2);
+            findings.Add($"{inputs.PluginErrorCount} plugin error(s) need operator review.");
+        }
+
+        if (inputs.PluginWarningCount > 0)
+        {
+            score -= Math.Min(4, inputs.PluginWarningCount);
+            findings.Add($"{inputs.PluginWarningCount} plugin warning(s) are active.");
+        }
+
+        if (inputs.ChannelDriftCount > 0)
+            findings.Add($"{inputs.ChannelDriftCount} channel(s) are not fully ready.");
+
+        if (findings.Count > 0)
+        {
+            recommendations.Add(new ReliabilityRecommendation
+            {
+                Id = "setup-status",
+                Summary = "Review setup posture and runtime hygiene before widening scope.",
+                Command = BuildConfigAwareCommand("openclaw setup status", inputs.ConfigPath),
+                Priority = 60
+            });
+        }
+
+        return BuildFactor("operator_hygiene", "Operator & runtime hygiene", weight, score, findings);
+    }
+
+    private static ReliabilityFactor BuildFactor(string id, string label, int weight, int score, IReadOnlyList<string> findings)
+    {
+        var boundedScore = Math.Clamp(score, 0, weight);
+        var status = boundedScore >= (int)Math.Ceiling(weight * 0.9)
+            ? ReliabilityStates.Healthy
+            : boundedScore >= (int)Math.Ceiling(weight * 0.6)
+                ? ReliabilityStates.Watch
+                : ReliabilityStates.ActionNeeded;
+        return new ReliabilityFactor
+        {
+            Id = id,
+            Label = label,
+            Weight = weight,
+            Score = boundedScore,
+            Status = status,
+            Findings = findings
+        };
+    }
+
+    private static string BuildConfigAwareCommand(string command, string? configPath)
+        => string.IsNullOrWhiteSpace(configPath)
+            ? command
+            : $"{command} --config {GatewaySetupPaths.QuoteIfNeeded(configPath)}";
+
+    private static bool IsNonLoopbackBind(string bindAddress)
+    {
+        var normalized = (bindAddress ?? string.Empty).Trim();
+        return normalized.Length > 0 &&
+               !string.Equals(normalized, "127.0.0.1", StringComparison.OrdinalIgnoreCase) &&
+               !string.Equals(normalized, "localhost", StringComparison.OrdinalIgnoreCase) &&
+               !string.Equals(normalized, "::1", StringComparison.OrdinalIgnoreCase) &&
+               !string.Equals(normalized, "[::1]", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/OpenClaw.Core/Setup/MaintenanceCoordinator.cs
+++ b/src/OpenClaw.Core/Setup/MaintenanceCoordinator.cs
@@ -127,16 +127,38 @@ public static class MaintenanceCoordinator
 
         if (applyMode is "all" or "metadata")
         {
-            var metadataAction = await PruneOrphanedMetadataAsync(config, request.DryRun, ct);
-            actions.Add(metadataAction);
+            try
+            {
+                var metadataAction = await PruneOrphanedMetadataAsync(config, request.DryRun, ct);
+                actions.Add(metadataAction);
+            }
+            catch (Exception ex)
+            {
+                warnings.Add($"Metadata pruning could not run: {ex.Message}");
+            }
         }
 
         if (applyMode is "all" or "artifacts")
         {
-            actions.Add(PruneModelEvaluationArtifacts(config, request.DryRun));
-            var traceAction = PrunePromptCacheTraceArtifacts(config, request.DryRun);
-            if (traceAction is not null)
-                actions.Add(traceAction);
+            try
+            {
+                actions.Add(PruneModelEvaluationArtifacts(config, request.DryRun));
+            }
+            catch (Exception ex)
+            {
+                warnings.Add($"Model evaluation artifact pruning could not run: {ex.Message}");
+            }
+
+            try
+            {
+                var traceAction = PrunePromptCacheTraceArtifacts(config, request.DryRun);
+                if (traceAction is not null)
+                    actions.Add(traceAction);
+            }
+            catch (Exception ex)
+            {
+                warnings.Add($"Prompt cache trace artifact pruning could not run: {ex.Message}");
+            }
         }
 
         var report = await ScanAsync(config, inputs, ct);

--- a/src/OpenClaw.Core/Validation/ConfigValidator.cs
+++ b/src/OpenClaw.Core/Validation/ConfigValidator.cs
@@ -1,5 +1,6 @@
 using OpenClaw.Core.Security;
 using OpenClaw.Core.Models;
+using OpenClaw.Core.Setup;
 using OpenClaw.Core.Plugins;
 
 namespace OpenClaw.Core.Validation;
@@ -583,6 +584,13 @@ public static class ConfigValidator
 
             if (string.IsNullOrWhiteSpace(profile.Model))
                 errors.Add($"Models.Profiles.{profile.Id}.Model must be set.");
+            if (!string.IsNullOrWhiteSpace(profile.PresetId))
+            {
+                if (!LocalModelPresetCatalog.TryGet(profile.PresetId, out _))
+                    errors.Add($"Models.Profiles.{profile.Id}.PresetId '{profile.PresetId}' is not a known local model preset.");
+                else if (!string.Equals(profile.Provider, "ollama", StringComparison.OrdinalIgnoreCase))
+                    errors.Add($"Models.Profiles.{profile.Id}.PresetId '{profile.PresetId}' currently requires Provider='ollama'.");
+            }
             if (profile.Capabilities?.MaxContextTokens < 0)
                 errors.Add($"Models.Profiles.{profile.Id}.Capabilities.MaxContextTokens must be >= 0.");
             if (profile.Capabilities?.MaxOutputTokens < 0)

--- a/src/OpenClaw.Core/Validation/ModelDoctorEvaluator.cs
+++ b/src/OpenClaw.Core/Validation/ModelDoctorEvaluator.cs
@@ -1,15 +1,20 @@
 using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Models;
 using OpenClaw.Core.Security;
+using OpenClaw.Core.Setup;
+using OpenClaw.Core.Observability;
 
 namespace OpenClaw.Core.Validation;
 
 public static class ModelDoctorEvaluator
 {
-    public static ModelSelectionDoctorResponse Build(GatewayConfig config, IModelProfileRegistry? registry = null)
+    public static ModelSelectionDoctorResponse Build(
+        GatewayConfig config,
+        IModelProfileRegistry? registry = null,
+        IReadOnlyList<ProviderTurnUsageEntry>? recentTurns = null)
     {
         if (registry is not null)
-            return BuildFromRegistry(registry);
+            return BuildFromRegistry(registry, recentTurns);
 
         var statuses = BuildStatusesFromConfig(config);
         var warnings = new List<string>();
@@ -25,6 +30,7 @@ public static class ModelDoctorEvaluator
         {
             if (status.ValidationIssues.Length > 0)
                 warnings.Add($"Profile '{status.Id}' has validation issues: {string.Join("; ", status.ValidationIssues)}");
+            warnings.AddRange(BuildPresetWarnings(status, config, recentTurns));
         }
 
         return new ModelSelectionDoctorResponse
@@ -36,7 +42,9 @@ public static class ModelDoctorEvaluator
         };
     }
 
-    private static ModelSelectionDoctorResponse BuildFromRegistry(IModelProfileRegistry registry)
+    private static ModelSelectionDoctorResponse BuildFromRegistry(
+        IModelProfileRegistry registry,
+        IReadOnlyList<ProviderTurnUsageEntry>? recentTurns)
     {
         var statuses = registry.ListStatuses();
         var warnings = new List<string>();
@@ -51,6 +59,7 @@ public static class ModelDoctorEvaluator
         {
             if (status.ValidationIssues.Length > 0)
                 warnings.Add($"Profile '{status.Id}' has validation issues: {string.Join("; ", status.ValidationIssues)}");
+            warnings.AddRange(BuildPresetWarnings(status, config: null, recentTurns));
         }
 
         return new ModelSelectionDoctorResponse
@@ -79,17 +88,20 @@ public static class ModelDoctorEvaluator
             statuses.Add(new ModelProfileStatus
             {
                 Id = normalizedId,
+                PresetId = Normalize(profile.PresetId),
                 ProviderId = providerId,
                 ModelId = modelId,
                 IsDefault = string.Equals(normalizedId, defaultProfileId, StringComparison.OrdinalIgnoreCase),
                 IsImplicit = config.Models.Profiles.Count == 0 && string.Equals(normalizedId, "default", StringComparison.OrdinalIgnoreCase),
                 IsAvailable = validationIssues.Length == 0,
-                Tags = NormalizeDistinct(profile.Tags),
-                Capabilities = profile.Capabilities ?? GuessCapabilities(providerId),
+                Tags = ResolveTags(profile),
+                Capabilities = ResolveCapabilities(profile, providerId),
                 PromptCaching = MergePromptCaching(config.Llm.PromptCaching, profile.PromptCaching),
                 ValidationIssues = validationIssues,
                 FallbackProfileIds = NormalizeDistinct(profile.FallbackProfileIds),
-                FallbackModels = NormalizeDistinct(profile.FallbackModels)
+                FallbackModels = NormalizeDistinct(profile.FallbackModels),
+                CompatibilityNotes = ResolveCompatibilityNotes(profile, config),
+                UsesCompatibilityTransport = providerId == "ollama" && OllamaEndpointNormalizer.UsesCompatibilityEndpoint(ResolveSecretValue(profile.BaseUrl) ?? ResolveSecretValue(config.Llm.Endpoint))
             });
         }
 
@@ -156,6 +168,12 @@ public static class ModelDoctorEvaluator
         {
             yield return "ApiKey is required for this provider unless inherited from OpenClaw:Llm:ApiKey.";
         }
+
+        if (providerId == "ollama" &&
+            OllamaEndpointNormalizer.UsesCompatibilityEndpoint(ResolveSecretValue(profile.BaseUrl) ?? ResolveSecretValue(config.Llm.Endpoint)))
+        {
+            yield return "This Ollama profile is using the legacy /v1 compatibility endpoint. Prefer the native Ollama base URL without /v1.";
+        }
     }
 
     private static bool RequiresEndpoint(string providerId)
@@ -218,4 +236,109 @@ public static class ModelDoctorEvaluator
 
     private static string? ResolveSecretValue(string? value)
         => string.IsNullOrWhiteSpace(value) ? value : SecretResolver.Resolve(value) ?? value;
+
+    private static ModelCapabilities ResolveCapabilities(ModelProfileConfig profile, string providerId)
+    {
+        if (profile.Capabilities is not null)
+            return profile.Capabilities;
+
+        if (LocalModelPresetCatalog.TryGet(profile.PresetId, out var preset) && preset is not null)
+            return preset.Capabilities;
+
+        return GuessCapabilities(providerId);
+    }
+
+    private static string[] ResolveTags(ModelProfileConfig profile)
+    {
+        var configured = NormalizeDistinct(profile.Tags);
+        if (!LocalModelPresetCatalog.TryGet(profile.PresetId, out var preset) || preset is null)
+            return configured;
+
+        return configured
+            .Concat(preset.Tags)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> ResolveCompatibilityNotes(ModelProfileConfig profile, GatewayConfig config)
+    {
+        var notes = new List<string>();
+        if ((Normalize(profile.Provider) ?? Normalize(config.Llm.Provider) ?? string.Empty) == "ollama" &&
+            OllamaEndpointNormalizer.UsesCompatibilityEndpoint(ResolveSecretValue(profile.BaseUrl) ?? ResolveSecretValue(config.Llm.Endpoint)))
+        {
+            notes.Add("Using legacy /v1 compatibility endpoint; migrate to the native Ollama base URL.");
+        }
+
+        if (LocalModelPresetCatalog.TryGet(profile.PresetId, out var preset) && preset is not null)
+            notes.AddRange(preset.CompatibilityNotes);
+
+        return notes.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildPresetWarnings(
+        ModelProfileStatus status,
+        GatewayConfig? config,
+        IReadOnlyList<ProviderTurnUsageEntry>? recentTurns)
+    {
+        var warnings = new List<string>();
+        if (status.ProviderId.Equals("ollama", StringComparison.OrdinalIgnoreCase) &&
+            string.IsNullOrWhiteSpace(status.PresetId))
+        {
+            warnings.Add($"Profile '{status.Id}' is an Ollama profile without a PresetId. Use a local preset so doctor and setup can apply local-model guidance.");
+        }
+
+        if (status.UsesCompatibilityTransport)
+        {
+            warnings.Add($"Profile '{status.Id}' is still using the legacy Ollama /v1 compatibility endpoint.");
+        }
+
+        if (status.ProviderId.Equals("ollama", StringComparison.OrdinalIgnoreCase) &&
+            status.Capabilities.SupportsTools &&
+            status.FallbackProfileIds.Length == 0 &&
+            status.FallbackModels.Length == 0)
+        {
+            warnings.Add($"Profile '{status.Id}' is local-agentic but has no fallback profile configured for unsupported features or context overflow.");
+        }
+
+        if (LocalModelPresetCatalog.TryGet(status.PresetId, out var preset) && preset is not null &&
+            recentTurns is { Count: > 0 })
+        {
+            var matchingTurns = recentTurns
+                .Where(turn => string.Equals(turn.ProviderId, status.ProviderId, StringComparison.OrdinalIgnoreCase) &&
+                               string.Equals(turn.ModelId, status.ModelId, StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(static turn => turn.TimestampUtc)
+                .Take(20)
+                .ToArray();
+
+            if (matchingTurns.Length > 0)
+            {
+                var p95 = matchingTurns
+                    .Select(static turn => turn.InputTokens)
+                    .OrderBy(static value => value)
+                    .ElementAt((int)Math.Floor((matchingTurns.Length - 1) * 0.95));
+                var threshold = (long)(preset.RecommendedContextTokens * 0.85);
+                if (p95 >= threshold)
+                {
+                    warnings.Add($"Profile '{status.Id}' is seeing recent prompt sizes near its effective context headroom (p95 {p95} tokens vs recommended {preset.RecommendedContextTokens}).");
+                }
+            }
+        }
+
+        if (config is not null && status.ProviderId.Equals("ollama", StringComparison.OrdinalIgnoreCase))
+        {
+            foreach (var route in config.Routing.Routes.Where(static item => !string.IsNullOrWhiteSpace(item.Value.ModelProfileId)))
+            {
+                if (!string.Equals(route.Value.ModelProfileId, status.Id, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (route.Value.ModelRequirements.SupportsTools == true && !status.Capabilities.SupportsTools && status.FallbackProfileIds.Length == 0)
+                    warnings.Add($"Route '{route.Key}' selects local profile '{status.Id}' for tool-required traffic without a compatible fallback profile.");
+
+                if (route.Value.ModelRequirements.SupportsJsonSchema == true && !status.Capabilities.SupportsJsonSchema && status.FallbackProfileIds.Length == 0)
+                    warnings.Add($"Route '{route.Key}' selects local profile '{status.Id}' for structured-output traffic without a compatible fallback profile.");
+            }
+        }
+
+        return warnings;
+    }
 }

--- a/src/OpenClaw.Core/Validation/ModelDoctorEvaluator.cs
+++ b/src/OpenClaw.Core/Validation/ModelDoctorEvaluator.cs
@@ -168,12 +168,6 @@ public static class ModelDoctorEvaluator
         {
             yield return "ApiKey is required for this provider unless inherited from OpenClaw:Llm:ApiKey.";
         }
-
-        if (providerId == "ollama" &&
-            OllamaEndpointNormalizer.UsesCompatibilityEndpoint(ResolveSecretValue(profile.BaseUrl) ?? ResolveSecretValue(config.Llm.Endpoint)))
-        {
-            yield return "This Ollama profile is using the legacy /v1 compatibility endpoint. Prefer the native Ollama base URL without /v1.";
-        }
     }
 
     private static bool RequiresEndpoint(string providerId)
@@ -267,6 +261,11 @@ public static class ModelDoctorEvaluator
             OllamaEndpointNormalizer.UsesCompatibilityEndpoint(ResolveSecretValue(profile.BaseUrl) ?? ResolveSecretValue(config.Llm.Endpoint)))
         {
             notes.Add("Using legacy /v1 compatibility endpoint; migrate to the native Ollama base URL.");
+        }
+        if ((Normalize(profile.Provider) ?? Normalize(config.Llm.Provider) ?? string.Empty) == "ollama" &&
+            string.IsNullOrWhiteSpace(profile.PresetId))
+        {
+            notes.Add("No local preset is configured; setup and doctor guidance will be more limited until a PresetId is added.");
         }
 
         if (LocalModelPresetCatalog.TryGet(profile.PresetId, out var preset) && preset is not null)

--- a/src/OpenClaw.Core/Validation/OllamaEndpointNormalizer.cs
+++ b/src/OpenClaw.Core/Validation/OllamaEndpointNormalizer.cs
@@ -1,0 +1,38 @@
+namespace OpenClaw.Core.Validation;
+
+public static class OllamaEndpointNormalizer
+{
+    public const string DefaultBaseUrl = "http://127.0.0.1:11434";
+
+    public static string NormalizeBaseUrl(string? endpoint)
+    {
+        return Normalize(endpoint).BaseUrl;
+    }
+
+    public static bool UsesCompatibilityEndpoint(string? endpoint)
+    {
+        return Normalize(endpoint).UsesCompatibilityEndpoint;
+    }
+
+    public static (string BaseUrl, bool UsesCompatibilityEndpoint) Normalize(string? endpoint)
+    {
+        if (string.IsNullOrWhiteSpace(endpoint))
+            return (DefaultBaseUrl, false);
+
+        var trimmed = endpoint.Trim().TrimEnd('/');
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+            return (trimmed, false);
+
+        var path = uri.AbsolutePath.TrimEnd('/');
+        if (string.Equals(path, "/v1", StringComparison.OrdinalIgnoreCase))
+        {
+            var builder = new UriBuilder(uri)
+            {
+                Path = string.Empty
+            };
+            return (builder.Uri.ToString().TrimEnd('/'), true);
+        }
+
+        return (trimmed, false);
+    }
+}

--- a/src/OpenClaw.Core/Validation/ProviderSmokeProbe.cs
+++ b/src/OpenClaw.Core/Validation/ProviderSmokeProbe.cs
@@ -148,8 +148,9 @@ public static class ProviderSmokeProbe
     {
         return provider switch
         {
-            "openai" or "openai-compatible" or "groq" or "together" or "lmstudio" or "ollama" or "azure-openai"
+            "openai" or "openai-compatible" or "groq" or "together" or "lmstudio" or "azure-openai"
                 => BuildOpenAiStyleRequest(provider, config, apiKey),
+            "ollama" => BuildOllamaRequest(config),
             "anthropic" or "claude" or "anthropic-vertex" or "amazon-bedrock"
                 => BuildAnthropicStyleRequest(provider, config, apiKey),
             "gemini" or "google"
@@ -166,7 +167,6 @@ public static class ProviderSmokeProbe
             "groq" => AppendPath(config.Endpoint, "https://api.groq.com/openai/v1", "chat/completions"),
             "together" => AppendPath(config.Endpoint, "https://api.together.xyz/v1", "chat/completions"),
             "lmstudio" => AppendPath(config.Endpoint, "http://127.0.0.1:1234/v1", "chat/completions"),
-            "ollama" => AppendPath(config.Endpoint, "http://127.0.0.1:11434/v1", "chat/completions"),
             "azure-openai" => AppendPath(config.Endpoint, null, "chat/completions"),
             _ => AppendPath(config.Endpoint, null, "chat/completions")
         };
@@ -182,6 +182,16 @@ public static class ProviderSmokeProbe
             {"model":"{{EscapeJson(config.Model)}}","messages":[{"role":"user","content":"Reply with READY."}],"temperature":0,"max_tokens":8}
             """);
         return request;
+    }
+
+    private static HttpRequestMessage BuildOllamaRequest(LlmProviderConfig config)
+    {
+        var endpoint = $"{OllamaEndpointNormalizer.NormalizeBaseUrl(config.Endpoint).TrimEnd('/')}/api/chat";
+        return new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = BuildJsonContent(
+                $"{{\"model\":\"{EscapeJson(config.Model)}\",\"stream\":false,\"messages\":[{{\"role\":\"user\",\"content\":\"Reply with READY.\"}}],\"options\":{{\"temperature\":0,\"num_predict\":8}}}}")
+        };
     }
 
     private static HttpRequestMessage BuildAnthropicStyleRequest(string provider, LlmProviderConfig config, string? apiKey)

--- a/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
@@ -122,6 +122,7 @@ internal static class CoreServicesExtensions
         services.AddSingleton<AutomationRunCoordinator>();
         services.AddSingleton<IAutomationRunDispatcher>(sp => sp.GetRequiredService<AutomationRunCoordinator>());
         services.AddSingleton<GatewayAutomationService>();
+        services.AddSingleton<GatewayMaintenanceRuntimeService>();
         services.AddSingleton<LearningService>();
         services.AddSingleton<ICronJobSource, GatewayCronJobSource>();
         services.AddSingleton<ActorRateLimitService>(sp =>

--- a/src/OpenClaw.Gateway/Composition/IntegrationApiFacade.cs
+++ b/src/OpenClaw.Gateway/Composition/IntegrationApiFacade.cs
@@ -18,6 +18,7 @@ internal sealed class IntegrationApiFacade
     private readonly IMemoryNoteCatalog? _memoryCatalog;
     private readonly IToolPresetResolver? _toolPresetResolver;
     private readonly TextToSpeechService? _textToSpeechService;
+    private readonly GatewayMaintenanceRuntimeService? _maintenanceService;
 
     public static IntegrationApiFacade Create(
         GatewayStartupContext startup,
@@ -35,6 +36,7 @@ internal sealed class IntegrationApiFacade
         var memoryCatalog = services.GetService<IMemoryStore>() as IMemoryNoteCatalog;
         var toolPresetResolver = services.GetService<IToolPresetResolver>();
         var textToSpeechService = services.GetService<TextToSpeechService>();
+        var maintenanceService = services.GetService<GatewayMaintenanceRuntimeService>();
 
         return new IntegrationApiFacade(
             startup,
@@ -46,7 +48,8 @@ internal sealed class IntegrationApiFacade
             learningService,
             memoryCatalog,
             toolPresetResolver,
-            textToSpeechService);
+            textToSpeechService,
+            maintenanceService);
     }
 
     public IntegrationApiFacade(
@@ -59,7 +62,8 @@ internal sealed class IntegrationApiFacade
         LearningService learningService,
         IMemoryNoteCatalog? memoryCatalog,
         IToolPresetResolver? toolPresetResolver,
-        TextToSpeechService? textToSpeechService)
+        TextToSpeechService? textToSpeechService,
+        GatewayMaintenanceRuntimeService? maintenanceService)
     {
         _startup = startup;
         _runtime = runtime;
@@ -71,6 +75,7 @@ internal sealed class IntegrationApiFacade
         _memoryCatalog = memoryCatalog;
         _toolPresetResolver = toolPresetResolver;
         _textToSpeechService = textToSpeechService;
+        _maintenanceService = maintenanceService;
     }
 
     public IntegrationStatusResponse BuildStatusResponse()
@@ -341,7 +346,7 @@ internal sealed class IntegrationApiFacade
             .ToArray();
         var memoryEvents = _runtime.Operations.RuntimeEvents.Query(new RuntimeEventQuery { Limit = 20, Component = "memory" });
 
-        return new OperatorDashboardSnapshot
+        var snapshot = new OperatorDashboardSnapshot
         {
             Sessions = new DashboardSessionSummary
             {
@@ -449,6 +454,23 @@ internal sealed class IntegrationApiFacade
                     pluginHealth.GroupBy(static item => item.CompatibilityStatus, StringComparer.OrdinalIgnoreCase)
                         .Select(static group => (Key: group.Key, Label: group.Key, Count: group.Count())))
             }
+        };
+
+        if (_maintenanceService is null)
+            return snapshot;
+
+        var maintenance = await _maintenanceService.ScanAsync(setupStatus: null, cancellationToken);
+        return new OperatorDashboardSnapshot
+        {
+            Sessions = snapshot.Sessions,
+            Approvals = snapshot.Approvals,
+            Memory = snapshot.Memory,
+            Automations = snapshot.Automations,
+            Learning = snapshot.Learning,
+            Delegation = snapshot.Delegation,
+            Channels = snapshot.Channels,
+            Plugins = snapshot.Plugins,
+            Reliability = maintenance.Reliability
         };
     }
 

--- a/src/OpenClaw.Gateway/Composition/IntegrationApiFacade.cs
+++ b/src/OpenClaw.Gateway/Composition/IntegrationApiFacade.cs
@@ -234,6 +234,9 @@ internal sealed class IntegrationApiFacade
     }
 
     public async Task<OperatorDashboardSnapshot> GetOperatorDashboardAsync(CancellationToken cancellationToken)
+        => await GetOperatorDashboardAsync(reliability: null, cancellationToken);
+
+    public async Task<OperatorDashboardSnapshot> GetOperatorDashboardAsync(ReliabilitySnapshot? reliability, CancellationToken cancellationToken)
     {
         var metadataById = _runtime.Operations.SessionMetadata.GetAll();
         var persistedSessions = await SessionAdminPersistedListing.ListAllMatchingSummariesAsync(
@@ -456,11 +459,20 @@ internal sealed class IntegrationApiFacade
             }
         };
 
+        if (reliability is not null)
+            return CloneWithReliability(snapshot, reliability);
+
         if (_maintenanceService is null)
             return snapshot;
 
         var maintenance = await _maintenanceService.ScanAsync(setupStatus: null, cancellationToken);
-        return new OperatorDashboardSnapshot
+        return CloneWithReliability(snapshot, maintenance.Reliability);
+    }
+
+    private static OperatorDashboardSnapshot CloneWithReliability(
+        OperatorDashboardSnapshot snapshot,
+        ReliabilitySnapshot reliability)
+        => new()
         {
             Sessions = snapshot.Sessions,
             Approvals = snapshot.Approvals,
@@ -470,9 +482,8 @@ internal sealed class IntegrationApiFacade
             Delegation = snapshot.Delegation,
             Channels = snapshot.Channels,
             Plugins = snapshot.Plugins,
-            Reliability = maintenance.Reliability
+            Reliability = reliability
         };
-    }
 
     public async Task<IntegrationSessionSearchResponse> SearchSessionsAsync(SessionSearchQuery query, CancellationToken cancellationToken)
         => new()

--- a/src/OpenClaw.Gateway/Endpoints/AdminEndpoints.cs
+++ b/src/OpenClaw.Gateway/Endpoints/AdminEndpoints.cs
@@ -52,6 +52,8 @@ internal static class AdminEndpoints
             ?? new SessionMetadataStore(startup.Config.Memory.StoragePath, NullLogger<SessionMetadataStore>.Instance);
         var toolPresetResolver = new ToolPresetResolver(startup.Config, sessionMetadataStore);
         var observability = new AdminObservabilityService(startup, runtime, automationService, organizationPolicy);
+        var maintenance = app.Services.GetService<GatewayMaintenanceRuntimeService>()
+            ?? new GatewayMaintenanceRuntimeService(startup, runtime, automationService);
         var sessionAdminStore = app.Services.GetRequiredService<ISessionAdminStore>();
         var operations = runtime.Operations;
         var providerSmokeRegistry = app.Services.GetService<ProviderSmokeRegistry>()
@@ -439,6 +441,16 @@ internal static class AdminEndpoints
             var retentionStatus = await runtime.RetentionCoordinator.GetStatusAsync(ctx.RequestAborted);
             var pluginHealth = operations.PluginHealth.ListSnapshots();
 
+            var setupStatus = await BuildSetupStatusResponseAsync(
+                startup,
+                organizationPolicy,
+                operatorAccounts,
+                modelProfiles,
+                providerSmokeRegistry,
+                setupVerificationSnapshots,
+                maintenance,
+                ctx.RequestAborted);
+
             var response = new AdminSummaryResponse
             {
                 Auth = new AdminSummaryAuth
@@ -487,21 +499,72 @@ internal static class AdminEndpoints
                     Routes = operations.LlmExecution.SnapshotRoutes(),
                     RecentTurns = runtime.ProviderUsage.RecentTurns(limit: 20)
                 },
-                Dashboard = await facade.GetOperatorDashboardAsync(ctx.RequestAborted)
+                Dashboard = await facade.GetOperatorDashboardAsync(ctx.RequestAborted),
+                Reliability = setupStatus.Reliability
             };
 
             return Results.Json(response, CoreJsonContext.Default.AdminSummaryResponse);
         });
 
-        app.MapGet("/admin/setup/status", (HttpContext ctx) =>
+        app.MapGet("/admin/setup/status", async (HttpContext ctx) =>
         {
             var authResult = AuthorizeOperator(ctx, startup, browserSessions, operations, requireCsrf: false, endpointScope: "admin.setup.status");
             if (authResult.Failure is not null)
                 return authResult.Failure;
 
             return Results.Json(
-                BuildSetupStatusResponse(startup, organizationPolicy, operatorAccounts, modelProfiles, providerSmokeRegistry, setupVerificationSnapshots),
+                await BuildSetupStatusResponseAsync(
+                    startup,
+                    organizationPolicy,
+                    operatorAccounts,
+                    modelProfiles,
+                    providerSmokeRegistry,
+                    setupVerificationSnapshots,
+                    maintenance,
+                    ctx.RequestAborted),
                 CoreJsonContext.Default.SetupStatusResponse);
+        });
+
+        app.MapGet("/admin/maintenance", async (HttpContext ctx) =>
+        {
+            var authResult = AuthorizeOperator(ctx, startup, browserSessions, operations, requireCsrf: false, endpointScope: "admin.observability");
+            if (authResult.Failure is not null)
+                return authResult.Failure;
+
+            var setupStatus = await BuildSetupStatusResponseAsync(
+                startup,
+                organizationPolicy,
+                operatorAccounts,
+                modelProfiles,
+                providerSmokeRegistry,
+                setupVerificationSnapshots,
+                maintenance,
+                ctx.RequestAborted);
+            var report = await maintenance.ScanAsync(setupStatus, ctx.RequestAborted);
+            return Results.Json(report, CoreJsonContext.Default.MaintenanceReportResponse);
+        });
+
+        app.MapPost("/admin/maintenance/fix", async (HttpContext ctx) =>
+        {
+            var authResult = AuthorizeOperator(ctx, startup, browserSessions, operations, requireCsrf: true, endpointScope: "admin.observability");
+            if (authResult.Failure is not null)
+                return authResult.Failure;
+
+            var requestPayload = await ReadJsonBodyAsync(ctx, CoreJsonContext.Default.MaintenanceFixRequest);
+            if (requestPayload.Failure is not null)
+                return requestPayload.Failure;
+
+            var setupStatus = await BuildSetupStatusResponseAsync(
+                startup,
+                organizationPolicy,
+                operatorAccounts,
+                modelProfiles,
+                providerSmokeRegistry,
+                setupVerificationSnapshots,
+                maintenance,
+                ctx.RequestAborted);
+            var result = await maintenance.FixAsync(requestPayload.Value ?? new MaintenanceFixRequest(), setupStatus, ctx.RequestAborted);
+            return Results.Json(result, CoreJsonContext.Default.MaintenanceFixResponse);
         });
 
         app.MapGet("/admin/setup/verify", async (HttpContext ctx) =>
@@ -3310,13 +3373,15 @@ internal static class AdminEndpoints
             : null;
     }
 
-    private static SetupStatusResponse BuildSetupStatusResponse(
+    private static async Task<SetupStatusResponse> BuildSetupStatusResponseAsync(
         GatewayStartupContext startup,
         OrganizationPolicyService organizationPolicy,
         OperatorAccountService operatorAccounts,
         IModelProfileRegistry modelProfiles,
         ProviderSmokeRegistry providerSmokeRegistry,
-        SetupVerificationSnapshotStore setupVerificationSnapshots)
+        SetupVerificationSnapshotStore setupVerificationSnapshots,
+        GatewayMaintenanceRuntimeService maintenance,
+        CancellationToken ct)
     {
         var policy = organizationPolicy.GetSnapshot();
         var publicBind = startup.IsNonLoopbackBind;
@@ -3335,7 +3400,7 @@ internal static class AdminEndpoints
         if (string.IsNullOrWhiteSpace(startup.Config.AuthToken))
             warnings.Add("No auth token is configured.");
 
-        return new SetupStatusResponse
+        var status = new SetupStatusResponse
         {
             Profile = publicBind ? "public" : "local",
             BindAddress = startup.Config.BindAddress,
@@ -3374,6 +3439,42 @@ internal static class AdminEndpoints
             ChannelReadiness = MapChannelReadiness(ChannelReadinessEvaluator.Evaluate(startup.Config, startup.IsNonLoopbackBind)),
             Artifacts = BuildSetupArtifacts(deployDirectory),
             Warnings = warnings
+        };
+
+        var maintenanceReport = await maintenance.ScanAsync(status, ct);
+        return new SetupStatusResponse
+        {
+            Profile = status.Profile,
+            BindAddress = status.BindAddress,
+            Port = status.Port,
+            PublicBind = status.PublicBind,
+            AuthTokenConfigured = status.AuthTokenConfigured,
+            BootstrapTokenEnabled = status.BootstrapTokenEnabled,
+            AllowedAuthModes = status.AllowedAuthModes,
+            MinimumPluginTrustLevel = status.MinimumPluginTrustLevel,
+            ReverseProxyRecommended = status.ReverseProxyRecommended,
+            ReachableBaseUrl = status.ReachableBaseUrl,
+            WorkspacePath = status.WorkspacePath,
+            WorkspaceExists = status.WorkspaceExists,
+            HasOperatorAccounts = status.HasOperatorAccounts,
+            OperatorAccountCount = status.OperatorAccountCount,
+            ProviderConfigured = status.ProviderConfigured,
+            ProviderSmokeStatus = status.ProviderSmokeStatus,
+            ModelDoctorStatus = status.ModelDoctorStatus,
+            BrowserToolRegistered = status.BrowserToolRegistered,
+            BrowserExecutionBackendConfigured = status.BrowserExecutionBackendConfigured,
+            BrowserCapabilityReason = status.BrowserCapabilityReason,
+            LastVerificationAtUtc = status.LastVerificationAtUtc,
+            LastVerificationSource = status.LastVerificationSource,
+            LastVerificationStatus = status.LastVerificationStatus,
+            LastVerificationHasFailures = status.LastVerificationHasFailures,
+            LastVerificationHasWarnings = status.LastVerificationHasWarnings,
+            BootstrapGuidanceState = status.BootstrapGuidanceState,
+            RecommendedNextActions = status.RecommendedNextActions,
+            ChannelReadiness = status.ChannelReadiness,
+            Artifacts = status.Artifacts,
+            Warnings = status.Warnings,
+            Reliability = maintenanceReport.Reliability
         };
     }
 

--- a/src/OpenClaw.Gateway/Endpoints/AdminEndpoints.cs
+++ b/src/OpenClaw.Gateway/Endpoints/AdminEndpoints.cs
@@ -449,6 +449,7 @@ internal static class AdminEndpoints
                 providerSmokeRegistry,
                 setupVerificationSnapshots,
                 maintenance,
+                includeReliability: true,
                 ctx.RequestAborted);
 
             var response = new AdminSummaryResponse
@@ -499,7 +500,7 @@ internal static class AdminEndpoints
                     Routes = operations.LlmExecution.SnapshotRoutes(),
                     RecentTurns = runtime.ProviderUsage.RecentTurns(limit: 20)
                 },
-                Dashboard = await facade.GetOperatorDashboardAsync(ctx.RequestAborted),
+                Dashboard = await facade.GetOperatorDashboardAsync(setupStatus.Reliability, ctx.RequestAborted),
                 Reliability = setupStatus.Reliability
             };
 
@@ -521,6 +522,7 @@ internal static class AdminEndpoints
                     providerSmokeRegistry,
                     setupVerificationSnapshots,
                     maintenance,
+                    includeReliability: true,
                     ctx.RequestAborted),
                 CoreJsonContext.Default.SetupStatusResponse);
         });
@@ -539,6 +541,7 @@ internal static class AdminEndpoints
                 providerSmokeRegistry,
                 setupVerificationSnapshots,
                 maintenance,
+                includeReliability: false,
                 ctx.RequestAborted);
             var report = await maintenance.ScanAsync(setupStatus, ctx.RequestAborted);
             return Results.Json(report, CoreJsonContext.Default.MaintenanceReportResponse);
@@ -562,6 +565,7 @@ internal static class AdminEndpoints
                 providerSmokeRegistry,
                 setupVerificationSnapshots,
                 maintenance,
+                includeReliability: false,
                 ctx.RequestAborted);
             var result = await maintenance.FixAsync(requestPayload.Value ?? new MaintenanceFixRequest(), setupStatus, ctx.RequestAborted);
             return Results.Json(result, CoreJsonContext.Default.MaintenanceFixResponse);
@@ -3381,6 +3385,7 @@ internal static class AdminEndpoints
         ProviderSmokeRegistry providerSmokeRegistry,
         SetupVerificationSnapshotStore setupVerificationSnapshots,
         GatewayMaintenanceRuntimeService maintenance,
+        bool includeReliability,
         CancellationToken ct)
     {
         var policy = organizationPolicy.GetSnapshot();
@@ -3440,6 +3445,9 @@ internal static class AdminEndpoints
             Artifacts = BuildSetupArtifacts(deployDirectory),
             Warnings = warnings
         };
+
+        if (!includeReliability)
+            return status;
 
         var maintenanceReport = await maintenance.ScanAsync(status, ct);
         return new SetupStatusResponse

--- a/src/OpenClaw.Gateway/Extensions/GatewayWorkers.cs
+++ b/src/OpenClaw.Gateway/Extensions/GatewayWorkers.cs
@@ -626,20 +626,32 @@ internal static class GatewayWorkers
                                 await wsChannel.SendStreamEventAsync(msg.SenderId, "typing_start", "", msg.MessageId, processingCt);
 
                                 AgentStreamEvent? doneEvent = null;
-                                await foreach (var evt in agentRuntime.RunStreamingAsync(
-                                    session, messageText, processingCt, approvalCallback: approvalCallback))
-                                {
-                                    if (string.Equals(evt.EnvelopeType, "assistant_done", StringComparison.Ordinal))
-                                    {
-                                        doneEvent = evt;
-                                        continue;
-                                    }
+                                var originalResponseMode = session.ResponseMode;
+                                var effectiveResponseMode = ResolveOperationalResponseMode(session, automation);
+                                if (!string.IsNullOrWhiteSpace(effectiveResponseMode))
+                                    session.ResponseMode = effectiveResponseMode!;
 
-                                    await wsChannel.SendStreamEventAsync(
-                                        msg.SenderId,
-                                        evt,
-                                        msg.MessageId,
-                                        processingCt);
+                                try
+                                {
+                                    await foreach (var evt in agentRuntime.RunStreamingAsync(
+                                        session, messageText, processingCt, approvalCallback: approvalCallback))
+                                    {
+                                        if (string.Equals(evt.EnvelopeType, "assistant_done", StringComparison.Ordinal))
+                                        {
+                                            doneEvent = evt;
+                                            continue;
+                                        }
+
+                                        await wsChannel.SendStreamEventAsync(
+                                            msg.SenderId,
+                                            evt,
+                                            msg.MessageId,
+                                            processingCt);
+                                    }
+                                }
+                                finally
+                                {
+                                    session.ResponseMode = originalResponseMode;
                                 }
                                 await sessionManager.PersistAsync(session, processingCt, sessionLockHeld: true);
                                 if (learningService is not null)
@@ -711,7 +723,21 @@ internal static class GatewayWorkers
                                     bridgedTypingStarted = true;
                                 }
 
-                                var responseText = await agentRuntime.RunAsync(session, messageText, processingCt, approvalCallback: approvalCallback);
+                                var originalResponseMode = session.ResponseMode;
+                                var effectiveResponseMode = ResolveOperationalResponseMode(session, automation);
+                                if (!string.IsNullOrWhiteSpace(effectiveResponseMode))
+                                    session.ResponseMode = effectiveResponseMode!;
+
+                                string responseText;
+                                try
+                                {
+                                    responseText = await agentRuntime.RunAsync(session, messageText, processingCt, approvalCallback: approvalCallback);
+                                }
+                                finally
+                                {
+                                    session.ResponseMode = originalResponseMode;
+                                }
+
                                 await sessionManager.PersistAsync(session, processingCt, sessionLockHeld: true);
                                 if (learningService is not null)
                                     await learningService.ObserveSessionAsync(session, processingCt);
@@ -953,6 +979,25 @@ internal static class GatewayWorkers
             return null;
 
         return CancellationTokenSource.CreateLinkedTokenSource(requestCancellation, appStopping);
+    }
+
+    private static string? ResolveOperationalResponseMode(Session session, AutomationDefinition? automation)
+    {
+        if (automation is not null)
+        {
+            if (string.Equals(automation.ResponseMode, SessionResponseModes.Full, StringComparison.OrdinalIgnoreCase))
+                return SessionResponseModes.Full;
+
+            return SessionResponseModes.ConciseOps;
+        }
+
+        if (session.ContractPolicy is not null &&
+            string.Equals(session.ResponseMode, SessionResponseModes.Default, StringComparison.OrdinalIgnoreCase))
+        {
+            return SessionResponseModes.ConciseOps;
+        }
+
+        return null;
     }
 
     private static void ObserveBackgroundTask(Task task, ILogger logger, string operation)

--- a/src/OpenClaw.Gateway/Extensions/LlmClientFactory.cs
+++ b/src/OpenClaw.Gateway/Extensions/LlmClientFactory.cs
@@ -7,6 +7,7 @@ using GeminiDotnet;
 using GeminiDotnet.Extensions.AI;
 using Microsoft.Extensions.AI;
 using OpenClaw.Core.Models;
+using OpenClaw.Core.Validation;
 
 namespace OpenClaw.Gateway.Extensions;
 
@@ -97,14 +98,12 @@ public static class LlmClientFactory
                 })
                 .AsIChatClient(config.Model),
             "gemini" or "google" => CreateGeminiClient(config),
-            "ollama" => CreateOpenAiClient(new LlmProviderConfig
+            "ollama" => new OllamaChatClient(new LlmProviderConfig
                 {
-                    ApiKey = config.ApiKey ?? "ollama",
-                    Endpoint = config.Endpoint ?? "http://localhost:11434/v1",
+                    ApiKey = config.ApiKey,
+                    Endpoint = OllamaEndpointNormalizer.NormalizeBaseUrl(config.Endpoint),
                     Model = config.Model
-                })
-                .GetChatClient(config.Model)
-                .AsIChatClient(),
+                }),
             "azure-openai" => CreateAzureOpenAiClient(config)
                 .GetChatClient(config.Model)
                 .AsIChatClient(),
@@ -149,10 +148,10 @@ public static class LlmClientFactory
         return config.Provider.ToLowerInvariant() switch
         {
             "openai" or "azure-openai" => CreateOpenAiEmbeddingClient(config, embeddingModel!),
-            "ollama" => CreateOpenAiEmbeddingClient(new LlmProviderConfig
+            "ollama" => new OllamaEmbeddingGenerator(new LlmProviderConfig
             {
-                ApiKey = config.ApiKey ?? "ollama",
-                Endpoint = config.Endpoint ?? "http://localhost:11434/v1",
+                ApiKey = config.ApiKey,
+                Endpoint = OllamaEndpointNormalizer.NormalizeBaseUrl(config.Endpoint),
                 Model = config.Model
             }, embeddingModel!),
             "gemini" or "google" => CreateGeminiEmbeddingClient(config, embeddingModel!),

--- a/src/OpenClaw.Gateway/Extensions/OllamaNativeClients.cs
+++ b/src/OpenClaw.Gateway/Extensions/OllamaNativeClients.cs
@@ -1,0 +1,518 @@
+using System.Collections;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.AI;
+using OpenClaw.Core.Http;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Validation;
+
+namespace OpenClaw.Gateway.Extensions;
+
+internal sealed class OllamaChatClient : IChatClient
+{
+    private readonly string _defaultModel;
+    private readonly Uri _chatUri;
+    private readonly HttpClient _httpClient;
+
+    public OllamaChatClient(LlmProviderConfig config, HttpClient? httpClient = null)
+    {
+        _defaultModel = config.Model;
+        _chatUri = new Uri($"{OllamaEndpointNormalizer.NormalizeBaseUrl(config.Endpoint).TrimEnd('/')}/api/chat", UriKind.Absolute);
+        _httpClient = httpClient ?? HttpClientFactory.Create(allowAutoRedirect: false);
+    }
+
+    public async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        using var request = BuildRequest(messages, options, stream: false);
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+            throw await CreateFailureAsync(response, cancellationToken);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync(cancellationToken));
+        var assistantContents = ParseAssistantContents(document.RootElement);
+        var usage = ParseUsage(document.RootElement);
+        var chatResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, assistantContents))
+        {
+            Usage = usage,
+            AdditionalProperties = new AdditionalPropertiesDictionary()
+        };
+
+        if (document.RootElement.TryGetProperty("done_reason", out var doneReason) && doneReason.ValueKind == JsonValueKind.String)
+            chatResponse.AdditionalProperties["done_reason"] = doneReason.GetString();
+
+        return chatResponse;
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        using var request = BuildRequest(messages, options, stream: true);
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+            throw await CreateFailureAsync(response, cancellationToken);
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        while (await reader.ReadLineAsync(cancellationToken) is { } line)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            using var document = JsonDocument.Parse(line);
+            var root = document.RootElement;
+            if (TryGetMessageText(root, out var text) && !string.IsNullOrEmpty(text))
+                yield return new ChatResponseUpdate(ChatRole.Assistant, [new TextContent(text)]);
+
+            var toolCalls = ParseToolCalls(root);
+            if (toolCalls.Count > 0)
+                yield return new ChatResponseUpdate(ChatRole.Assistant, toolCalls);
+
+            if (root.TryGetProperty("done", out var doneElement) &&
+                doneElement.ValueKind == JsonValueKind.True)
+            {
+                var usage = ParseUsage(root);
+                if (usage.InputTokenCount is > 0 || usage.OutputTokenCount is > 0)
+                    yield return new ChatResponseUpdate(ChatRole.Assistant, [new UsageContent(usage)]);
+            }
+        }
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+
+    private HttpRequestMessage BuildRequest(IEnumerable<ChatMessage> messages, ChatOptions? options, bool stream)
+    {
+        var payload = new JsonObject
+        {
+            ["model"] = options?.ModelId ?? _defaultModel,
+            ["stream"] = stream,
+            ["messages"] = SerializeMessages(messages)
+        };
+
+        if (ShouldSendTools(options))
+            payload["tools"] = SerializeTools(options!.Tools!);
+
+        var format = SerializeFormat(options?.ResponseFormat);
+        if (format is not null)
+            payload["format"] = format;
+
+        var ollamaOptions = new JsonObject();
+        if (options?.Temperature is { } temperature)
+            ollamaOptions["temperature"] = temperature;
+        if (options?.MaxOutputTokens is { } maxOutputTokens)
+            ollamaOptions["num_predict"] = maxOutputTokens;
+        if (options?.TopP is { } topP)
+            ollamaOptions["top_p"] = topP;
+        if (options?.TopK is { } topK)
+            ollamaOptions["top_k"] = topK;
+        if (options?.Seed is { } seed)
+            ollamaOptions["seed"] = seed;
+
+        if (ollamaOptions.Count > 0)
+            payload["options"] = ollamaOptions;
+
+        return new HttpRequestMessage(HttpMethod.Post, _chatUri)
+        {
+            Content = CreateJsonContent(payload)
+        };
+    }
+
+    private static JsonArray SerializeMessages(IEnumerable<ChatMessage> messages)
+    {
+        var array = new JsonArray();
+        foreach (var message in messages)
+        {
+            foreach (var serialized in SerializeMessage(message))
+                array.Add((JsonNode)serialized);
+        }
+
+        return array;
+    }
+
+    private static IEnumerable<JsonObject> SerializeMessage(ChatMessage message)
+    {
+        if (message.Role == ChatRole.Tool)
+        {
+            var results = message.Contents.OfType<FunctionResultContent>().ToArray();
+            if (results.Length > 0)
+            {
+                foreach (var result in results)
+                {
+                    yield return new JsonObject
+                    {
+                        ["role"] = "tool",
+                        ["content"] = result.Result?.ToString() ?? string.Empty
+                    };
+                }
+
+                yield break;
+            }
+        }
+
+        var textBuilder = new StringBuilder();
+        var images = new JsonArray();
+        var toolCalls = new JsonArray();
+        foreach (var content in message.Contents)
+        {
+            switch (content)
+            {
+                case TextContent text:
+                    textBuilder.Append(text.Text);
+                    break;
+                case FunctionCallContent call:
+                    toolCalls.Add((JsonNode)new JsonObject
+                    {
+                        ["function"] = new JsonObject
+                        {
+                            ["name"] = call.Name,
+                            ["arguments"] = ToJsonNode(call.Arguments)
+                        }
+                    });
+                    break;
+                case UriContent uri when uri.MediaType?.StartsWith("image/", StringComparison.OrdinalIgnoreCase) == true:
+                    var image = TrySerializeImage(uri.Uri);
+                    if (!string.IsNullOrWhiteSpace(image))
+                        images.Add((JsonNode?)JsonValue.Create(image));
+                    break;
+            }
+        }
+
+        var obj = new JsonObject
+        {
+            ["role"] = NormalizeRole(message.Role),
+            ["content"] = textBuilder.ToString()
+        };
+        if (images.Count > 0)
+            obj["images"] = images;
+        if (toolCalls.Count > 0)
+            obj["tool_calls"] = toolCalls;
+
+        yield return obj;
+    }
+
+    private static string NormalizeRole(ChatRole role)
+        => role == ChatRole.System ? "system"
+            : role == ChatRole.Assistant ? "assistant"
+            : role == ChatRole.Tool ? "tool"
+            : "user";
+
+    private static bool ShouldSendTools(ChatOptions? options)
+    {
+        if (options?.Tools is not { Count: > 0 })
+            return false;
+
+        return options.ToolMode is null || !options.ToolMode.Equals(ChatToolMode.None);
+    }
+
+    private static JsonArray SerializeTools(IEnumerable<AITool> tools)
+    {
+        var array = new JsonArray();
+        foreach (var tool in tools)
+        {
+            var declaration = tool as AIFunctionDeclaration ?? tool.GetService<AIFunctionDeclaration>();
+            array.Add((JsonNode)new JsonObject
+            {
+                ["type"] = "function",
+                ["function"] = new JsonObject
+                {
+                    ["name"] = tool.Name,
+                    ["description"] = tool.Description,
+                    ["parameters"] = declaration?.JsonSchema.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null
+                        ? null
+                        : JsonNode.Parse(declaration!.JsonSchema.GetRawText())
+                }
+            });
+        }
+
+        return array;
+    }
+
+    private static JsonNode? SerializeFormat(ChatResponseFormat? format)
+    {
+        if (format is null)
+            return null;
+
+        if (format is ChatResponseFormatJson json)
+        {
+            if (json.Schema is { } schema &&
+                schema.ValueKind is JsonValueKind.Object or JsonValueKind.Array)
+            {
+                return JsonNode.Parse(schema.GetRawText());
+            }
+
+            return JsonValue.Create("json");
+        }
+
+        return null;
+    }
+
+    private static List<AIContent> ParseAssistantContents(JsonElement root)
+    {
+        var contents = new List<AIContent>();
+        if (TryGetMessageText(root, out var text) && !string.IsNullOrWhiteSpace(text))
+            contents.Add(new TextContent(text));
+
+        contents.AddRange(ParseToolCalls(root));
+        if (contents.Count == 0)
+            contents.Add(new TextContent(string.Empty));
+
+        return contents;
+    }
+
+    private static List<AIContent> ParseToolCalls(JsonElement root)
+    {
+        if (!TryGetToolCalls(root, out var toolCalls))
+            return [];
+
+        var contents = new List<AIContent>();
+        var index = 0;
+        foreach (var item in toolCalls.EnumerateArray())
+        {
+            if (!item.TryGetProperty("function", out var function) ||
+                !function.TryGetProperty("name", out var nameElement) ||
+                nameElement.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var arguments = new Dictionary<string, object?>(StringComparer.Ordinal);
+            if (function.TryGetProperty("arguments", out var argumentsElement))
+            {
+                if (argumentsElement.ValueKind == JsonValueKind.Object)
+                {
+                    foreach (var property in argumentsElement.EnumerateObject())
+                        arguments[property.Name] = ToObject(property.Value);
+                }
+                else if (argumentsElement.ValueKind == JsonValueKind.String)
+                {
+                    var raw = argumentsElement.GetString();
+                    if (!string.IsNullOrWhiteSpace(raw))
+                    {
+                        using var parsed = JsonDocument.Parse(raw);
+                        if (parsed.RootElement.ValueKind == JsonValueKind.Object)
+                        {
+                            foreach (var property in parsed.RootElement.EnumerateObject())
+                                arguments[property.Name] = ToObject(property.Value);
+                        }
+                    }
+                }
+            }
+
+            contents.Add(new FunctionCallContent($"ollama_call_{++index}", nameElement.GetString()!, arguments));
+        }
+
+        return contents;
+    }
+
+    private static bool TryGetMessageText(JsonElement root, out string? text)
+    {
+        text = null;
+        if (root.TryGetProperty("message", out var message) &&
+            message.TryGetProperty("content", out var content) &&
+            content.ValueKind == JsonValueKind.String)
+        {
+            text = content.GetString();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryGetToolCalls(JsonElement root, out JsonElement toolCalls)
+    {
+        toolCalls = default;
+        return root.TryGetProperty("message", out var message) &&
+               message.TryGetProperty("tool_calls", out toolCalls) &&
+               toolCalls.ValueKind == JsonValueKind.Array;
+    }
+
+    private static UsageDetails ParseUsage(JsonElement root)
+    {
+        var usage = new UsageDetails();
+        if (root.TryGetProperty("prompt_eval_count", out var input) && input.ValueKind == JsonValueKind.Number && input.TryGetInt64(out var inputCount))
+            usage.InputTokenCount = inputCount;
+        if (root.TryGetProperty("eval_count", out var output) && output.ValueKind == JsonValueKind.Number && output.TryGetInt64(out var outputCount))
+            usage.OutputTokenCount = outputCount;
+        return usage;
+    }
+
+    private static object? ToObject(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Object => element.EnumerateObject().ToDictionary(property => property.Name, property => ToObject(property.Value), StringComparer.Ordinal),
+            JsonValueKind.Array => element.EnumerateArray().Select(ToObject).ToArray(),
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number when element.TryGetInt64(out var longValue) => longValue,
+            JsonValueKind.Number => element.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => null
+        };
+    }
+
+    private static string? TrySerializeImage(Uri uri)
+    {
+        if (uri.IsFile && File.Exists(uri.LocalPath))
+            return Convert.ToBase64String(File.ReadAllBytes(uri.LocalPath));
+
+        if (uri.Scheme.Equals("data", StringComparison.OrdinalIgnoreCase))
+        {
+            var raw = uri.OriginalString;
+            var comma = raw.IndexOf(',');
+            if (comma >= 0)
+                return raw[(comma + 1)..];
+        }
+
+        return null;
+    }
+
+    internal static HttpContent CreateJsonContent(JsonNode payload)
+        => new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+
+    private static JsonNode? ToJsonNode(object? value)
+    {
+        if (value is null)
+            return null;
+
+        if (value is JsonNode node)
+            return node.DeepClone();
+
+        if (value is JsonElement element)
+            return JsonNode.Parse(element.GetRawText());
+
+        if (value is string text)
+            return JsonValue.Create(text);
+
+        if (value is bool boolean)
+            return JsonValue.Create(boolean);
+
+        if (value is int int32)
+            return JsonValue.Create(int32);
+
+        if (value is long int64)
+            return JsonValue.Create(int64);
+
+        if (value is float single)
+            return JsonValue.Create(single);
+
+        if (value is double dbl)
+            return JsonValue.Create(dbl);
+
+        if (value is decimal dec)
+            return JsonValue.Create(dec);
+
+        if (value is IDictionary dictionary)
+        {
+            var obj = new JsonObject();
+            foreach (DictionaryEntry entry in dictionary)
+            {
+                if (entry.Key?.ToString() is not { } key)
+                    continue;
+
+                obj[key] = ToJsonNode(entry.Value);
+            }
+
+            return obj;
+        }
+
+        if (value is IEnumerable enumerable and not string)
+        {
+            var array = new JsonArray();
+            foreach (var item in enumerable)
+                array.Add(ToJsonNode(item));
+
+            return array;
+        }
+
+        return JsonValue.Create(value.ToString());
+    }
+
+    internal static async Task<Exception> CreateFailureAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        var detail = await response.Content.ReadAsStringAsync(cancellationToken);
+        var message = $"Ollama request failed with HTTP {(int)response.StatusCode}.";
+        if (!string.IsNullOrWhiteSpace(detail))
+            message += $" {(detail.Length <= 400 ? detail : detail[..400])}";
+
+        return new HttpRequestException(message, null, response.StatusCode);
+    }
+}
+
+internal sealed class OllamaEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+{
+    private readonly Uri _embedUri;
+    private readonly string _model;
+    private readonly HttpClient _httpClient;
+
+    public OllamaEmbeddingGenerator(LlmProviderConfig config, string embeddingModel, HttpClient? httpClient = null)
+    {
+        _model = embeddingModel;
+        _embedUri = new Uri($"{OllamaEndpointNormalizer.NormalizeBaseUrl(config.Endpoint).TrimEnd('/')}/api/embed", UriKind.Absolute);
+        _httpClient = httpClient ?? HttpClientFactory.Create(allowAutoRedirect: false);
+        Metadata = new EmbeddingGeneratorMetadata("ollama");
+    }
+
+    public EmbeddingGeneratorMetadata Metadata { get; }
+
+    public async Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+        IEnumerable<string> values,
+        EmbeddingGenerationOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var payload = new JsonObject
+        {
+            ["model"] = _model,
+            ["input"] = SerializeInputs(values)
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, _embedUri)
+        {
+            Content = OllamaChatClient.CreateJsonContent(payload)
+        };
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+            throw await OllamaChatClient.CreateFailureAsync(response, cancellationToken);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync(cancellationToken));
+        if (!document.RootElement.TryGetProperty("embeddings", out var embeddingsElement) ||
+            embeddingsElement.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidOperationException("Ollama embedding response did not include an embeddings array.");
+        }
+
+        var generated = new GeneratedEmbeddings<Embedding<float>>();
+        foreach (var embedding in embeddingsElement.EnumerateArray())
+        {
+            generated.Add(new Embedding<float>(embedding.EnumerateArray().Select(static item => item.GetSingle()).ToArray()));
+        }
+
+        return generated;
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+
+    private static JsonArray SerializeInputs(IEnumerable<string> values)
+    {
+        var array = new JsonArray();
+        foreach (var value in values)
+            array.Add((JsonNode?)JsonValue.Create(value));
+
+        return array;
+    }
+}

--- a/src/OpenClaw.Gateway/GatewayAutomationService.cs
+++ b/src/OpenClaw.Gateway/GatewayAutomationService.cs
@@ -534,6 +534,7 @@ internal sealed class GatewayAutomationService
             Timezone = string.IsNullOrWhiteSpace(automation.Timezone) ? null : automation.Timezone.Trim(),
             Prompt = automation.Prompt ?? "",
             ModelId = string.IsNullOrWhiteSpace(automation.ModelId) ? null : automation.ModelId.Trim(),
+            ResponseMode = NormalizeResponseMode(automation.ResponseMode),
             RunOnStartup = automation.RunOnStartup,
             SessionId = string.IsNullOrWhiteSpace(automation.SessionId) ? null : automation.SessionId.Trim(),
             DeliveryChannelId = string.IsNullOrWhiteSpace(automation.DeliveryChannelId) ? "cron" : automation.DeliveryChannelId.Trim(),
@@ -561,6 +562,7 @@ internal sealed class GatewayAutomationService
             Prompt = job.Prompt ?? "",
             RunOnStartup = job.RunOnStartup,
             SessionId = job.SessionId,
+            ResponseMode = SessionResponseModes.ConciseOps,
             DeliveryChannelId = string.IsNullOrWhiteSpace(job.ChannelId) ? "cron" : job.ChannelId!,
             DeliveryRecipientId = job.RecipientId,
             DeliverySubject = job.Subject,
@@ -580,6 +582,7 @@ internal sealed class GatewayAutomationService
             Timezone = config.Timezone,
             Prompt = _heartbeat.BuildManagedPrompt(config, _heartbeat.RenderMarkdown(config)),
             ModelId = config.ModelId,
+            ResponseMode = SessionResponseModes.ConciseOps,
             DeliveryChannelId = config.DeliveryChannelId,
             DeliveryRecipientId = config.DeliveryRecipientId,
             DeliverySubject = config.DeliverySubject,
@@ -648,5 +651,16 @@ internal sealed class GatewayAutomationService
         if (string.Equals(schedule, "@monthly", StringComparison.OrdinalIgnoreCase))
             return 1;
         return 30;
+    }
+
+    private static string NormalizeResponseMode(string? responseMode)
+    {
+        var normalized = responseMode?.Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            SessionResponseModes.ConciseOps => SessionResponseModes.ConciseOps,
+            SessionResponseModes.Full => SessionResponseModes.Full,
+            _ => SessionResponseModes.ConciseOps
+        };
     }
 }

--- a/src/OpenClaw.Gateway/GatewayAutomationService.cs
+++ b/src/OpenClaw.Gateway/GatewayAutomationService.cs
@@ -540,7 +540,11 @@ internal sealed class GatewayAutomationService
             DeliveryChannelId = string.IsNullOrWhiteSpace(automation.DeliveryChannelId) ? "cron" : automation.DeliveryChannelId.Trim(),
             DeliveryRecipientId = string.IsNullOrWhiteSpace(automation.DeliveryRecipientId) ? null : automation.DeliveryRecipientId.Trim(),
             DeliverySubject = string.IsNullOrWhiteSpace(automation.DeliverySubject) ? null : automation.DeliverySubject.Trim(),
-            Tags = automation.Tags.Where(static item => !string.IsNullOrWhiteSpace(item)).Select(static item => item.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToArray(),
+            Tags = (automation.Tags ?? [])
+                .Where(static item => !string.IsNullOrWhiteSpace(item))
+                .Select(static item => item.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
             IsDraft = automation.IsDraft,
             Source = string.IsNullOrWhiteSpace(automation.Source) ? "managed" : automation.Source.Trim(),
             TemplateKey = string.IsNullOrWhiteSpace(automation.TemplateKey) ? null : automation.TemplateKey.Trim(),
@@ -658,9 +662,10 @@ internal sealed class GatewayAutomationService
         var normalized = responseMode?.Trim().ToLowerInvariant();
         return normalized switch
         {
+            SessionResponseModes.Default => SessionResponseModes.Default,
             SessionResponseModes.ConciseOps => SessionResponseModes.ConciseOps,
             SessionResponseModes.Full => SessionResponseModes.Full,
-            _ => SessionResponseModes.ConciseOps
+            _ => SessionResponseModes.Default
         };
     }
 }

--- a/src/OpenClaw.Gateway/GatewayLlmExecutionService.cs
+++ b/src/OpenClaw.Gateway/GatewayLlmExecutionService.cs
@@ -220,7 +220,7 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
         LlmExecutionEstimate estimate,
         CancellationToken ct)
     {
-        var selection = ResolveSelection(session, messages, options, streaming: false);
+        var selection = ResolveSelection(session, messages, options, estimate, streaming: false);
         var legacyPolicy = _policyService.Resolve(session, _config.Llm);
         if (!string.IsNullOrWhiteSpace(selection.Explanation))
             _logger.LogInformation("{Explanation}", selection.Explanation);
@@ -361,7 +361,7 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
         LlmExecutionEstimate estimate,
         CancellationToken ct)
     {
-        var selection = ResolveSelection(session, messages, options, streaming: true);
+        var selection = ResolveSelection(session, messages, options, estimate, streaming: true);
         var legacyPolicy = _policyService.Resolve(session, _config.Llm);
         Exception? lastError = null;
         foreach (var candidate in selection.Candidates)
@@ -529,6 +529,7 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
         Session session,
         IReadOnlyList<ChatMessage> messages,
         ChatOptions options,
+        LlmExecutionEstimate estimate,
         bool streaming)
     {
         var explicitProfileId = !string.IsNullOrWhiteSpace(session.ModelProfileId)
@@ -536,13 +537,20 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
             : (!string.IsNullOrWhiteSpace(session.ModelOverride) && _modelProfiles.TryGet(session.ModelOverride!, out _)
                 ? session.ModelOverride
                 : null);
+
+        var reservedOutputTokens = options.MaxOutputTokens
+            ?? session.ModelRequirements.MinOutputTokens
+            ?? _config.Llm.MaxTokens;
+
         return _selectionPolicy.Resolve(new ModelSelectionRequest
         {
             ExplicitProfileId = explicitProfileId,
             Session = session,
             Messages = messages,
             Options = options,
-            Streaming = streaming
+            Streaming = streaming,
+            EstimatedInputTokens = estimate.EstimatedInputTokens,
+            ReservedOutputTokens = reservedOutputTokens > 0 ? reservedOutputTokens : null
         });
     }
 
@@ -561,10 +569,11 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
         if (legacyPolicy.MaxOutputTokens > 0)
             maxOutputTokens = maxOutputTokens is > 0 ? Math.Min(maxOutputTokens.Value, legacyPolicy.MaxOutputTokens) : legacyPolicy.MaxOutputTokens;
 
-        if (profile.Capabilities.MaxContextTokens > 0 && estimate.EstimatedInputTokens > profile.Capabilities.MaxContextTokens)
+        var estimatedTotalTokens = estimate.EstimatedInputTokens + (maxOutputTokens ?? 0);
+        if (profile.Capabilities.MaxContextTokens > 0 && estimatedTotalTokens > profile.Capabilities.MaxContextTokens)
         {
             profileLimitError =
-                $"Selected model profile '{profile.Id}' cannot satisfy this request because estimated input tokens ({estimate.EstimatedInputTokens}) exceed MaxContextTokens ({profile.Capabilities.MaxContextTokens}).";
+                $"Selected model profile '{profile.Id}' cannot satisfy this request because estimated prompt plus reserved output tokens ({estimatedTotalTokens}) exceed MaxContextTokens ({profile.Capabilities.MaxContextTokens}).";
             effectiveOptions = source;
             return false;
         }

--- a/src/OpenClaw.Gateway/GatewayMaintenanceRuntimeService.cs
+++ b/src/OpenClaw.Gateway/GatewayMaintenanceRuntimeService.cs
@@ -1,0 +1,64 @@
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Setup;
+using OpenClaw.Core.Validation;
+using OpenClaw.Gateway.Bootstrap;
+using OpenClaw.Gateway.Composition;
+
+namespace OpenClaw.Gateway;
+
+internal sealed class GatewayMaintenanceRuntimeService
+{
+    private readonly GatewayStartupContext _startup;
+    private readonly GatewayAppRuntime _runtime;
+    private readonly GatewayAutomationService _automationService;
+
+    public GatewayMaintenanceRuntimeService(
+        GatewayStartupContext startup,
+        GatewayAppRuntime runtime,
+        GatewayAutomationService automationService)
+    {
+        _startup = startup;
+        _runtime = runtime;
+        _automationService = automationService;
+    }
+
+    public async Task<MaintenanceReportResponse> ScanAsync(SetupStatusResponse? setupStatus, CancellationToken ct)
+        => await MaintenanceCoordinator.ScanAsync(_startup.Config, await BuildInputsAsync(setupStatus, ct), ct);
+
+    public async Task<MaintenanceFixResponse> FixAsync(MaintenanceFixRequest request, SetupStatusResponse? setupStatus, CancellationToken ct)
+        => await MaintenanceCoordinator.FixAsync(_startup.Config, request, await BuildInputsAsync(setupStatus, ct), ct);
+
+    private async Task<MaintenanceScanInputs> BuildInputsAsync(SetupStatusResponse? setupStatus, CancellationToken ct)
+    {
+        var automations = await _automationService.ListAsync(ct);
+        var runStates = new List<AutomationRunState>(automations.Count);
+        foreach (var automation in automations)
+        {
+            var state = await _automationService.GetRunStateAsync(automation.Id, ct);
+            if (state is not null)
+                runStates.Add(state);
+        }
+
+        var pluginWarningCount = _runtime.PluginReports.Sum(static report =>
+            report.Diagnostics.Count(static item => string.Equals(item.Severity, "warning", StringComparison.OrdinalIgnoreCase)));
+        var pluginErrorCount = _runtime.PluginReports.Count(static report => !string.IsNullOrWhiteSpace(report.Error))
+            + _runtime.PluginReports.Sum(static report =>
+                report.Diagnostics.Count(static item => string.Equals(item.Severity, "error", StringComparison.OrdinalIgnoreCase)));
+        var modelDoctor = ModelDoctorEvaluator.Build(_startup.Config, _runtime.Operations.ModelProfiles, _runtime.ProviderUsage.RecentTurns(limit: 200));
+
+        return new MaintenanceScanInputs
+        {
+            SetupStatus = setupStatus,
+            ModelDoctor = modelDoctor,
+            RecentTurns = _runtime.ProviderUsage.RecentTurns(limit: 200),
+            ProviderRoutes = _runtime.Operations.LlmExecution.SnapshotRoutes(),
+            AutomationRunStates = runStates,
+            RuntimeMetrics = _runtime.RuntimeMetrics.Snapshot(),
+            LoadedSkills = _runtime.LoadedSkills,
+            ChannelDriftCount = ChannelReadinessEvaluator.Evaluate(_startup.Config, _startup.IsNonLoopbackBind)
+                .Count(static item => !item.Ready || !string.Equals(item.Status, "ready", StringComparison.OrdinalIgnoreCase)),
+            PluginWarningCount = pluginWarningCount,
+            PluginErrorCount = pluginErrorCount
+        };
+    }
+}

--- a/src/OpenClaw.Gateway/GatewayMaintenanceRuntimeService.cs
+++ b/src/OpenClaw.Gateway/GatewayMaintenanceRuntimeService.cs
@@ -8,9 +8,13 @@ namespace OpenClaw.Gateway;
 
 internal sealed class GatewayMaintenanceRuntimeService
 {
+    private static readonly TimeSpan ScanCacheTtl = TimeSpan.FromSeconds(10);
+
     private readonly GatewayStartupContext _startup;
     private readonly GatewayAppRuntime _runtime;
     private readonly GatewayAutomationService _automationService;
+    private readonly SemaphoreSlim _scanCacheGate = new(1, 1);
+    private MaintenanceCacheEntry? _scanCache;
 
     public GatewayMaintenanceRuntimeService(
         GatewayStartupContext startup,
@@ -23,10 +27,43 @@ internal sealed class GatewayMaintenanceRuntimeService
     }
 
     public async Task<MaintenanceReportResponse> ScanAsync(SetupStatusResponse? setupStatus, CancellationToken ct)
-        => await MaintenanceCoordinator.ScanAsync(_startup.Config, await BuildInputsAsync(setupStatus, ct), ct);
+    {
+        var cached = _scanCache;
+        if (cached is not null &&
+            DateTimeOffset.UtcNow - cached.CreatedAtUtc <= ScanCacheTtl &&
+            (cached.IncludesSetupStatus || setupStatus is null))
+        {
+            return cached.Report;
+        }
+
+        await _scanCacheGate.WaitAsync(ct);
+        try
+        {
+            cached = _scanCache;
+            if (cached is not null &&
+                DateTimeOffset.UtcNow - cached.CreatedAtUtc <= ScanCacheTtl &&
+                (cached.IncludesSetupStatus || setupStatus is null))
+            {
+                return cached.Report;
+            }
+
+            var report = await MaintenanceCoordinator.ScanAsync(_startup.Config, await BuildInputsAsync(setupStatus, ct), ct);
+            _scanCache = new MaintenanceCacheEntry(report, DateTimeOffset.UtcNow, setupStatus is not null);
+            return report;
+        }
+        finally
+        {
+            _scanCacheGate.Release();
+        }
+    }
 
     public async Task<MaintenanceFixResponse> FixAsync(MaintenanceFixRequest request, SetupStatusResponse? setupStatus, CancellationToken ct)
-        => await MaintenanceCoordinator.FixAsync(_startup.Config, request, await BuildInputsAsync(setupStatus, ct), ct);
+    {
+        _scanCache = null;
+        var result = await MaintenanceCoordinator.FixAsync(_startup.Config, request, await BuildInputsAsync(setupStatus, ct), ct);
+        _scanCache = null;
+        return result;
+    }
 
     private async Task<MaintenanceScanInputs> BuildInputsAsync(SetupStatusResponse? setupStatus, CancellationToken ct)
     {
@@ -44,13 +81,14 @@ internal sealed class GatewayMaintenanceRuntimeService
         var pluginErrorCount = _runtime.PluginReports.Count(static report => !string.IsNullOrWhiteSpace(report.Error))
             + _runtime.PluginReports.Sum(static report =>
                 report.Diagnostics.Count(static item => string.Equals(item.Severity, "error", StringComparison.OrdinalIgnoreCase)));
-        var modelDoctor = ModelDoctorEvaluator.Build(_startup.Config, _runtime.Operations.ModelProfiles, _runtime.ProviderUsage.RecentTurns(limit: 200));
+        var recentTurns = _runtime.ProviderUsage.RecentTurns(limit: 200);
+        var modelDoctor = ModelDoctorEvaluator.Build(_startup.Config, _runtime.Operations.ModelProfiles, recentTurns);
 
         return new MaintenanceScanInputs
         {
             SetupStatus = setupStatus,
             ModelDoctor = modelDoctor,
-            RecentTurns = _runtime.ProviderUsage.RecentTurns(limit: 200),
+            RecentTurns = recentTurns,
             ProviderRoutes = _runtime.Operations.LlmExecution.SnapshotRoutes(),
             AutomationRunStates = runStates,
             RuntimeMetrics = _runtime.RuntimeMetrics.Snapshot(),
@@ -61,4 +99,9 @@ internal sealed class GatewayMaintenanceRuntimeService
             PluginErrorCount = pluginErrorCount
         };
     }
+
+    private sealed record MaintenanceCacheEntry(
+        MaintenanceReportResponse Report,
+        DateTimeOffset CreatedAtUtc,
+        bool IncludesSetupStatus);
 }

--- a/src/OpenClaw.Gateway/Models/ConfiguredModelProfileRegistry.cs
+++ b/src/OpenClaw.Gateway/Models/ConfiguredModelProfileRegistry.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Logging;
 using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Models;
 using OpenClaw.Core.Security;
+using OpenClaw.Core.Setup;
+using OpenClaw.Core.Validation;
 using OpenClaw.Gateway.Extensions;
 
 namespace OpenClaw.Gateway.Models;
@@ -72,7 +74,10 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry
                 PromptCaching = item.Profile.PromptCaching,
                 ValidationIssues = item.ValidationIssues,
                 FallbackProfileIds = item.Profile.FallbackProfileIds,
-                FallbackModels = item.Profile.FallbackModels
+                FallbackModels = item.Profile.FallbackModels,
+                PresetId = item.Profile.PresetId,
+                CompatibilityNotes = BuildCompatibilityNotes(item.Profile),
+                UsesCompatibilityTransport = ProfileUsesCompatibilityTransport(item.Profile)
             })
             .ToArray();
 
@@ -145,6 +150,7 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry
         => new()
         {
             Id = "default",
+            PresetId = null,
             Provider = config.Llm.Provider,
             Model = config.Llm.Model,
             BaseUrl = config.Llm.Endpoint,
@@ -186,14 +192,15 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry
         => new()
         {
             Id = Normalize(model.Id) ?? "default",
+            PresetId = Normalize(model.PresetId),
             ProviderId = Normalize(model.Provider) ?? config.Llm.Provider,
             ModelId = Normalize(model.Model) ?? config.Llm.Model,
             BaseUrl = ResolveSecretValue(model.BaseUrl),
             ApiKey = ResolveSecretValue(model.ApiKey),
-            Tags = NormalizeDistinct(model.Tags),
+            Tags = MergeTags(model),
             FallbackProfileIds = NormalizeDistinct(model.FallbackProfileIds),
             FallbackModels = NormalizeDistinct(model.FallbackModels),
-            Capabilities = model.Capabilities ?? GuessCapabilities(Normalize(model.Provider) ?? config.Llm.Provider),
+            Capabilities = ResolveCapabilities(config, model),
             PromptCaching = MergePromptCaching(config.Llm.PromptCaching, model.PromptCaching),
             IsImplicit = string.Equals(model.Id, "default", StringComparison.OrdinalIgnoreCase)
                 && config.Models.Profiles.Count == 0
@@ -207,6 +214,8 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry
             yield return "Provider is required.";
         if (string.IsNullOrWhiteSpace(profile.ModelId))
             yield return "Model is required.";
+        if (profile.ProviderId.Equals("ollama", StringComparison.OrdinalIgnoreCase) && string.IsNullOrWhiteSpace(profile.PresetId))
+            yield return "PresetId is recommended for Ollama profiles so doctor and setup can apply local-model guidance.";
         if ((profile.ProviderId.Equals("openai-compatible", StringComparison.OrdinalIgnoreCase) ||
              profile.ProviderId.Equals("groq", StringComparison.OrdinalIgnoreCase) ||
              profile.ProviderId.Equals("together", StringComparison.OrdinalIgnoreCase) ||
@@ -236,6 +245,12 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry
         {
             yield return "ApiKey is required for remote provider profiles unless inherited from OpenClaw:Llm:ApiKey.";
         }
+
+        if (profile.ProviderId.Equals("ollama", StringComparison.OrdinalIgnoreCase) &&
+            OllamaEndpointNormalizer.UsesCompatibilityEndpoint(profile.BaseUrl ?? config.Llm.Endpoint))
+        {
+            yield return "This Ollama profile is using the legacy /v1 compatibility endpoint. Prefer the native Ollama base URL without /v1.";
+        }
     }
 
     internal static LlmProviderConfig BuildProviderConfig(GatewayConfig config, ModelProfile profile)
@@ -244,7 +259,7 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry
             Provider = profile.ProviderId,
             Model = profile.ModelId,
             ApiKey = profile.ApiKey ?? config.Llm.ApiKey,
-            Endpoint = profile.BaseUrl ?? config.Llm.Endpoint,
+            Endpoint = ResolveEndpoint(config, profile),
             FallbackModels = profile.FallbackModels,
             MaxTokens = profile.Capabilities.MaxOutputTokens > 0 ? profile.Capabilities.MaxOutputTokens : config.Llm.MaxTokens,
             Temperature = config.Llm.Temperature,
@@ -265,6 +280,73 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry
 
         var resolved = SecretResolver.Resolve(value);
         return string.IsNullOrWhiteSpace(resolved) ? null : resolved.Trim();
+    }
+
+    private static string[] MergeTags(ModelProfileConfig model)
+    {
+        var configured = NormalizeDistinct(model.Tags);
+        if (!LocalModelPresetCatalog.TryGet(model.PresetId, out var preset) || preset is null)
+            return configured;
+
+        return configured
+            .Concat(preset.Tags)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static ModelCapabilities ResolveCapabilities(GatewayConfig config, ModelProfileConfig model)
+    {
+        if (model.Capabilities is not null)
+            return model.Capabilities;
+
+        if (LocalModelPresetCatalog.TryGet(model.PresetId, out var preset) && preset is not null)
+        {
+            return new ModelCapabilities
+            {
+                SupportsTools = preset.Capabilities.SupportsTools,
+                SupportsVision = preset.Capabilities.SupportsVision,
+                SupportsJsonSchema = preset.Capabilities.SupportsJsonSchema,
+                SupportsStructuredOutputs = preset.Capabilities.SupportsStructuredOutputs,
+                SupportsStreaming = preset.Capabilities.SupportsStreaming,
+                SupportsParallelToolCalls = preset.Capabilities.SupportsParallelToolCalls,
+                SupportsReasoningEffort = preset.Capabilities.SupportsReasoningEffort,
+                SupportsSystemMessages = preset.Capabilities.SupportsSystemMessages,
+                SupportsImageInput = preset.Capabilities.SupportsImageInput,
+                SupportsAudioInput = preset.Capabilities.SupportsAudioInput,
+                SupportsPromptCaching = preset.Capabilities.SupportsPromptCaching,
+                SupportsExplicitCacheRetention = preset.Capabilities.SupportsExplicitCacheRetention,
+                ReportsCacheReadTokens = preset.Capabilities.ReportsCacheReadTokens,
+                ReportsCacheWriteTokens = preset.Capabilities.ReportsCacheWriteTokens,
+                MaxContextTokens = preset.Capabilities.MaxContextTokens,
+                MaxOutputTokens = preset.Capabilities.MaxOutputTokens
+            };
+        }
+
+        return GuessCapabilities(Normalize(model.Provider) ?? config.Llm.Provider);
+    }
+
+    private static string? ResolveEndpoint(GatewayConfig config, ModelProfile profile)
+    {
+        var endpoint = profile.BaseUrl ?? config.Llm.Endpoint;
+        return profile.ProviderId.Equals("ollama", StringComparison.OrdinalIgnoreCase)
+            ? OllamaEndpointNormalizer.NormalizeBaseUrl(endpoint)
+            : endpoint;
+    }
+
+    private static bool ProfileUsesCompatibilityTransport(ModelProfile profile)
+        => profile.ProviderId.Equals("ollama", StringComparison.OrdinalIgnoreCase) &&
+           OllamaEndpointNormalizer.UsesCompatibilityEndpoint(profile.BaseUrl);
+
+    private static IReadOnlyList<string> BuildCompatibilityNotes(ModelProfile profile)
+    {
+        var notes = new List<string>();
+        if (profile.ProviderId.Equals("ollama", StringComparison.OrdinalIgnoreCase) && ProfileUsesCompatibilityTransport(profile))
+            notes.Add("Using legacy /v1 compatibility endpoint; migrate to the native Ollama base URL.");
+
+        if (LocalModelPresetCatalog.TryGet(profile.PresetId, out var preset) && preset is not null)
+            notes.AddRange(preset.CompatibilityNotes);
+
+        return notes.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
     }
 
     private static string[] NormalizeDistinct(IEnumerable<string>? values)

--- a/src/OpenClaw.Gateway/Models/ConfiguredModelProfileRegistry.cs
+++ b/src/OpenClaw.Gateway/Models/ConfiguredModelProfileRegistry.cs
@@ -214,8 +214,6 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry
             yield return "Provider is required.";
         if (string.IsNullOrWhiteSpace(profile.ModelId))
             yield return "Model is required.";
-        if (profile.ProviderId.Equals("ollama", StringComparison.OrdinalIgnoreCase) && string.IsNullOrWhiteSpace(profile.PresetId))
-            yield return "PresetId is recommended for Ollama profiles so doctor and setup can apply local-model guidance.";
         if ((profile.ProviderId.Equals("openai-compatible", StringComparison.OrdinalIgnoreCase) ||
              profile.ProviderId.Equals("groq", StringComparison.OrdinalIgnoreCase) ||
              profile.ProviderId.Equals("together", StringComparison.OrdinalIgnoreCase) ||
@@ -244,12 +242,6 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry
             string.IsNullOrWhiteSpace(config.Llm.ApiKey))
         {
             yield return "ApiKey is required for remote provider profiles unless inherited from OpenClaw:Llm:ApiKey.";
-        }
-
-        if (profile.ProviderId.Equals("ollama", StringComparison.OrdinalIgnoreCase) &&
-            OllamaEndpointNormalizer.UsesCompatibilityEndpoint(profile.BaseUrl ?? config.Llm.Endpoint))
-        {
-            yield return "This Ollama profile is using the legacy /v1 compatibility endpoint. Prefer the native Ollama base URL without /v1.";
         }
     }
 
@@ -342,6 +334,8 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry
         var notes = new List<string>();
         if (profile.ProviderId.Equals("ollama", StringComparison.OrdinalIgnoreCase) && ProfileUsesCompatibilityTransport(profile))
             notes.Add("Using legacy /v1 compatibility endpoint; migrate to the native Ollama base URL.");
+        if (profile.ProviderId.Equals("ollama", StringComparison.OrdinalIgnoreCase) && string.IsNullOrWhiteSpace(profile.PresetId))
+            notes.Add("No local preset is configured; setup and doctor guidance will be more limited until a PresetId is added.");
 
         if (LocalModelPresetCatalog.TryGet(profile.PresetId, out var preset) && preset is not null)
             notes.AddRange(preset.CompatibilityNotes);

--- a/src/OpenClaw.Gateway/Models/DefaultModelSelectionPolicy.cs
+++ b/src/OpenClaw.Gateway/Models/DefaultModelSelectionPolicy.cs
@@ -176,6 +176,24 @@ internal sealed class DefaultModelSelectionPolicy : IModelSelectionPolicy
         if (request.Messages.SelectMany(static message => message.Contents).OfType<UriContent>().Any(static content => HasMediaPrefix(content.MediaType, "audio/")))
             combined.SupportsAudioInput = true;
 
+        var reservedOutputTokens = request.ReservedOutputTokens ?? 0;
+        if (reservedOutputTokens > 0)
+        {
+            combined.MinOutputTokens = combined.MinOutputTokens.HasValue
+                ? Math.Max(combined.MinOutputTokens.Value, reservedOutputTokens)
+                : reservedOutputTokens;
+        }
+
+        var estimatedInputTokens = request.EstimatedInputTokens ?? 0;
+        var requiredContextTokens = estimatedInputTokens + reservedOutputTokens;
+        if (requiredContextTokens > 0)
+        {
+            var capped = (int)Math.Min(int.MaxValue, requiredContextTokens);
+            combined.MinContextTokens = combined.MinContextTokens.HasValue
+                ? Math.Max(combined.MinContextTokens.Value, capped)
+                : capped;
+        }
+
         return combined;
     }
 

--- a/src/OpenClaw.Gateway/Models/DefaultModelSelectionPolicy.cs
+++ b/src/OpenClaw.Gateway/Models/DefaultModelSelectionPolicy.cs
@@ -177,13 +177,6 @@ internal sealed class DefaultModelSelectionPolicy : IModelSelectionPolicy
             combined.SupportsAudioInput = true;
 
         var reservedOutputTokens = request.ReservedOutputTokens ?? 0;
-        if (reservedOutputTokens > 0)
-        {
-            combined.MinOutputTokens = combined.MinOutputTokens.HasValue
-                ? Math.Max(combined.MinOutputTokens.Value, reservedOutputTokens)
-                : reservedOutputTokens;
-        }
-
         var estimatedInputTokens = request.EstimatedInputTokens ?? 0;
         var requiredContextTokens = estimatedInputTokens + reservedOutputTokens;
         if (requiredContextTokens > 0)

--- a/src/OpenClaw.Gateway/wwwroot/admin.html
+++ b/src/OpenClaw.Gateway/wwwroot/admin.html
@@ -3188,7 +3188,8 @@
                 { label: 'Automations', value: operator.automations?.total ?? 0, note: `${operator.automations?.enabled ?? 0} enabled` },
                 { label: 'Learning Queue', value: operator.learning?.pending ?? 0, note: `${operator.learning?.approved ?? 0} approved` },
                 { label: 'Ready Channels', value: operator.channels?.ready ?? 0, note: `${operator.channels?.misconfigured ?? 0} misconfigured` },
-                { label: 'Needs Review', value: operator.plugins?.needsReview ?? 0, note: `${operator.plugins?.quarantined ?? 0} quarantined` }
+                { label: 'Needs Review', value: operator.plugins?.needsReview ?? 0, note: `${operator.plugins?.quarantined ?? 0} quarantined` },
+                { label: 'Reliability', value: `${operator.reliability?.score ?? 0}/100`, note: operator.reliability?.status ?? 'unknown' }
             ].map(item => `
                 <div class="metric-card">
                     <div class="muted">${escapeHtml(item.label)}</div>
@@ -3231,6 +3232,12 @@
                             <li>Profiles: ${escapeHtml((operator.delegation?.profiles || []).join(', ') || 'none')}</li>
                             <li>24h delegated sessions: ${escapeHtml(operator.delegation?.last24Hours ?? 0)}</li>
                         </ul>
+                    </div>
+                    <div class="readiness-card">
+                        <strong>Reliability Recommendations</strong>
+                        ${(operator.reliability?.recommendations || []).length
+                            ? `<ul class="list">${operator.reliability.recommendations.slice(0, 4).map(item => `<li>${escapeHtml(item.summary)}<br><code>${escapeHtml(item.command)}</code></li>`).join('')}</ul>`
+                            : '<div class="muted">No guided actions right now.</div>'}
                     </div>
                 </div>
             `;

--- a/src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs
+++ b/src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs
@@ -489,6 +489,8 @@ public sealed class MafAgentRuntime : IAgentRuntime
             systemPrompt = _systemPrompt;
         }
 
+        systemPrompt = AgentSystemPromptBuilder.ApplyResponseMode(systemPrompt, session.ResponseMode);
+
         if (string.IsNullOrWhiteSpace(session.SystemPromptOverride))
             return systemPrompt;
 

--- a/src/OpenClaw.Tests/AgentSystemPromptBuilderTests.cs
+++ b/src/OpenClaw.Tests/AgentSystemPromptBuilderTests.cs
@@ -1,0 +1,24 @@
+using OpenClaw.Agent;
+using OpenClaw.Core.Models;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class AgentSystemPromptBuilderTests
+{
+    [Fact]
+    public void ApplyResponseMode_AddsOperationalInstructions_ForConciseOps()
+    {
+        var prompt = AgentSystemPromptBuilder.ApplyResponseMode("Base prompt", SessionResponseModes.ConciseOps);
+
+        Assert.Contains("Operational Response Mode", prompt, StringComparison.Ordinal);
+        Assert.Contains("state the action taken", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ApplyResponseMode_LeavesPromptUnchanged_ForDefaultAndFull()
+    {
+        Assert.Equal("Base prompt", AgentSystemPromptBuilder.ApplyResponseMode("Base prompt", SessionResponseModes.Default));
+        Assert.Equal("Base prompt", AgentSystemPromptBuilder.ApplyResponseMode("Base prompt", SessionResponseModes.Full));
+    }
+}

--- a/src/OpenClaw.Tests/ChatCommandProcessorTests.cs
+++ b/src/OpenClaw.Tests/ChatCommandProcessorTests.cs
@@ -90,4 +90,47 @@ public sealed class ChatCommandProcessorTests
         Assert.True(handled);
         Assert.Contains("Prompt Cache: 512 read / 0 write", response, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public async Task Concise_Command_TogglesSessionResponseMode()
+    {
+        var store = new FileMemoryStore(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "openclaw-command-tests", Guid.NewGuid().ToString("N")), 4);
+        var processor = new ChatCommandProcessor(new SessionManager(store, new GatewayConfig(), NullLogger.Instance));
+        var session = new Session
+        {
+            Id = "sess-concise",
+            ChannelId = "websocket",
+            SenderId = "user1"
+        };
+
+        var (_, onResponse) = await processor.TryProcessCommandAsync(session, "/concise on", CancellationToken.None);
+        Assert.Equal(SessionResponseModes.ConciseOps, session.ResponseMode);
+        Assert.Equal("Concise operational mode enabled.", onResponse);
+
+        var (_, offResponse) = await processor.TryProcessCommandAsync(session, "/concise off", CancellationToken.None);
+        Assert.Equal(SessionResponseModes.Full, session.ResponseMode);
+        Assert.Equal("Concise operational mode disabled for this session.", offResponse);
+
+        var (_, autoResponse) = await processor.TryProcessCommandAsync(session, "/concise auto", CancellationToken.None);
+        Assert.Equal(SessionResponseModes.Default, session.ResponseMode);
+        Assert.Equal("Concise mode reset to automatic behavior.", autoResponse);
+    }
+
+    [Fact]
+    public async Task Help_Command_IncludesConciseMode()
+    {
+        var store = new FileMemoryStore(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "openclaw-command-tests", Guid.NewGuid().ToString("N")), 4);
+        var processor = new ChatCommandProcessor(new SessionManager(store, new GatewayConfig(), NullLogger.Instance));
+        var session = new Session
+        {
+            Id = "sess-help",
+            ChannelId = "websocket",
+            SenderId = "user1"
+        };
+
+        var (handled, response) = await processor.TryProcessCommandAsync(session, "/help", CancellationToken.None);
+
+        Assert.True(handled);
+        Assert.Contains("/concise on|off|auto", response, StringComparison.Ordinal);
+    }
 }

--- a/src/OpenClaw.Tests/DocsConsistencyTests.cs
+++ b/src/OpenClaw.Tests/DocsConsistencyTests.cs
@@ -17,9 +17,12 @@ public sealed class DocsConsistencyTests
         Assert.Contains("openclaw setup launch", readme, StringComparison.Ordinal);
         Assert.Contains("openclaw setup service", readme, StringComparison.Ordinal);
         Assert.Contains("openclaw setup status", readme, StringComparison.Ordinal);
+        Assert.Contains("openclaw models presets", readme, StringComparison.Ordinal);
+        Assert.Contains("openclaw maintenance scan", readme, StringComparison.Ordinal);
         Assert.Contains("docs/COMPATIBILITY.md", readme, StringComparison.Ordinal);
         Assert.Contains("openclaw skills inspect", readme, StringComparison.Ordinal);
         Assert.Contains("/admin/skills", readme, StringComparison.Ordinal);
+        Assert.Contains("/admin/maintenance", readme, StringComparison.Ordinal);
         Assert.Contains("openclaw compatibility catalog", readme, StringComparison.Ordinal);
         Assert.Contains("openclaw upgrade rollback", readme, StringComparison.Ordinal);
         Assert.Contains("openclaw migrate upstream", readme, StringComparison.Ordinal);
@@ -27,11 +30,15 @@ public sealed class DocsConsistencyTests
         Assert.Contains("/admin/audit/export", readme, StringComparison.Ordinal);
         Assert.Contains("Breaking change", readme, StringComparison.Ordinal);
         Assert.Contains("operator account tokens", readme, StringComparison.Ordinal);
+        Assert.Contains("http://127.0.0.1:11434", readme, StringComparison.Ordinal);
 
         Assert.Contains("openclaw setup", quickstart, StringComparison.Ordinal);
         Assert.Contains("openclaw setup launch", quickstart, StringComparison.Ordinal);
         Assert.Contains("openclaw setup service", quickstart, StringComparison.Ordinal);
         Assert.Contains("openclaw setup status", quickstart, StringComparison.Ordinal);
+        Assert.Contains("openclaw models presets", quickstart, StringComparison.Ordinal);
+        Assert.Contains("openclaw maintenance scan", quickstart, StringComparison.Ordinal);
+        Assert.Contains("/concise on|off|auto", quickstart, StringComparison.Ordinal);
         Assert.Contains("openclaw init", quickstart, StringComparison.Ordinal);
         Assert.Contains("--doctor", quickstart, StringComparison.Ordinal);
         Assert.Contains("openclaw admin posture", quickstart, StringComparison.Ordinal);
@@ -45,6 +52,9 @@ public sealed class DocsConsistencyTests
         Assert.Contains("openclaw setup launch", userGuide, StringComparison.Ordinal);
         Assert.Contains("openclaw setup service", userGuide, StringComparison.Ordinal);
         Assert.Contains("openclaw setup status", userGuide, StringComparison.Ordinal);
+        Assert.Contains("openclaw models presets", userGuide, StringComparison.Ordinal);
+        Assert.Contains("openclaw maintenance scan", userGuide, StringComparison.Ordinal);
+        Assert.Contains("/concise on", userGuide, StringComparison.Ordinal);
         Assert.Contains("openclaw init", userGuide, StringComparison.Ordinal);
         Assert.Contains("Compatibility Guide", userGuide, StringComparison.Ordinal);
         Assert.Contains("openclaw skills inspect", userGuide, StringComparison.Ordinal);
@@ -52,11 +62,13 @@ public sealed class DocsConsistencyTests
         Assert.Contains("openclaw compatibility catalog", userGuide, StringComparison.Ordinal);
         Assert.Contains("openclaw upgrade rollback", userGuide, StringComparison.Ordinal);
         Assert.Contains("/admin/compatibility/catalog", userGuide, StringComparison.Ordinal);
+        Assert.Contains("/admin/maintenance", userGuide, StringComparison.Ordinal);
         Assert.Contains("/admin/observability/summary", userGuide, StringComparison.Ordinal);
         Assert.Contains("/admin/audit/export", userGuide, StringComparison.Ordinal);
         Assert.Contains("openclaw migrate upstream", userGuide, StringComparison.Ordinal);
         Assert.Contains("Breaking Changes", userGuide, StringComparison.Ordinal);
         Assert.Contains("operator account tokens", userGuide, StringComparison.Ordinal);
+        Assert.Contains("http://127.0.0.1:11434", userGuide, StringComparison.Ordinal);
 
         Assert.Contains("openclaw setup", dockerhub, StringComparison.Ordinal);
         Assert.Contains("openclaw setup launch", dockerhub, StringComparison.Ordinal);

--- a/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
+++ b/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
@@ -297,6 +297,57 @@ public sealed class GatewayAdminEndpointTests
             id => id == "caddy");
         var caddy = payload.RootElement.GetProperty("artifacts").EnumerateArray().First(item => item.GetProperty("id").GetString() == "caddy");
         Assert.True(caddy.GetProperty("exists").GetBoolean());
+        Assert.True(payload.RootElement.GetProperty("reliability").GetProperty("score").GetInt32() >= 0);
+    }
+
+    [Fact]
+    public async Task AdminMaintenance_ReportsFindings_AndFixesManagedArtifacts()
+    {
+        await using var harness = await CreateHarnessAsync(nonLoopbackBind: false);
+        var adminRoot = Path.Combine(harness.StoragePath, "admin");
+        var evaluationRoot = Path.Combine(adminRoot, "model-evaluations");
+        Directory.CreateDirectory(evaluationRoot);
+        Directory.CreateDirectory(Path.Combine(harness.StoragePath, "logs"));
+
+        await File.WriteAllTextAsync(Path.Combine(harness.StoragePath, "logs", "cache-trace.jsonl"), "trace");
+        await File.WriteAllTextAsync(Path.Combine(evaluationRoot, "eval-old-01.json"), "{}");
+        await File.WriteAllTextAsync(
+            Path.Combine(adminRoot, "session-metadata.json"),
+            JsonSerializer.Serialize(
+                new List<SessionMetadataSnapshot> { new() { SessionId = "missing-session" } },
+                CoreJsonContext.Default.ListSessionMetadataSnapshot));
+
+        using var reportRequest = new HttpRequestMessage(HttpMethod.Get, "/admin/maintenance");
+        reportRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+        var reportResponse = await harness.Client.SendAsync(reportRequest);
+        reportResponse.EnsureSuccessStatusCode();
+
+        using var reportPayload = await ReadJsonAsync(reportResponse);
+        Assert.True(reportPayload.RootElement.GetProperty("reliability").GetProperty("score").GetInt32() >= 0);
+        Assert.Contains(
+            reportPayload.RootElement.GetProperty("findings").EnumerateArray().Select(static item => item.GetProperty("id").GetString()).OfType<string>(),
+            id => id == "orphaned-session-metadata");
+
+        using var fixRequest = new HttpRequestMessage(HttpMethod.Post, "/admin/maintenance/fix");
+        fixRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+        fixRequest.Content = new StringContent(
+            JsonSerializer.Serialize(
+                new MaintenanceFixRequest
+                {
+                    DryRun = false,
+                    Apply = "all"
+                },
+                CoreJsonContext.Default.MaintenanceFixRequest),
+            Encoding.UTF8,
+            "application/json");
+        var fixResponse = await harness.Client.SendAsync(fixRequest);
+        fixResponse.EnsureSuccessStatusCode();
+
+        Assert.False(File.Exists(Path.Combine(harness.StoragePath, "logs", "cache-trace.jsonl")));
+        var metadata = JsonSerializer.Deserialize(
+            await File.ReadAllTextAsync(Path.Combine(adminRoot, "session-metadata.json")),
+            CoreJsonContext.Default.ListSessionMetadataSnapshot);
+        Assert.Empty(metadata ?? []);
     }
 
     [Fact]
@@ -2659,6 +2710,7 @@ public sealed class GatewayAdminEndpointTests
         Assert.True(dashboardPayload.RootElement.GetProperty("operator").GetProperty("automations").GetProperty("failing").GetInt32() >= 1);
         Assert.True(dashboardPayload.RootElement.GetProperty("operator").GetProperty("automations").GetProperty("templates").GetArrayLength() >= 2);
         Assert.True(dashboardPayload.RootElement.GetProperty("operator").GetProperty("channels").GetProperty("items").GetArrayLength() >= 1);
+        Assert.True(dashboardPayload.RootElement.GetProperty("operator").GetProperty("reliability").GetProperty("score").GetInt32() >= 0);
 
         using var approvalsRequest = new HttpRequestMessage(HttpMethod.Get, "/api/integration/approvals?channelId=api&senderId=user-dashboard");
         approvalsRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);

--- a/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
+++ b/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
@@ -351,6 +351,38 @@ public sealed class GatewayAdminEndpointTests
     }
 
     [Fact]
+    public async Task AdminSummary_WritesSingleMaintenanceSnapshotPerRequest()
+    {
+        await using var harness = await CreateHarnessAsync(nonLoopbackBind: false);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/admin/summary");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+        var response = await harness.Client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        var history = JsonSerializer.Deserialize(
+            await File.ReadAllTextAsync(Path.Combine(harness.StoragePath, "admin", "maintenance-history.json")),
+            CoreJsonContext.Default.ListMaintenanceHistorySnapshot);
+        Assert.Single(history ?? []);
+    }
+
+    [Fact]
+    public async Task AdminMaintenance_WritesSingleMaintenanceSnapshotPerRequest()
+    {
+        await using var harness = await CreateHarnessAsync(nonLoopbackBind: false);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/admin/maintenance");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+        var response = await harness.Client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        var history = JsonSerializer.Deserialize(
+            await File.ReadAllTextAsync(Path.Combine(harness.StoragePath, "admin", "maintenance-history.json")),
+            CoreJsonContext.Default.ListMaintenanceHistorySnapshot);
+        Assert.Single(history ?? []);
+    }
+
+    [Fact]
     public async Task AdminSetupVerify_ReturnsStructuredChecks()
     {
         await using var harness = await CreateHarnessAsync(nonLoopbackBind: false);
@@ -2818,6 +2850,41 @@ public sealed class GatewayAdminEndpointTests
         detailRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
         var detailResponse = await harness.Client.SendAsync(detailRequest);
         Assert.Equal(HttpStatusCode.NotFound, detailResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task AutomationEndpoints_PreserveExplicitDefaultResponseMode()
+    {
+        await using var harness = await CreateHarnessAsync(nonLoopbackBind: true);
+
+        using var saveRequest = new HttpRequestMessage(HttpMethod.Put, "/admin/automations/auto_default_response_mode")
+        {
+            Content = JsonContent("""
+                {
+                  "id": "auto_default_response_mode",
+                  "name": "Default response mode automation",
+                  "enabled": true,
+                  "schedule": "@daily",
+                  "prompt": "Ping once a day.",
+                  "deliveryChannelId": "cron",
+                  "responseMode": "default",
+                  "source": "managed"
+                }
+                """)
+        };
+        saveRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+        var saveResponse = await harness.Client.SendAsync(saveRequest);
+        saveResponse.EnsureSuccessStatusCode();
+
+        using var detailRequest = new HttpRequestMessage(HttpMethod.Get, "/admin/automations/auto_default_response_mode");
+        detailRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+        var detailResponse = await harness.Client.SendAsync(detailRequest);
+        detailResponse.EnsureSuccessStatusCode();
+        using var detailPayload = await ReadJsonAsync(detailResponse);
+
+        Assert.Equal(
+            SessionResponseModes.Default,
+            detailPayload.RootElement.GetProperty("automation").GetProperty("responseMode").GetString());
     }
 
     [Fact]

--- a/src/OpenClaw.Tests/MaintenanceCoordinatorTests.cs
+++ b/src/OpenClaw.Tests/MaintenanceCoordinatorTests.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Setup;
+using OpenClaw.Core.Skills;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class MaintenanceCoordinatorTests
+{
+    [Fact]
+    public async Task ScanAndFix_ReportManagedFindings_WithoutMutatingPromptFiles()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "openclaw-maintenance-tests", Guid.NewGuid().ToString("N"));
+        var memoryRoot = Path.Combine(root, "memory");
+        var workspaceRoot = Path.Combine(root, "workspace");
+        Directory.CreateDirectory(memoryRoot);
+        Directory.CreateDirectory(workspaceRoot);
+
+        try
+        {
+            var agentsPath = Path.Combine(workspaceRoot, "AGENTS.md");
+            var soulPath = Path.Combine(workspaceRoot, "SOUL.md");
+            var agentsContent = new string('A', 13_000);
+            var soulContent = new string('S', 13_500);
+            await File.WriteAllTextAsync(agentsPath, agentsContent);
+            await File.WriteAllTextAsync(soulPath, soulContent);
+
+            var adminRoot = Path.Combine(memoryRoot, "admin");
+            var evaluationRoot = Path.Combine(adminRoot, "model-evaluations");
+            Directory.CreateDirectory(evaluationRoot);
+            for (var i = 0; i < 48; i++)
+                await File.WriteAllTextAsync(Path.Combine(evaluationRoot, $"eval-{i:D2}.json"), "{}");
+
+            Directory.CreateDirectory(Path.Combine(memoryRoot, "logs"));
+            await File.WriteAllTextAsync(Path.Combine(memoryRoot, "logs", "cache-trace.jsonl"), "trace");
+
+            Directory.CreateDirectory(adminRoot);
+            var metadata = new List<SessionMetadataSnapshot>
+            {
+                new() { SessionId = "missing-session", Tags = ["ops"] }
+            };
+            await File.WriteAllTextAsync(
+                Path.Combine(adminRoot, "session-metadata.json"),
+                JsonSerializer.Serialize(metadata, CoreJsonContext.Default.ListSessionMetadataSnapshot));
+
+            var config = new GatewayConfig
+            {
+                Memory = new MemoryConfig
+                {
+                    StoragePath = memoryRoot
+                },
+                Tooling = new ToolingConfig
+                {
+                    WorkspaceRoot = workspaceRoot
+                }
+            };
+
+            var lowScan = await MaintenanceCoordinator.ScanAsync(
+                config,
+                new MaintenanceScanInputs
+                {
+                    ConfigPath = Path.Combine(root, "openclaw.settings.json"),
+                    RecentTurns =
+                    [
+                        BuildTurn("sess-1", 500),
+                        BuildTurn("sess-2", 650)
+                    ],
+                    LoadedSkills =
+                    [
+                        new SkillDefinition
+                        {
+                            Name = "triage",
+                            Description = "Triage messages.",
+                            Instructions = "Do triage.",
+                            Location = workspaceRoot
+                        }
+                    ]
+                },
+                CancellationToken.None);
+
+            var report = await MaintenanceCoordinator.ScanAsync(
+                config,
+                new MaintenanceScanInputs
+                {
+                    ConfigPath = Path.Combine(root, "openclaw.settings.json"),
+                    RecentTurns =
+                    [
+                        BuildTurn("sess-3", 32_000),
+                        BuildTurn("sess-4", 34_000)
+                    ],
+                    LoadedSkills =
+                    [
+                        new SkillDefinition
+                        {
+                            Name = "triage",
+                            Description = "Triage messages.",
+                            Instructions = "Do triage.",
+                            Location = workspaceRoot
+                        }
+                    ]
+                },
+                CancellationToken.None);
+
+            Assert.Equal(0, lowScan.Drift.PromptP95Delta);
+            Assert.True(report.Drift.PromptP95Delta > 0);
+            Assert.Contains(report.Findings, finding => finding.Id == "orphaned-session-metadata");
+            Assert.Contains(report.Findings, finding => finding.Id == "model-evaluation-artifacts");
+            Assert.Contains(report.Findings, finding => finding.Id == "prompt-cache-traces");
+            Assert.Contains(report.Findings, finding => finding.Id == "agents-file-size");
+            Assert.Contains(report.Findings, finding => finding.Id == "soul-file-size");
+            Assert.True(report.Reliability.Score >= 0);
+            Assert.NotEmpty(report.Reliability.Recommendations);
+            Assert.True(File.Exists(Path.Combine(adminRoot, "maintenance-history.json")));
+
+            var dryRun = await MaintenanceCoordinator.FixAsync(
+                config,
+                new MaintenanceFixRequest
+                {
+                    DryRun = true,
+                    Apply = "all"
+                },
+                new MaintenanceScanInputs(),
+                CancellationToken.None);
+
+            Assert.Contains(dryRun.Actions, action => action.Id == "metadata");
+            Assert.Contains(dryRun.Actions, action => action.Id == "model-evaluations");
+            Assert.Contains(dryRun.Actions, action => action.Id == "prompt-cache-traces");
+            Assert.Equal(agentsContent, await File.ReadAllTextAsync(agentsPath));
+            Assert.Equal(soulContent, await File.ReadAllTextAsync(soulPath));
+
+            var applied = await MaintenanceCoordinator.FixAsync(
+                config,
+                new MaintenanceFixRequest
+                {
+                    DryRun = false,
+                    Apply = "all"
+                },
+                new MaintenanceScanInputs(),
+                CancellationToken.None);
+
+            Assert.True(applied.Success);
+            Assert.False(File.Exists(Path.Combine(memoryRoot, "logs", "cache-trace.jsonl")));
+            Assert.Empty(JsonSerializer.Deserialize(
+                await File.ReadAllTextAsync(Path.Combine(adminRoot, "session-metadata.json")),
+                CoreJsonContext.Default.ListSessionMetadataSnapshot) ?? []);
+            Assert.True(Directory.EnumerateFiles(evaluationRoot).Count() <= 20);
+            Assert.Equal(agentsContent, await File.ReadAllTextAsync(agentsPath));
+            Assert.Equal(soulContent, await File.ReadAllTextAsync(soulPath));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static ProviderTurnUsageEntry BuildTurn(string sessionId, long inputTokens)
+        => new()
+        {
+            SessionId = sessionId,
+            ChannelId = "websocket",
+            ProviderId = "ollama",
+            ModelId = "llama3.2",
+            InputTokens = inputTokens,
+            OutputTokens = 128,
+            EstimatedInputTokensByComponent = new InputTokenComponentEstimate
+            {
+                SystemPrompt = inputTokens / 4,
+                Skills = inputTokens / 4,
+                History = inputTokens / 4,
+                ToolOutputs = inputTokens / 8,
+                UserInput = inputTokens / 8
+            }
+        };
+}

--- a/src/OpenClaw.Tests/MaintenanceCoordinatorTests.cs
+++ b/src/OpenClaw.Tests/MaintenanceCoordinatorTests.cs
@@ -155,6 +155,68 @@ public sealed class MaintenanceCoordinatorTests
         }
     }
 
+    [Fact]
+    public async Task FixAsync_ContinuesWhenMetadataPruningFails()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "openclaw-maintenance-tests", Guid.NewGuid().ToString("N"));
+        var memoryRoot = Path.Combine(root, "memory");
+        var metadataPath = Path.Combine(memoryRoot, "admin", "session-metadata.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(metadataPath)!);
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                metadataPath,
+                JsonSerializer.Serialize(
+                    new List<SessionMetadataSnapshot> { new() { SessionId = "missing-session" } },
+                    CoreJsonContext.Default.ListSessionMetadataSnapshot));
+            SetReadOnly(metadataPath, readOnly: true);
+
+            var config = new GatewayConfig
+            {
+                Memory = new MemoryConfig
+                {
+                    StoragePath = memoryRoot
+                }
+            };
+
+            var result = await MaintenanceCoordinator.FixAsync(
+                config,
+                new MaintenanceFixRequest
+                {
+                    DryRun = false,
+                    Apply = "metadata"
+                },
+                new MaintenanceScanInputs(),
+                CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains(result.Warnings, warning => warning.Contains("Metadata pruning could not run", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            if (File.Exists(metadataPath))
+                SetReadOnly(metadataPath, readOnly: false);
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static void SetReadOnly(string path, bool readOnly)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            File.SetAttributes(path, readOnly ? FileAttributes.ReadOnly : FileAttributes.Normal);
+            return;
+        }
+
+        File.SetUnixFileMode(
+            path,
+            readOnly
+                ? UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead
+                : UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+    }
+
     private static ProviderTurnUsageEntry BuildTurn(string sessionId, long inputTokens)
         => new()
         {

--- a/src/OpenClaw.Tests/ModelProfileSelectionTests.cs
+++ b/src/OpenClaw.Tests/ModelProfileSelectionTests.cs
@@ -116,6 +116,38 @@ public sealed class ModelProfileSelectionTests
     }
 
     [Fact]
+    public void SelectionPolicy_FallsBackWhenEstimatedPromptExceedsContextWindow()
+    {
+        LlmClientFactory.ResetDynamicProviders();
+        LlmClientFactory.RegisterProvider("fake-profile-tests", new EvaluationChatClient());
+
+        var config = BuildProfileConfig();
+        var registry = new ConfiguredModelProfileRegistry(config, NullLogger<ConfiguredModelProfileRegistry>.Instance);
+        var policy = new DefaultModelSelectionPolicy(registry);
+        var session = new Session
+        {
+            Id = "s2-budget",
+            ChannelId = "test",
+            SenderId = "user",
+            ModelProfileId = "gemma4-local",
+            FallbackModelProfileIds = ["frontier-tools"]
+        };
+
+        var selection = policy.Resolve(new OpenClaw.Core.Abstractions.ModelSelectionRequest
+        {
+            Session = session,
+            Messages = [new ChatMessage(ChatRole.User, "Need a large-context answer")],
+            Options = new ChatOptions(),
+            EstimatedInputTokens = 130_000,
+            ReservedOutputTokens = 8_000,
+            Streaming = false
+        });
+
+        Assert.Equal("frontier-tools", selection.SelectedProfileId);
+        Assert.Contains("Falling back from 'gemma4-local'", selection.Explanation, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ConfigValidator_RejectsUnknownDefaultModelProfile()
     {
         var config = new GatewayConfig
@@ -281,6 +313,43 @@ public sealed class ModelProfileSelectionTests
             Environment.SetEnvironmentVariable("MODEL_PROFILE_ENDPOINT", null);
             Environment.SetEnvironmentVariable("MODEL_PROFILE_KEY", null);
         }
+    }
+
+    [Fact]
+    public void ModelDoctor_WarnsForLegacyOllamaCompatibilityEndpoint()
+    {
+        var config = new GatewayConfig
+        {
+            Llm = new LlmProviderConfig
+            {
+                Provider = "ollama",
+                Model = "llama3.2",
+                Endpoint = "http://127.0.0.1:11434/v1"
+            },
+            Models = new ModelsConfig
+            {
+                DefaultProfile = "local-primary",
+                Profiles =
+                [
+                    new ModelProfileConfig
+                    {
+                        Id = "local-primary",
+                        Provider = "ollama",
+                        Model = "llama3.2",
+                        PresetId = "ollama-agentic",
+                        BaseUrl = "http://127.0.0.1:11434/v1"
+                    }
+                ]
+            }
+        };
+
+        var registry = new ConfiguredModelProfileRegistry(config, NullLogger<ConfiguredModelProfileRegistry>.Instance);
+        var doctor = ModelDoctorEvaluator.Build(config, registry);
+        var profile = Assert.Single(doctor.Profiles);
+
+        Assert.True(profile.UsesCompatibilityTransport);
+        Assert.Contains(doctor.Warnings, warning => warning.Contains("legacy Ollama /v1", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(profile.CompatibilityNotes, note => note.Contains("legacy /v1 compatibility endpoint", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/src/OpenClaw.Tests/ModelProfileSelectionTests.cs
+++ b/src/OpenClaw.Tests/ModelProfileSelectionTests.cs
@@ -148,6 +148,37 @@ public sealed class ModelProfileSelectionTests
     }
 
     [Fact]
+    public void SelectionPolicy_DoesNotTreatReservedOutputBudgetAsHardMinimumOutputRequirement()
+    {
+        LlmClientFactory.ResetDynamicProviders();
+        LlmClientFactory.RegisterProvider("fake-profile-tests", new EvaluationChatClient());
+
+        var config = BuildProfileConfig();
+        var registry = new ConfiguredModelProfileRegistry(config, NullLogger<ConfiguredModelProfileRegistry>.Instance);
+        var policy = new DefaultModelSelectionPolicy(registry);
+        var session = new Session
+        {
+            Id = "s2-reserved-output",
+            ChannelId = "test",
+            SenderId = "user",
+            ModelProfileId = "gemma4-local",
+            FallbackModelProfileIds = ["frontier-tools"]
+        };
+
+        var selection = policy.Resolve(new OpenClaw.Core.Abstractions.ModelSelectionRequest
+        {
+            Session = session,
+            Messages = [new ChatMessage(ChatRole.User, "Need a short answer.")],
+            Options = new ChatOptions(),
+            EstimatedInputTokens = 2_000,
+            ReservedOutputTokens = 12_000,
+            Streaming = false
+        });
+
+        Assert.Equal("gemma4-local", selection.SelectedProfileId);
+    }
+
+    [Fact]
     public void ConfigValidator_RejectsUnknownDefaultModelProfile()
     {
         var config = new GatewayConfig
@@ -348,8 +379,45 @@ public sealed class ModelProfileSelectionTests
         var profile = Assert.Single(doctor.Profiles);
 
         Assert.True(profile.UsesCompatibilityTransport);
+        Assert.True(profile.IsAvailable);
         Assert.Contains(doctor.Warnings, warning => warning.Contains("legacy Ollama /v1", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(profile.CompatibilityNotes, note => note.Contains("legacy /v1 compatibility endpoint", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Registry_LeavesOllamaProfilesWithoutPresetAvailable()
+    {
+        LlmClientFactory.ResetDynamicProviders();
+        LlmClientFactory.RegisterProvider("fake-profile-tests", new EvaluationChatClient());
+
+        var config = new GatewayConfig
+        {
+            Llm = new LlmProviderConfig
+            {
+                Provider = "fake-profile-tests",
+                Model = "legacy-model"
+            },
+            Models = new ModelsConfig
+            {
+                Profiles =
+                [
+                    new ModelProfileConfig
+                    {
+                        Id = "local-without-preset",
+                        Provider = "ollama",
+                        Model = "llama3.2",
+                        BaseUrl = "http://127.0.0.1:11434"
+                    }
+                ]
+            }
+        };
+
+        var registry = new ConfiguredModelProfileRegistry(config, NullLogger<ConfiguredModelProfileRegistry>.Instance);
+        var status = Assert.Single(registry.ListStatuses());
+
+        Assert.True(status.IsAvailable);
+        Assert.Empty(status.ValidationIssues);
+        Assert.Contains(status.CompatibilityNotes, note => note.Contains("No local preset is configured", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/src/OpenClaw.Tests/OllamaNativeClientTests.cs
+++ b/src/OpenClaw.Tests/OllamaNativeClientTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using OpenClaw.Core.Models;
+using OpenClaw.Gateway.Extensions;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class OllamaNativeClientTests
+{
+    [Fact]
+    public async Task ChatClient_UsesNativeApiChat_AndParsesToolCallsAndUsage()
+    {
+        var requests = new List<(Uri Uri, string Body)>();
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(async request =>
+        {
+            requests.Add((request.RequestUri!, await request.Content!.ReadAsStringAsync()));
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {"message":{"content":"READY","tool_calls":[{"function":{"name":"record_observation","arguments":{"value":"gemma4"}}}]},"done_reason":"stop","prompt_eval_count":12,"eval_count":4}
+                    """,
+                    Encoding.UTF8,
+                    "application/json")
+            };
+        }));
+
+        using var client = new OllamaChatClient(
+            new LlmProviderConfig
+            {
+                Provider = "ollama",
+                Model = "llama3.2",
+                Endpoint = "http://127.0.0.1:11434/v1"
+            },
+            httpClient);
+
+        var response = await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "hello")],
+            new ChatOptions
+            {
+                Tools =
+                [
+                    AIFunctionFactory.CreateDeclaration(
+                        "record_observation",
+                        "Record an observation",
+                        JsonDocument.Parse("""{"type":"object","properties":{"value":{"type":"string"}},"required":["value"]}""").RootElement.Clone(),
+                        returnJsonSchema: null)
+                ]
+            },
+            CancellationToken.None);
+
+        var request = Assert.Single(requests);
+        Assert.Equal("/api/chat", request.Uri.AbsolutePath);
+        Assert.DoesNotContain("/v1", request.Uri.AbsoluteUri, StringComparison.Ordinal);
+        Assert.Contains("\"tools\"", request.Body, StringComparison.Ordinal);
+        Assert.Contains("\"record_observation\"", request.Body, StringComparison.Ordinal);
+        var assistant = Assert.Single(response.Messages);
+        Assert.Contains(assistant.Contents.OfType<TextContent>(), content => content.Text == "READY");
+        Assert.Contains(assistant.Contents.OfType<FunctionCallContent>(), content => content.Name == "record_observation");
+        Assert.Equal(12, response.Usage?.InputTokenCount);
+        Assert.Equal(4, response.Usage?.OutputTokenCount);
+    }
+
+    [Fact]
+    public async Task ChatClient_Streaming_UsesNativeApiChatStream_AndEmitsUsage()
+    {
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(_ =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {"message":{"content":"Hel"},"done":false}
+                    {"message":{"content":"lo"},"done":false}
+                    {"done":true,"prompt_eval_count":7,"eval_count":3}
+                    """.ReplaceLineEndings("\n"),
+                    Encoding.UTF8,
+                    "application/json")
+            })));
+
+        using var client = new OllamaChatClient(
+            new LlmProviderConfig
+            {
+                Provider = "ollama",
+                Model = "llama3.2"
+            },
+            httpClient);
+
+        var updates = new List<ChatResponseUpdate>();
+        await foreach (var update in client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "hello")], cancellationToken: CancellationToken.None))
+            updates.Add(update);
+
+        Assert.Equal("Hello", string.Concat(updates.SelectMany(static update => update.Contents).OfType<TextContent>().Select(static content => content.Text)));
+        var usage = Assert.Single(updates.SelectMany(static update => update.Contents).OfType<UsageContent>());
+        Assert.Equal(7, usage.Details.InputTokenCount);
+        Assert.Equal(3, usage.Details.OutputTokenCount);
+    }
+
+    [Fact]
+    public async Task EmbeddingGenerator_UsesNativeApiEmbed()
+    {
+        var requests = new List<(Uri Uri, string Body)>();
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(async request =>
+        {
+            requests.Add((request.RequestUri!, await request.Content!.ReadAsStringAsync()));
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {"embeddings":[[0.1,0.2,0.3],[0.4,0.5,0.6]]}
+                    """,
+                    Encoding.UTF8,
+                    "application/json")
+            };
+        }));
+
+        using var generator = new OllamaEmbeddingGenerator(
+            new LlmProviderConfig
+            {
+                Provider = "ollama",
+                Model = "llama3.2",
+                Endpoint = "http://127.0.0.1:11434/v1"
+            },
+            "nomic-embed-text",
+            httpClient);
+
+        var embeddings = await generator.GenerateAsync(["alpha", "beta"], cancellationToken: CancellationToken.None);
+
+        var request = Assert.Single(requests);
+        Assert.Equal("/api/embed", request.Uri.AbsolutePath);
+        Assert.DoesNotContain("/v1", request.Uri.AbsoluteUri, StringComparison.Ordinal);
+        Assert.Contains("\"nomic-embed-text\"", request.Body, StringComparison.Ordinal);
+        Assert.Equal(2, embeddings.Count);
+        Assert.Equal(0.1f, embeddings[0].Vector.Span[0]);
+        Assert.Equal(0.6f, embeddings[1].Vector.Span[2]);
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _handler;
+
+        public StubHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => _handler(request);
+    }
+}

--- a/src/OpenClaw.Tests/SetupCommandTests.cs
+++ b/src/OpenClaw.Tests/SetupCommandTests.cs
@@ -139,6 +139,59 @@ public sealed class SetupCommandTests
     }
 
     [Fact]
+    public async Task RunAsync_NonInteractiveOllamaPreset_WritesPresetBackedLocalProfile()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var configPath = Path.Combine(root, "config", "openclaw.ollama.json");
+            var workspace = Path.Combine(root, "workspace");
+            using var output = new StringWriter();
+            using var error = new StringWriter();
+
+            var exitCode = await SetupCommand.RunAsync(
+                [
+                    "--non-interactive",
+                    "--profile", "local",
+                    "--config", configPath,
+                    "--workspace", workspace,
+                    "--provider", "ollama",
+                    "--model", "llama3.2",
+                    "--model-preset", "ollama-general"
+                ],
+                new StringReader(string.Empty),
+                output,
+                error,
+                root,
+                canPrompt: false);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(string.Empty, error.ToString());
+
+            using var document = JsonDocument.Parse(await File.ReadAllTextAsync(configPath));
+            var openClaw = document.RootElement.GetProperty("OpenClaw");
+            Assert.Equal("ollama", openClaw.GetProperty("llm").GetProperty("provider").GetString());
+            Assert.Equal("llama3.2", openClaw.GetProperty("llm").GetProperty("model").GetString());
+            Assert.Equal("http://127.0.0.1:11434", openClaw.GetProperty("llm").GetProperty("endpoint").GetString());
+
+            var models = openClaw.GetProperty("models");
+            Assert.Equal("local-primary", models.GetProperty("defaultProfile").GetString());
+            var profile = Assert.Single(models.GetProperty("profiles").EnumerateArray());
+            Assert.Equal("local-primary", profile.GetProperty("id").GetString());
+            Assert.Equal("ollama-general", profile.GetProperty("presetId").GetString());
+            Assert.Equal("http://127.0.0.1:11434", profile.GetProperty("baseUrl").GetString());
+
+            var envExample = await File.ReadAllTextAsync(Path.Combine(root, "config", "openclaw.ollama.env.example"));
+            Assert.DoesNotContain("MODEL_PROVIDER_KEY=replace-me", envExample, StringComparison.Ordinal);
+            Assert.Contains($"OPENCLAW_WORKSPACE={workspace}", envExample, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task RunAsync_NonInteractiveWithoutProfile_FailsFast()
     {
         var root = CreateTempRoot();


### PR DESCRIPTION
## Summary
- add native Ollama transport, local preset catalog support, and deterministic prompt-budget fallback behavior
- add maintenance scan/fix plus reliability scoring across setup, admin, and integration/operator surfaces
- add concise operational response mode, admin UI updates, docs, and regression coverage for the new local-model and maintenance flows

## Validation
- dotnet build src/OpenClaw.Tests/OpenClaw.Tests.csproj
- dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj --filter "FullyQualifiedName~AgentSystemPromptBuilderTests|FullyQualifiedName~ChatCommandProcessorTests|FullyQualifiedName~SetupCommandTests|FullyQualifiedName~ModelProfileSelectionTests|FullyQualifiedName~MaintenanceCoordinatorTests|FullyQualifiedName~OllamaNativeClientTests|FullyQualifiedName~GatewayAdminEndpointTests"
- dotnet run --project src/OpenClaw.Cli -c Release -- maintenance --help
- dotnet run --project src/OpenClaw.Cli -c Release -- models presets

## Notes
- the unrelated untracked `DIRECT_COMPETITOR_ROADMAP.md` file is intentionally not included
