### PR TITLE
[codex] add config diagnostics and image prompt fixes

### DIFF
--- a/docs/MODEL_PROFILES.md
+++ b/docs/MODEL_PROFILES.md
@@ -38,6 +38,21 @@ The runtime uses those profiles to:
 - fall back to another profile when allowed
 - fail clearly when no profile can safely satisfy the request
 
+## OpenAI-compatible request mapping
+
+When a client calls OpenClaw's OpenAI-compatible HTTP routes, the request `model` field is interpreted as either:
+
+- a model profile id, if it matches a configured OpenClaw profile, or
+- a literal upstream model id override, if it does not.
+
+If the request omits `model`, OpenClaw falls back to the configured default profile or `OpenClaw:Llm:Model`.
+
+This matters for downstream integrations:
+
+- `"default"` is not a built-in sentinel for "use your configured default".
+- `"default"` only works if you defined a profile with id `default`.
+- If you want the gateway default route, omit `model`.
+
 ## Example configuration
 
 ```json

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -522,6 +522,29 @@ On non-loopback/public binds, authenticate these surfaces with `Authorization: B
 - Admin session listings and session detail now expose `stableSessionId`, `stableSessionNamespace`, and `stableSessionOwnerKey` so operators can audit the binding.
 - Unsafe stable session ids (path separators, traversal patterns, overlong ids) are rejected at the HTTP edge.
 
+### OpenAI-compatible model resolution
+
+For `POST /v1/chat/completions` and `POST /v1/responses`, the incoming `model` field is resolved in this order:
+
+1. If `model` matches a configured OpenClaw model profile id, OpenClaw selects that profile.
+2. Otherwise, OpenClaw treats `model` as a literal upstream model id override.
+3. If `model` is omitted, OpenClaw falls back to the configured gateway default model profile or `OpenClaw:Llm:Model`.
+
+Important implications:
+
+- The incoming bearer token only authenticates the caller to OpenClaw. It does not tell OpenClaw which provider or model to use.
+- A model profile id is an OpenClaw concept. An upstream model id is a provider concept. They are not interchangeable unless you intentionally name them the same way.
+- `"default"` is not a reserved sentinel on the OpenAI-compatible routes. It only works if you actually defined a model profile with id `default`.
+- If your client wants "whatever OpenClaw is configured to use by default", omit the `model` field instead of sending `"default"`.
+
+Examples:
+
+- Omit `model`: use the gateway default route.
+- `"model": "frontier-tools"`: select the OpenClaw model profile with id `frontier-tools`.
+- `"model": "gpt-4o-mini"`: pass the literal upstream model id `gpt-4o-mini` through the selected provider route.
+
+If you are building a downstream app against OpenClaw's OpenAI-compatible surface, do not assume your own config placeholder values such as `"default"` or `"primary"` have meaning unless you created matching model profiles in OpenClaw.
+
 ## Upstream Migration
 
 Use the upstream migration flow to translate an upstream-style OpenClaw tree into an external OpenClaw.NET config:

--- a/src/OpenClaw.Agent/Execution/ToolExecutionRouter.cs
+++ b/src/OpenClaw.Agent/Execution/ToolExecutionRouter.cs
@@ -83,7 +83,17 @@ public sealed class ToolExecutionRouter
         if (tool is not ISandboxCapableTool sandboxCapableTool)
             return false;
 
-        sandboxMode = ToolSandboxPolicy.ResolveMode(_config, tool.Name, sandboxCapableTool.DefaultSandboxMode);
+        var sandboxResolution = ToolSandboxPolicy.ResolveModeDetailed(_config, tool.Name, sandboxCapableTool.DefaultSandboxMode);
+        sandboxMode = sandboxResolution.EffectiveMode;
+        _logger?.LogInformation(
+            "Sandbox mode resolved for tool {Tool}: provider={Provider} source={Source} default={DefaultMode} configured={ConfiguredMode} effective={EffectiveMode} reason={Reason}",
+            tool.Name,
+            sandboxResolution.Provider,
+            sandboxResolution.ModeSource,
+            sandboxResolution.DefaultMode,
+            sandboxResolution.ConfiguredMode?.ToString() ?? "",
+            sandboxResolution.EffectiveMode,
+            sandboxResolution.Reason);
         if (sandboxMode == ToolSandboxMode.None)
             return false;
 

--- a/src/OpenClaw.Cli/CliArgs.cs
+++ b/src/OpenClaw.Cli/CliArgs.cs
@@ -7,6 +7,7 @@ internal sealed class CliArgs
 
     public List<string> Positionals { get; } = [];
     public List<string> Files { get; } = [];
+    public List<string> Images { get; } = [];
     public bool ShowHelp { get; private set; }
     public IReadOnlyDictionary<string, List<string>> Options => _options;
 
@@ -56,6 +57,12 @@ internal sealed class CliArgs
             if (a == "--file")
             {
                 parsed.Files.Add(value);
+                continue;
+            }
+
+            if (a == "--image")
+            {
+                parsed.Images.Add(value);
                 continue;
             }
 

--- a/src/OpenClaw.Cli/Program.cs
+++ b/src/OpenClaw.Cli/Program.cs
@@ -1679,6 +1679,9 @@ internal static class Program
             return $"[IMAGE_URL:{image}]";
         }
 
+        if (Uri.TryCreate(image, UriKind.Absolute, out uri) && uri.IsFile)
+            return $"[IMAGE_PATH:{Path.GetFullPath(uri.LocalPath)}]";
+
         return $"[IMAGE_PATH:{Path.GetFullPath(image)}]";
     }
 

--- a/src/OpenClaw.Cli/Program.cs
+++ b/src/OpenClaw.Cli/Program.cs
@@ -111,6 +111,7 @@ internal static class Program
 
             run options:
               --file <path>      Attach file contents (repeatable)
+              --image <path|url> Attach image input (repeatable)
               --no-stream        Disable SSE streaming
               --temperature <n>  Temperature (optional)
               --max-tokens <n>   Max tokens (optional)
@@ -119,6 +120,7 @@ internal static class Program
               /help, /exit, /reset
               /system <text>
               /model <model>
+              /image <path|url> [prompt]
 
             Examples:
               openclaw start
@@ -424,7 +426,7 @@ internal static class Program
             return 2;
         }
 
-        var userContent = BuildUserContent(prompt, parsed.Files);
+        var userContent = BuildUserContent(prompt, parsed.Files, parsed.Images);
         var messages = BuildMessages(system, userContent, priorConversation: null);
 
         using var client = new OpenClawHttpClient(baseUrl, token);
@@ -488,15 +490,22 @@ internal static class Program
             if (line.Length == 0)
                 continue;
 
-            if (line.StartsWith('/'))
+            var userContent = line.StartsWith("/image ", StringComparison.OrdinalIgnoreCase)
+                ? BuildImageCommandContent(line)
+                : line;
+
+            if (userContent is null)
+                continue;
+
+            if (line.StartsWith('/') && !line.StartsWith("/image ", StringComparison.OrdinalIgnoreCase))
             {
                 if (HandleSlashCommand(line, conversation, ref system, ref model))
                     break;
                 continue;
             }
 
-            conversation.Add(new OpenAiMessage { Role = "user", Content = line });
-            var messages = BuildMessages(system, line, conversation);
+            conversation.Add(new OpenAiMessage { Role = "user", Content = userContent });
+            var messages = BuildMessages(system, userContent, conversation);
 
             var request = new OpenAiChatCompletionRequest
             {
@@ -1612,15 +1621,43 @@ internal static class Program
         return messages;
     }
 
-    private static string BuildUserContent(string prompt, IReadOnlyList<string> files)
+    internal static string? BuildImageCommandContent(string command)
     {
-        if (files.Count == 0)
+        var tail = command["/image ".Length..].Trim();
+        if (tail.Length == 0)
+        {
+            Console.Error.WriteLine("Usage: /image <path|url> [prompt]");
+            return null;
+        }
+
+        var firstSpace = tail.IndexOf(' ');
+        var image = firstSpace < 0 ? tail : tail[..firstSpace].Trim();
+        var prompt = firstSpace < 0 ? "Describe this image." : tail[(firstSpace + 1)..].Trim();
+        if (string.IsNullOrWhiteSpace(prompt))
+            prompt = "Describe this image.";
+
+        return BuildUserContent(prompt, files: [], images: [image]);
+    }
+
+    internal static string BuildUserContent(string prompt, IReadOnlyList<string> files, IReadOnlyList<string>? images = null)
+    {
+        images ??= [];
+        if (files.Count == 0 && images.Count == 0)
             return prompt;
 
         var parts = new List<string> { prompt };
+        foreach (var image in images)
+            parts.Add(BuildImageMarker(image));
+
         foreach (var path in files)
         {
             var fullPath = Path.GetFullPath(path);
+            if (IsImagePath(fullPath))
+            {
+                parts.Add(BuildImageMarker(fullPath));
+                continue;
+            }
+
             var content = File.ReadAllText(fullPath);
             parts.Add(
                 $"""
@@ -1632,6 +1669,27 @@ internal static class Program
                 """);
         }
         return string.Join('\n', parts);
+    }
+
+    private static string BuildImageMarker(string image)
+    {
+        if (Uri.TryCreate(image, UriKind.Absolute, out var uri) &&
+            (uri.Scheme is "http" or "https" or "data"))
+        {
+            return $"[IMAGE_URL:{image}]";
+        }
+
+        return $"[IMAGE_PATH:{Path.GetFullPath(image)}]";
+    }
+
+    private static bool IsImagePath(string path)
+    {
+        var extension = Path.GetExtension(path);
+        return extension.Equals(".png", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".webp", StringComparison.OrdinalIgnoreCase)
+               || extension.Equals(".gif", StringComparison.OrdinalIgnoreCase);
     }
 
     private static async Task<string?> ReadAllStdinAsync()

--- a/src/OpenClaw.Core/Models/ConfigurationDiagnostics.cs
+++ b/src/OpenClaw.Core/Models/ConfigurationDiagnostics.cs
@@ -1,0 +1,15 @@
+namespace OpenClaw.Core.Models;
+
+public sealed class ConfigSourceDiagnosticItem
+{
+    public required string Label { get; init; }
+    public required string Key { get; init; }
+    public required string EffectiveValue { get; init; }
+    public required string Source { get; init; }
+    public bool Redacted { get; init; }
+}
+
+public sealed class ConfigSourceDiagnostics
+{
+    public IReadOnlyList<ConfigSourceDiagnosticItem> Items { get; init; } = [];
+}

--- a/src/OpenClaw.Core/Models/GatewayConfig.cs
+++ b/src/OpenClaw.Core/Models/GatewayConfig.cs
@@ -286,7 +286,7 @@ public sealed class SecurityConfig
 
 public sealed class WebSocketConfig
 {
-    public int MaxMessageBytes { get; set; } = 65_536;
+    public int MaxMessageBytes { get; set; } = 1024 * 1024;
     public int MaxConnections { get; set; } = 1_000;
     public int MaxConnectionsPerIp { get; set; } = 50;
     public int MessagesPerMinutePerConnection { get; set; } = 120;

--- a/src/OpenClaw.Core/Models/GatewayConfig.cs
+++ b/src/OpenClaw.Core/Models/GatewayConfig.cs
@@ -286,7 +286,7 @@ public sealed class SecurityConfig
 
 public sealed class WebSocketConfig
 {
-    public int MaxMessageBytes { get; set; } = 1024 * 1024;
+    public int MaxMessageBytes { get; set; } = 256 * 1024;
     public int MaxConnections { get; set; } = 1_000;
     public int MaxConnectionsPerIp { get; set; } = 50;
     public int MessagesPerMinutePerConnection { get; set; } = 120;

--- a/src/OpenClaw.Core/Models/OpenAiModels.cs
+++ b/src/OpenClaw.Core/Models/OpenAiModels.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace OpenClaw.Core.Models;
@@ -32,7 +33,148 @@ public sealed class OpenAiChatCompletionRequest
 public sealed class OpenAiMessage
 {
     public required string Role { get; set; }
-    public required string Content { get; set; }
+    public required OpenAiMessageContent Content { get; set; }
+}
+
+[JsonConverter(typeof(OpenAiMessageContentJsonConverter))]
+public sealed class OpenAiMessageContent
+{
+    public string? Text { get; init; }
+    public List<OpenAiMessageContentPart> Parts { get; init; } = [];
+
+    public static implicit operator OpenAiMessageContent(string text)
+        => FromText(text);
+
+    public static OpenAiMessageContent FromText(string? text)
+        => new() { Text = text ?? string.Empty };
+
+    public string ToPromptText()
+    {
+        if (Parts.Count == 0)
+            return Text ?? string.Empty;
+
+        var lines = new List<string>();
+        foreach (var part in Parts)
+        {
+            if (part.IsText && !string.IsNullOrWhiteSpace(part.Text))
+            {
+                lines.Add(part.Text!);
+                continue;
+            }
+
+            if (part.IsImage && !string.IsNullOrWhiteSpace(part.ImageUrl))
+                lines.Add($"[IMAGE_URL:{part.ImageUrl}]");
+        }
+
+        return string.Join('\n', lines).Trim();
+    }
+
+    public override string ToString() => ToPromptText();
+
+    public override bool Equals(object? obj)
+        => obj switch
+        {
+            OpenAiMessageContent other => string.Equals(ToPromptText(), other.ToPromptText(), StringComparison.Ordinal),
+            string text => string.Equals(ToPromptText(), text, StringComparison.Ordinal),
+            _ => false
+        };
+
+    public override int GetHashCode()
+        => StringComparer.Ordinal.GetHashCode(ToPromptText());
+}
+
+public sealed class OpenAiMessageContentPart
+{
+    public string Type { get; init; } = "";
+    public string? Text { get; init; }
+    public string? ImageUrl { get; init; }
+
+    public bool IsText => Type is "text" or "input_text";
+    public bool IsImage => Type is "image_url" or "input_image";
+}
+
+public sealed class OpenAiMessageContentJsonConverter : JsonConverter<OpenAiMessageContent>
+{
+    public override OpenAiMessageContent Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+            return OpenAiMessageContent.FromText(reader.GetString());
+
+        if (reader.TokenType != JsonTokenType.StartArray)
+            throw new JsonException("OpenAI message content must be a string or an array of content parts.");
+
+        var parts = new List<OpenAiMessageContentPart>();
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndArray)
+                return new OpenAiMessageContent { Parts = parts };
+
+            using var doc = JsonDocument.ParseValue(ref reader);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                continue;
+
+            var type = root.TryGetProperty("type", out var typeProp) ? typeProp.GetString() ?? "" : "";
+            if (type is "text" or "input_text")
+            {
+                var text = root.TryGetProperty("text", out var textProp) ? textProp.GetString() : null;
+                parts.Add(new OpenAiMessageContentPart { Type = type, Text = text });
+                continue;
+            }
+
+            if (type is "image_url" or "input_image")
+            {
+                string? imageUrl = null;
+                if (root.TryGetProperty("image_url", out var imageUrlProp))
+                {
+                    imageUrl = imageUrlProp.ValueKind == JsonValueKind.String
+                        ? imageUrlProp.GetString()
+                        : imageUrlProp.TryGetProperty("url", out var urlProp) ? urlProp.GetString() : null;
+                }
+                else if (root.TryGetProperty("image", out var inputImageProp))
+                {
+                    imageUrl = inputImageProp.GetString();
+                }
+                else if (root.TryGetProperty("url", out var urlProp))
+                {
+                    imageUrl = urlProp.GetString();
+                }
+
+                parts.Add(new OpenAiMessageContentPart { Type = type, ImageUrl = imageUrl });
+            }
+        }
+
+        throw new JsonException("Unexpected end of OpenAI message content array.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, OpenAiMessageContent value, JsonSerializerOptions options)
+    {
+        if (value.Parts.Count == 0)
+        {
+            writer.WriteStringValue(value.Text ?? string.Empty);
+            return;
+        }
+
+        writer.WriteStartArray();
+        foreach (var part in value.Parts)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", part.Type);
+            if (part.IsText)
+            {
+                writer.WriteString("text", part.Text ?? string.Empty);
+            }
+            else if (part.IsImage)
+            {
+                writer.WritePropertyName("image_url");
+                writer.WriteStartObject();
+                writer.WriteString("url", part.ImageUrl ?? string.Empty);
+                writer.WriteEndObject();
+            }
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
+    }
 }
 
 /// <summary>

--- a/src/OpenClaw.Core/Models/OpenAiModels.cs
+++ b/src/OpenClaw.Core/Models/OpenAiModels.cs
@@ -95,8 +95,13 @@ public sealed class OpenAiMessageContentPart
 
 public sealed class OpenAiMessageContentJsonConverter : JsonConverter<OpenAiMessageContent>
 {
+    public override bool HandleNull => true;
+
     public override OpenAiMessageContent Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
+        if (reader.TokenType == JsonTokenType.Null)
+            return OpenAiMessageContent.FromText(null);
+
         if (reader.TokenType == JsonTokenType.String)
             return OpenAiMessageContent.FromText(reader.GetString());
 

--- a/src/OpenClaw.Core/Models/SandboxConfig.cs
+++ b/src/OpenClaw.Core/Models/SandboxConfig.cs
@@ -26,6 +26,14 @@ public sealed class SandboxToolConfig
     public int? TTL { get; set; }
 }
 
+public sealed record ToolSandboxModeResolution(
+    string Provider,
+    string ModeSource,
+    ToolSandboxMode DefaultMode,
+    ToolSandboxMode? ConfiguredMode,
+    ToolSandboxMode EffectiveMode,
+    string Reason);
+
 public static class SandboxProviderNames
 {
     public const string None = "None";
@@ -79,14 +87,38 @@ public static class ToolSandboxPolicy
         GatewayConfig config,
         string toolName,
         ToolSandboxMode defaultMode)
+        => ResolveModeDetailed(config, toolName, defaultMode).EffectiveMode;
+
+    public static ToolSandboxModeResolution ResolveModeDetailed(
+        GatewayConfig config,
+        string toolName,
+        ToolSandboxMode defaultMode)
     {
-        if (config.Sandbox.Tools.TryGetValue(toolName, out var toolConfig) &&
-            TryParseMode(toolConfig.Mode, out var configuredMode))
+        var provider = SandboxProviderNames.Normalize(config.Sandbox.Provider);
+        var configuredMode = ToolSandboxMode.None;
+        var hasConfiguredMode = config.Sandbox.Tools.TryGetValue(toolName, out var toolConfig) &&
+                                TryParseMode(toolConfig.Mode, out configuredMode);
+        var selectedMode = hasConfiguredMode ? configuredMode : defaultMode;
+        var modeSource = hasConfiguredMode ? "tool-config" : "tool-default";
+
+        if (string.Equals(provider, SandboxProviderNames.None, StringComparison.OrdinalIgnoreCase))
         {
-            return configuredMode;
+            return new ToolSandboxModeResolution(
+                provider,
+                modeSource,
+                defaultMode,
+                hasConfiguredMode ? configuredMode : null,
+                ToolSandboxMode.None,
+                "sandbox provider is None, the global sandbox off switch");
         }
 
-        return defaultMode;
+        return new ToolSandboxModeResolution(
+            provider,
+            modeSource,
+            defaultMode,
+            hasConfiguredMode ? configuredMode : null,
+            selectedMode,
+            hasConfiguredMode ? "tool-specific sandbox mode configured" : "using tool default sandbox mode");
     }
 
     public static string? ResolveTemplate(GatewayConfig config, string toolName)

--- a/src/OpenClaw.Core/Models/Session.cs
+++ b/src/OpenClaw.Core/Models/Session.cs
@@ -445,6 +445,8 @@ public sealed class SessionDelegationChildSummary
 [JsonSerializable(typeof(OpenAiChatCompletionRequest))]
 [JsonSerializable(typeof(OpenAiChatCompletionResponse))]
 [JsonSerializable(typeof(OpenAiMessage))]
+[JsonSerializable(typeof(OpenAiMessageContent))]
+[JsonSerializable(typeof(OpenAiMessageContentPart))]
 [JsonSerializable(typeof(OpenAiChoice))]
 [JsonSerializable(typeof(OpenAiResponseMessage))]
 [JsonSerializable(typeof(OpenAiUsage))]

--- a/src/OpenClaw.Core/Validation/DoctorCheck.cs
+++ b/src/OpenClaw.Core/Validation/DoctorCheck.cs
@@ -8,7 +8,10 @@ namespace OpenClaw.Core.Validation;
 /// </summary>
 public static class DoctorCheck
 {
-    public static async Task<bool> RunAsync(GatewayConfig config, GatewayRuntimeState runtimeState)
+    public static async Task<bool> RunAsync(
+        GatewayConfig config,
+        GatewayRuntimeState runtimeState,
+        ConfigSourceDiagnostics? configSources = null)
     {
         var localState = LocalSetupStateLoader.Load(config.Memory.StoragePath);
         var report = await SetupVerificationService.BuildDoctorReportAsync(new DoctorReportRequest
@@ -21,7 +24,8 @@ public static class DoctorCheck
             RequireProvider = false,
             CheckPortAvailability = true,
             WorkspacePath = config.Tooling.WorkspaceRoot,
-            ModelDoctor = ModelDoctorEvaluator.Build(config)
+            ModelDoctor = ModelDoctorEvaluator.Build(config),
+            ConfigSources = configSources
         }, CancellationToken.None);
 
         Console.WriteLine(SetupVerificationService.RenderDoctorText(report));

--- a/src/OpenClaw.Core/Validation/SetupVerificationService.cs
+++ b/src/OpenClaw.Core/Validation/SetupVerificationService.cs
@@ -20,6 +20,7 @@ public sealed class SetupVerificationRequest
     public ModelSelectionDoctorResponse? ModelDoctor { get; init; }
     public IModelProfileRegistry? ModelProfiles { get; init; }
     public ProviderSmokeRegistry? ProviderSmokeRegistry { get; init; }
+    public ConfigSourceDiagnostics? ConfigSources { get; init; }
 }
 
 public sealed class DoctorReportRequest
@@ -35,6 +36,7 @@ public sealed class DoctorReportRequest
     public ModelSelectionDoctorResponse? ModelDoctor { get; init; }
     public IModelProfileRegistry? ModelProfiles { get; init; }
     public ProviderSmokeRegistry? ProviderSmokeRegistry { get; init; }
+    public ConfigSourceDiagnostics? ConfigSources { get; init; }
 }
 
 public static class SetupVerificationService
@@ -64,7 +66,8 @@ public static class SetupVerificationService
             WorkspacePath = request.WorkspacePath,
             ModelDoctor = request.ModelDoctor,
             ModelProfiles = request.ModelProfiles,
-            ProviderSmokeRegistry = request.ProviderSmokeRegistry
+            ProviderSmokeRegistry = request.ProviderSmokeRegistry,
+            ConfigSources = request.ConfigSources
         }, ct);
 
         return BuildSetupVerificationResponse(report);
@@ -82,6 +85,7 @@ public static class SetupVerificationService
         {
             BuildRuntimeCheck(request.RuntimeState),
             BuildConfigCheck(config),
+            BuildConfigSourceDiagnosticsCheck(request.ConfigSources),
             BuildPromptCacheCheck(config),
             BuildModelProfileConsistencyCheck(config),
             BuildWorkspaceCheck(config, workspacePath),
@@ -321,6 +325,32 @@ public static class SetupVerificationService
             Summary = $"Static configuration validation found {errors.Count} issue(s).",
             Detail = string.Join(Environment.NewLine, errors.Take(8).Select(static item => $"- {item}")),
             NextStep = "Fix the configuration validation errors and rerun doctor or setup verify."
+        };
+    }
+
+    private static DoctorCheckItem BuildConfigSourceDiagnosticsCheck(ConfigSourceDiagnostics? diagnostics)
+    {
+        if (diagnostics is null || diagnostics.Items.Count == 0)
+        {
+            return new DoctorCheckItem
+            {
+                Id = "config_sources",
+                Label = "Effective configuration sources",
+                Category = DoctorCheckCategories.Config,
+                Status = SetupCheckStates.Skip,
+                Summary = "Configuration source diagnostics were not supplied."
+            };
+        }
+
+        return new DoctorCheckItem
+        {
+            Id = "config_sources",
+            Label = "Effective configuration sources",
+            Category = DoctorCheckCategories.Config,
+            Status = SetupCheckStates.Pass,
+            Summary = "Effective bind, storage, provider, and secret-source winners are listed.",
+            Detail = string.Join(Environment.NewLine, diagnostics.Items.Select(static item =>
+                $"- {item.Label}: {item.EffectiveValue} (source: {item.Source})"))
         };
     }
 

--- a/src/OpenClaw.Core/Validation/SetupVerificationService.cs
+++ b/src/OpenClaw.Core/Validation/SetupVerificationService.cs
@@ -350,9 +350,12 @@ public static class SetupVerificationService
             Status = SetupCheckStates.Pass,
             Summary = "Effective bind, storage, provider, and secret-source winners are listed.",
             Detail = string.Join(Environment.NewLine, diagnostics.Items.Select(static item =>
-                $"- {item.Label}: {item.EffectiveValue} (source: {item.Source})"))
+                $"- {item.Label}: {FormatConfigDiagnosticValue(item)} (source: {item.Source})"))
         };
     }
+
+    private static string FormatConfigDiagnosticValue(ConfigSourceDiagnosticItem item)
+        => item.Redacted ? "configured (redacted)" : item.EffectiveValue;
 
     private static DoctorCheckItem BuildPromptCacheCheck(GatewayConfig config)
         => HasValidPromptCacheConfiguration(config)

--- a/src/OpenClaw.Gateway/Bootstrap/ConfigurationSourceDiagnosticsBuilder.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/ConfigurationSourceDiagnosticsBuilder.cs
@@ -1,0 +1,161 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.CommandLine;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+using Microsoft.Extensions.Configuration.Json;
+using Microsoft.Extensions.Configuration.Memory;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Security;
+
+namespace OpenClaw.Gateway.Bootstrap;
+
+internal static class ConfigurationSourceDiagnosticsBuilder
+{
+    public static ConfigSourceDiagnostics Build(IConfigurationRoot configuration, GatewayConfig config)
+    {
+        var items = new List<ConfigSourceDiagnosticItem>
+        {
+            BuildPlainItem(configuration, "Bind address", "OpenClaw:BindAddress", config.BindAddress),
+            BuildPlainItem(configuration, "Memory storage path", "OpenClaw:Memory:StoragePath", config.Memory.StoragePath),
+            BuildPlainItem(configuration, "SQLite DB path", "OpenClaw:Memory:Sqlite:DbPath", config.Memory.Sqlite.DbPath),
+            BuildPlainItem(configuration, "Retention archive path", "OpenClaw:Memory:Retention:ArchivePath", config.Memory.Retention.ArchivePath),
+            BuildPlainItem(configuration, "Workspace root", "OpenClaw:Tooling:WorkspaceRoot", config.Tooling.WorkspaceRoot),
+            BuildPlainItem(configuration, "Provider", "OpenClaw:Llm:Provider", config.Llm.Provider),
+            BuildProviderModelItem(configuration, config),
+            BuildPlainItem(configuration, "Provider endpoint", "OpenClaw:Llm:Endpoint", config.Llm.Endpoint),
+            BuildApiKeyItem(configuration, config)
+        };
+
+        return new ConfigSourceDiagnostics { Items = items };
+    }
+
+    public static string Render(ConfigSourceDiagnostics diagnostics)
+        => string.Join(Environment.NewLine, diagnostics.Items.Select(static item =>
+            $"- {item.Label}: {item.EffectiveValue} (source: {item.Source})"));
+
+    private static ConfigSourceDiagnosticItem BuildProviderModelItem(IConfigurationRoot configuration, GatewayConfig config)
+    {
+        if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("MODEL_PROVIDER_MODEL")))
+        {
+            return new ConfigSourceDiagnosticItem
+            {
+                Label = "Model",
+                Key = "OpenClaw:Llm:Model",
+                EffectiveValue = Display(config.Llm.Model),
+                Source = "environment variable MODEL_PROVIDER_MODEL (compatibility override)"
+            };
+        }
+
+        return BuildPlainItem(configuration, "Model", "OpenClaw:Llm:Model", config.Llm.Model);
+    }
+
+    private static ConfigSourceDiagnosticItem BuildApiKeyItem(IConfigurationRoot configuration, GatewayConfig config)
+    {
+        const string key = "OpenClaw:Llm:ApiKey";
+        var configuredRef = configuration[key];
+        var configuredSource = ResolveWinningSource(configuration, key);
+        var modelProviderKey = Environment.GetEnvironmentVariable("MODEL_PROVIDER_KEY");
+        var resolvedFromRef = SecretResolver.Resolve(configuredRef);
+        var hasEffectiveKey = !string.IsNullOrWhiteSpace(config.Llm.ApiKey);
+
+        string source;
+        if (!string.IsNullOrWhiteSpace(configuredRef) && !string.IsNullOrWhiteSpace(resolvedFromRef))
+        {
+            source = $"{configuredSource}; {DescribeSecretReference(configuredRef)}";
+        }
+        else if (!string.IsNullOrWhiteSpace(modelProviderKey))
+        {
+            source = "environment variable MODEL_PROVIDER_KEY (compatibility override)";
+        }
+        else if (!string.IsNullOrWhiteSpace(configuredRef))
+        {
+            source = $"{configuredSource}; {DescribeSecretReference(configuredRef)} (unresolved)";
+        }
+        else
+        {
+            source = "not configured";
+        }
+
+        return new ConfigSourceDiagnosticItem
+        {
+            Label = "API key",
+            Key = key,
+            EffectiveValue = hasEffectiveKey ? "configured (redacted)" : "not configured",
+            Source = source,
+            Redacted = true
+        };
+    }
+
+    private static ConfigSourceDiagnosticItem BuildPlainItem(
+        IConfigurationRoot configuration,
+        string label,
+        string key,
+        string? effectiveValue)
+    {
+        if (string.Equals(key, "OpenClaw:Llm:Endpoint", StringComparison.Ordinal) &&
+            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("MODEL_PROVIDER_ENDPOINT")))
+        {
+            return new ConfigSourceDiagnosticItem
+            {
+                Label = label,
+                Key = key,
+                EffectiveValue = Display(effectiveValue),
+                Source = "environment variable MODEL_PROVIDER_ENDPOINT (compatibility override)"
+            };
+        }
+
+        return new ConfigSourceDiagnosticItem
+        {
+            Label = label,
+            Key = key,
+            EffectiveValue = Display(effectiveValue),
+            Source = ResolveWinningSource(configuration, key)
+        };
+    }
+
+    private static string ResolveWinningSource(IConfigurationRoot configuration, string key)
+    {
+        string? source = null;
+        foreach (var provider in configuration.Providers)
+        {
+            if (provider.TryGet(key, out _))
+                source = DescribeProvider(provider, key);
+        }
+
+        return source ?? "built-in default";
+    }
+
+    private static string DescribeProvider(IConfigurationProvider provider, string key)
+        => provider switch
+        {
+            JsonConfigurationProvider json when !string.IsNullOrWhiteSpace(json.Source.Path)
+                => json.Source.Path!,
+            EnvironmentVariablesConfigurationProvider
+                => $"environment variable {ToEnvironmentVariableName(key)}",
+            CommandLineConfigurationProvider
+                => "command line",
+            MemoryConfigurationProvider
+                => "in-memory override",
+            _ => provider.GetType().Name.Replace("ConfigurationProvider", "", StringComparison.Ordinal)
+        };
+
+    private static string DescribeSecretReference(string value)
+    {
+        if (value.StartsWith("env:", StringComparison.OrdinalIgnoreCase))
+            return $"secret reference {value}";
+
+        if (value.StartsWith("raw:", StringComparison.OrdinalIgnoreCase))
+            return "raw secret reference (value redacted)";
+
+        var envValue = Environment.GetEnvironmentVariable(value);
+        if (envValue is not null)
+            return $"environment variable {value}";
+
+        return "literal or bare secret reference (value redacted)";
+    }
+
+    private static string ToEnvironmentVariableName(string key)
+        => key.Replace(':', '_').Replace("_", "__", StringComparison.Ordinal);
+
+    private static string Display(string? value)
+        => string.IsNullOrWhiteSpace(value) ? "unset" : value;
+}

--- a/src/OpenClaw.Gateway/Bootstrap/GatewayBootstrapExtensions.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/GatewayBootstrapExtensions.cs
@@ -21,6 +21,7 @@ internal static class GatewayBootstrapExtensions
             opts.SerializerOptions.TypeInfoResolverChain.Add(CoreJsonContext.Default));
 
         var config = LoadGatewayConfig(builder.Configuration);
+        var configSources = ConfigurationSourceDiagnosticsBuilder.Build(builder.Configuration, config);
 
         var isNonLoopbackBind = !GatewaySecurity.IsLoopbackBind(config.BindAddress);
         var isDoctorMode = args.Any(a => string.Equals(a, "--doctor", StringComparison.Ordinal));
@@ -39,6 +40,7 @@ internal static class GatewayBootstrapExtensions
         if (isNonLoopbackBind && string.IsNullOrWhiteSpace(config.AuthToken))
         {
             var message = "OPENCLAW_AUTH_TOKEN must be set when binding to a non-loopback address.";
+            WriteConfigSourceDiagnostics(configSources);
             if (isDoctorMode)
             {
                 Console.Error.WriteLine(message);
@@ -57,6 +59,7 @@ internal static class GatewayBootstrapExtensions
             configErrors.Add(featureError);
         if (configErrors.Count > 0)
         {
+            WriteConfigSourceDiagnostics(configSources);
             foreach (var err in configErrors)
                 Console.Error.WriteLine($"Configuration error: {err}");
 
@@ -79,6 +82,7 @@ internal static class GatewayBootstrapExtensions
         }
         catch (Exception ex)
         {
+            WriteConfigSourceDiagnostics(configSources);
             Console.Error.WriteLine($"Configuration error: {ex.Message}");
             if (isDoctorMode)
             {
@@ -94,7 +98,10 @@ internal static class GatewayBootstrapExtensions
 
         if (isDoctorMode)
         {
-            var ok = await DoctorCheck.RunAsync(config, runtimeState);
+            var ok = await DoctorCheck.RunAsync(
+                config,
+                runtimeState,
+                configSources);
             return new BootstrapResult
             {
                 ShouldExit = true,
@@ -113,9 +120,16 @@ internal static class GatewayBootstrapExtensions
                 Config = config,
                 RuntimeState = runtimeState,
                 IsNonLoopbackBind = isNonLoopbackBind,
+                ConfigSources = configSources,
                 WorkspacePath = Environment.GetEnvironmentVariable("OPENCLAW_WORKSPACE")
             }
         };
+    }
+
+    private static void WriteConfigSourceDiagnostics(ConfigSourceDiagnostics diagnostics)
+    {
+        Console.Error.WriteLine("Effective configuration winners:");
+        Console.Error.WriteLine(ConfigurationSourceDiagnosticsBuilder.Render(diagnostics));
     }
 
     internal static GatewayConfig LoadGatewayConfig(IConfiguration configuration)

--- a/src/OpenClaw.Gateway/Bootstrap/GatewayStartupContext.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/GatewayStartupContext.cs
@@ -7,5 +7,6 @@ internal sealed class GatewayStartupContext
     public required GatewayConfig Config { get; init; }
     public required GatewayRuntimeState RuntimeState { get; init; }
     public required bool IsNonLoopbackBind { get; init; }
+    public ConfigSourceDiagnostics? ConfigSources { get; init; }
     public string? WorkspacePath { get; init; }
 }

--- a/src/OpenClaw.Gateway/Bootstrap/StartupConsoleCoordinator.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/StartupConsoleCoordinator.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using OpenClaw.Core.Models;
 
 namespace OpenClaw.Gateway.Bootstrap;
 
@@ -13,6 +14,7 @@ internal sealed class StartupConsoleCoordinator
 
     public void WriteConfigurationSummary(
         ConfigurationManager configuration,
+        GatewayConfig config,
         string environmentName,
         LocalStartupSession? session,
         TextWriter? output = null)
@@ -27,6 +29,10 @@ internal sealed class StartupConsoleCoordinator
         writer.WriteLine(session is null
             ? "- Session-only overrides: none"
             : $"- Session-only overrides: active ({session.Mode})");
+
+        writer.WriteLine("Effective configuration winners:");
+        writer.WriteLine(ConfigurationSourceDiagnosticsBuilder.Render(
+            ConfigurationSourceDiagnosticsBuilder.Build(configuration, config)));
         writer.Flush();
     }
 

--- a/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.ChatCompletions.cs
+++ b/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.ChatCompletions.cs
@@ -60,7 +60,7 @@ internal static partial class OpenAiEndpoints
 
             var lastUserMsg = req.Messages.FindLast(m =>
                 string.Equals(m.Role, "user", StringComparison.OrdinalIgnoreCase));
-            var userText = lastUserMsg?.Content ?? req.Messages[^1].Content ?? "";
+            var userText = (lastUserMsg?.Content ?? req.Messages[^1].Content).ToPromptText();
 
             var requesterKey = EndpointHelpers.GetHttpRateLimitKey(ctx, startup.Config);
             if (!TryGetOptionalStableSessionId(ctx, out var stableSessionId, out var stableSessionError))
@@ -158,7 +158,7 @@ internal static partial class OpenAiEndpoints
                             session.History.Add(new ChatTurn
                             {
                                 Role = message.Role.ToLowerInvariant(),
-                                Content = message.Content
+                                Content = message.Content.ToPromptText()
                             });
                         }
                     }

--- a/src/OpenClaw.Gateway/Program.cs
+++ b/src/OpenClaw.Gateway/Program.cs
@@ -63,7 +63,7 @@ while (true)
         startup = bootstrap.Startup
             ?? throw new InvalidOperationException("Bootstrap completed without a startup context.");
 
-        startupConsole.WriteConfigurationSummary(builder.Configuration, environmentName, localSession);
+        startupConsole.WriteConfigurationSummary(builder.Configuration, startup.Config, environmentName, localSession);
         startupConsole.WritePhase("Building services");
         builder.Services.AddOpenApi("openclaw-integration");
         builder.AddOpenClawObservability();

--- a/src/OpenClaw.Gateway/appsettings.Production.json
+++ b/src/OpenClaw.Gateway/appsettings.Production.json
@@ -46,7 +46,7 @@
     },
 
     "WebSocket": {
-      "MaxMessageBytes": 65536,
+      "MaxMessageBytes": 1048576,
       "MaxConnections": 1000,
       "MaxConnectionsPerIp": 20,
       "MessagesPerMinutePerConnection": 60,

--- a/src/OpenClaw.Gateway/appsettings.json
+++ b/src/OpenClaw.Gateway/appsettings.json
@@ -58,7 +58,7 @@
       "AllowRawSecretRefsOnPublicBind": false
     },
     "WebSocket": {
-      "MaxMessageBytes": 65536,
+      "MaxMessageBytes": 1048576,
       "MaxConnections": 1000,
       "MaxConnectionsPerIp": 50,
       "MessagesPerMinutePerConnection": 120,

--- a/src/OpenClaw.Gateway/wwwroot/webchat.html
+++ b/src/OpenClaw.Gateway/wwwroot/webchat.html
@@ -788,7 +788,7 @@
                 <button id="live-interrupt-button" type="button" title="Interrupt live generation" disabled>Interrupt</button>
             </div>
             <div id="input-container">
-                <button id="attach-button" type="button" title="Attach image">+</button>
+                <button id="attach-button" type="button" title="Attach image" aria-label="Attach image">+</button>
                 <input id="image-input" type="file" accept="image/*" multiple>
                 <textarea id="message-input" rows="1" placeholder="Message OpenClaw.NET..." disabled></textarea>
                 <button id="send-button" disabled title="Send Message">
@@ -1646,6 +1646,11 @@
             });
         }
 
+        function clearImageSelection() {
+            imageInput.value = '';
+            attachButton.classList.remove('has-files');
+        }
+
         async function sendMessage() {
             const text = messageInput.value.trim();
             const imageFiles = Array.from(imageInput.files || []);
@@ -1655,8 +1660,27 @@
                     appendSystem('Start a live session before sending live messages.', true);
                     return;
                 }
+                if (imageFiles.length > 0) {
+                    appendSystem('Image attachments are available in Chat mode.', true);
+                    clearImageSelection();
+                    return;
+                }
             } else if (!ws || ws.readyState !== WebSocket.OPEN) {
                 return;
+            }
+
+            let outboundText = text;
+            if (!isLiveMode()) {
+                outboundText = text || 'Describe this image.';
+                try {
+                    for (const file of imageFiles) {
+                        outboundText += `\n[IMAGE_URL:${await readImageAsDataUrl(file)}]`;
+                    }
+                } catch (error) {
+                    appendSystem(error.message || 'Unable to read image attachment.', true);
+                    clearImageSelection();
+                    return;
+                }
             }
 
             const row = createRow('user');
@@ -1668,10 +1692,6 @@
             chatContainer.insertBefore(row, typingRow);
 
             if (isLiveMode()) {
-                if (imageFiles.length > 0) {
-                    appendSystem('Image attachments are available in Chat mode.', true);
-                    return;
-                }
                 liveWs.send(JSON.stringify({
                     type: "text",
                     text: text,
@@ -1679,16 +1699,6 @@
                 }));
                 typingRow.style.display = 'flex';
             } else {
-                let outboundText = text || 'Describe this image.';
-                try {
-                    for (const file of imageFiles) {
-                        outboundText += `\n[IMAGE_URL:${await readImageAsDataUrl(file)}]`;
-                    }
-                } catch (error) {
-                    appendSystem(error.message || 'Unable to read image attachment.', true);
-                    return;
-                }
-
                 ws.send(JSON.stringify({
                     type: "user_message",
                     text: outboundText
@@ -1696,8 +1706,7 @@
             }
 
             messageInput.value = '';
-            imageInput.value = '';
-            attachButton.classList.remove('has-files');
+            clearImageSelection();
             messageInput.style.height = 'auto';
             sendButton.style.opacity = '0.7';
             activeResponseDiv = null;

--- a/src/OpenClaw.Gateway/wwwroot/webchat.html
+++ b/src/OpenClaw.Gateway/wwwroot/webchat.html
@@ -583,6 +583,30 @@
             align-items: flex-end;
         }
 
+        #attach-button {
+            background: var(--bg-elevated);
+            color: var(--text-secondary);
+            border: 1px solid var(--separator);
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            flex-shrink: 0;
+            margin-bottom: 6px;
+        }
+
+        #attach-button.has-files {
+            color: var(--accent);
+            border-color: var(--accent);
+        }
+
+        #image-input {
+            display: none;
+        }
+
         #message-input {
             flex-grow: 1;
             background: var(--bg-elevated);
@@ -764,6 +788,8 @@
                 <button id="live-interrupt-button" type="button" title="Interrupt live generation" disabled>Interrupt</button>
             </div>
             <div id="input-container">
+                <button id="attach-button" type="button" title="Attach image">+</button>
+                <input id="image-input" type="file" accept="image/*" multiple>
                 <textarea id="message-input" rows="1" placeholder="Message OpenClaw.NET..." disabled></textarea>
                 <button id="send-button" disabled title="Send Message">
                     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
@@ -795,6 +821,8 @@
         const chatContainer = document.getElementById('chat-container');
         const messageInput = document.getElementById('message-input');
         const sendButton = document.getElementById('send-button');
+        const attachButton = document.getElementById('attach-button');
+        const imageInput = document.getElementById('image-input');
         const tokenInput = document.getElementById('token-input');
         const rememberToken = document.getElementById('remember-token');
         const doctorButton = document.getElementById('doctor-button');
@@ -1609,9 +1637,19 @@
             };
         }
 
-        function sendMessage() {
+        function readImageAsDataUrl(file) {
+            return new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = () => resolve(String(reader.result || ''));
+                reader.onerror = () => reject(reader.error || new Error('Unable to read image.'));
+                reader.readAsDataURL(file);
+            });
+        }
+
+        async function sendMessage() {
             const text = messageInput.value.trim();
-            if (!text) return;
+            const imageFiles = Array.from(imageInput.files || []);
+            if (!text && imageFiles.length === 0) return;
             if (isLiveMode()) {
                 if (!isLiveConnected()) {
                     appendSystem('Start a live session before sending live messages.', true);
@@ -1630,6 +1668,10 @@
             chatContainer.insertBefore(row, typingRow);
 
             if (isLiveMode()) {
+                if (imageFiles.length > 0) {
+                    appendSystem('Image attachments are available in Chat mode.', true);
+                    return;
+                }
                 liveWs.send(JSON.stringify({
                     type: "text",
                     text: text,
@@ -1637,13 +1679,25 @@
                 }));
                 typingRow.style.display = 'flex';
             } else {
+                let outboundText = text || 'Describe this image.';
+                try {
+                    for (const file of imageFiles) {
+                        outboundText += `\n[IMAGE_URL:${await readImageAsDataUrl(file)}]`;
+                    }
+                } catch (error) {
+                    appendSystem(error.message || 'Unable to read image attachment.', true);
+                    return;
+                }
+
                 ws.send(JSON.stringify({
                     type: "user_message",
-                    text: text
+                    text: outboundText
                 }));
             }
 
             messageInput.value = '';
+            imageInput.value = '';
+            attachButton.classList.remove('has-files');
             messageInput.style.height = 'auto';
             sendButton.style.opacity = '0.7';
             activeResponseDiv = null;
@@ -1671,11 +1725,15 @@
         messageInput.addEventListener('keydown', (e) => {
             if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();
-                sendMessage();
+                void sendMessage();
             }
         });
 
-        sendButton.addEventListener('click', sendMessage);
+        sendButton.addEventListener('click', () => void sendMessage());
+        attachButton.addEventListener('click', () => imageInput.click());
+        imageInput.addEventListener('change', () => {
+            attachButton.classList.toggle('has-files', (imageInput.files || []).length > 0);
+        });
         modeSelect.addEventListener('change', updateComposerAvailability);
         liveConnectButton.addEventListener('click', connectLive);
         liveInterruptButton.addEventListener('click', () => {

--- a/src/OpenClaw.MicrosoftAgentFrameworkAdapter/OpenClaw.MicrosoftAgentFrameworkAdapter.csproj
+++ b/src/OpenClaw.MicrosoftAgentFrameworkAdapter/OpenClaw.MicrosoftAgentFrameworkAdapter.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.Agents.AI.Hosting.A2A" Version="1.0.0-preview.260330.1" />
     <PackageReference Include="A2A" Version="1.0.0-preview" />
     <PackageReference Include="A2A.AspNetCore" Version="1.0.0-preview" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />

--- a/src/OpenClaw.Tests/AgentRuntimeTests.cs
+++ b/src/OpenClaw.Tests/AgentRuntimeTests.cs
@@ -46,6 +46,31 @@ public class AgentRuntimeTests
     }
 
     [Fact]
+    public async Task RunAsync_ImageUrlMarker_ReachesLlmAsUriContent()
+    {
+        IList<ChatMessage>? capturedMessages = null;
+        _chatClient.GetResponseAsync(
+            Arg.Do<IList<ChatMessage>>(messages => capturedMessages = messages),
+            Arg.Any<ChatOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ChatResponse(new[] { new ChatMessage(ChatRole.Assistant, "saw image") })));
+
+        var session = new Session { Id = "sess1", SenderId = "user1", ChannelId = "test-channel" };
+
+        await _agent.RunAsync(
+            session,
+            "What is this?\n[IMAGE_URL:data:image/png;base64,AAAA]",
+            CancellationToken.None);
+
+        Assert.NotNull(capturedMessages);
+        var user = capturedMessages!.Last(message => message.Role == ChatRole.User);
+        Assert.Contains(user.Contents.OfType<TextContent>(), content => content.Text.Contains("What is this?", StringComparison.Ordinal));
+        Assert.Contains(user.Contents.OfType<UriContent>(), content =>
+            content.Uri.ToString() == "data:image/png;base64,AAAA" &&
+            content.MediaType.StartsWith("image/", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task RunAsync_TrimsHistory()
     {
         var session = new Session { Id = "sess1", SenderId = "user1", ChannelId = "test-channel" };

--- a/src/OpenClaw.Tests/CliProgramTests.cs
+++ b/src/OpenClaw.Tests/CliProgramTests.cs
@@ -99,4 +99,18 @@ public sealed class CliProgramTests
         Assert.Contains("Describe this image.", content, StringComparison.Ordinal);
         Assert.Contains("[IMAGE_URL:https://example.test/cat.png]", content, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void BuildUserContent_TreatsFileUriImagesAsImagePaths()
+    {
+        var tempImage = Path.Combine(Path.GetTempPath(), $"openclaw-{Guid.NewGuid():N}.png");
+        var fileUri = new Uri(tempImage).AbsoluteUri;
+
+        var content = OpenClaw.Cli.Program.BuildUserContent(
+            "Describe it.",
+            files: [],
+            images: [fileUri]);
+
+        Assert.Contains($"[IMAGE_PATH:{tempImage}]", content, StringComparison.Ordinal);
+    }
 }

--- a/src/OpenClaw.Tests/CliProgramTests.cs
+++ b/src/OpenClaw.Tests/CliProgramTests.cs
@@ -69,4 +69,34 @@ public sealed class CliProgramTests
         Assert.Equal("./repo", parsed.GetOption("--workspace"));
         Assert.True(parsed.HasFlag("--no-stream"));
     }
+
+    [Fact]
+    public void CliArgs_Parse_RepeatedImageOptions()
+    {
+        var parsed = CliArgs.Parse(["describe", "--image", "one.png", "--image", "https://example.test/two.png"]);
+
+        Assert.Equal(["one.png", "https://example.test/two.png"], parsed.Images);
+    }
+
+    [Fact]
+    public void BuildUserContent_AddsImageMarkersForImageOptions()
+    {
+        var content = OpenClaw.Cli.Program.BuildUserContent(
+            "Describe these.",
+            files: [],
+            images: ["https://example.test/cat.png"]);
+
+        Assert.Contains("Describe these.", content, StringComparison.Ordinal);
+        Assert.Contains("[IMAGE_URL:https://example.test/cat.png]", content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildImageCommandContent_AddsImageMarkerAndDefaultPrompt()
+    {
+        var content = OpenClaw.Cli.Program.BuildImageCommandContent("/image https://example.test/cat.png");
+
+        Assert.NotNull(content);
+        Assert.Contains("Describe this image.", content, StringComparison.Ordinal);
+        Assert.Contains("[IMAGE_URL:https://example.test/cat.png]", content, StringComparison.Ordinal);
+    }
 }

--- a/src/OpenClaw.Tests/DoctorCheckTests.cs
+++ b/src/OpenClaw.Tests/DoctorCheckTests.cs
@@ -40,4 +40,62 @@ public sealed class DoctorCheckTests
             Directory.Delete(storagePath, recursive: true);
         }
     }
+
+    [Fact]
+    public async Task BuildDoctorReport_IncludesConfigSourceDiagnosticsWithoutSecrets()
+    {
+        var storagePath = Path.Combine(Path.GetTempPath(), "openclaw-doctor-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(storagePath);
+
+        try
+        {
+            var config = new GatewayConfig
+            {
+                Memory = new MemoryConfig
+                {
+                    StoragePath = storagePath
+                },
+                Llm = new LlmProviderConfig
+                {
+                    Provider = "openai",
+                    Model = "gpt-4o",
+                    ApiKey = "sk-test-secret"
+                }
+            };
+
+            var report = await SetupVerificationService.BuildDoctorReportAsync(new DoctorReportRequest
+            {
+                Config = config,
+                RuntimeState = RuntimeModeResolver.Resolve(config.Runtime),
+                Offline = true,
+                RequireProvider = false,
+                CheckPortAvailability = false,
+                ConfigSources = new ConfigSourceDiagnostics
+                {
+                    Items =
+                    [
+                        new ConfigSourceDiagnosticItem
+                        {
+                            Label = "API key",
+                            Key = "OpenClaw:Llm:ApiKey",
+                            EffectiveValue = "configured (redacted)",
+                            Source = "environment variable MODEL_PROVIDER_KEY",
+                            Redacted = true
+                        }
+                    ]
+                }
+            }, CancellationToken.None);
+
+            var text = SetupVerificationService.RenderDoctorText(report);
+
+            Assert.Contains("config/config_sources", text, StringComparison.Ordinal);
+            Assert.Contains("API key: configured (redacted)", text, StringComparison.Ordinal);
+            Assert.Contains("MODEL_PROVIDER_KEY", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("sk-test-secret", text, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(storagePath, recursive: true);
+        }
+    }
 }

--- a/src/OpenClaw.Tests/DoctorCheckTests.cs
+++ b/src/OpenClaw.Tests/DoctorCheckTests.cs
@@ -78,7 +78,7 @@ public sealed class DoctorCheckTests
                         {
                             Label = "API key",
                             Key = "OpenClaw:Llm:ApiKey",
-                            EffectiveValue = "configured (redacted)",
+                            EffectiveValue = "sk-test-secret",
                             Source = "environment variable MODEL_PROVIDER_KEY",
                             Redacted = true
                         }

--- a/src/OpenClaw.Tests/OpenAiEndpointTests.cs
+++ b/src/OpenClaw.Tests/OpenAiEndpointTests.cs
@@ -89,6 +89,17 @@ public class OpenAiEndpointTests
         Assert.Contains("[IMAGE_URL:data:image/png;base64,AAAA]", content, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ChatCompletionRequest_Deserializes_NullContentAsEmptyPromptText()
+    {
+        const string json = """{"messages":[{"role":"assistant","content":null}]}""";
+
+        var req = JsonSerializer.Deserialize(json, CoreJsonContext.Default.OpenAiChatCompletionRequest);
+
+        Assert.NotNull(req);
+        Assert.Equal(string.Empty, req.Messages[0].Content.ToPromptText());
+    }
+
     // ── Response Serialization ──────────────────────────────────────────
 
     [Fact]

--- a/src/OpenClaw.Tests/OpenAiEndpointTests.cs
+++ b/src/OpenClaw.Tests/OpenAiEndpointTests.cs
@@ -64,6 +64,31 @@ public class OpenAiEndpointTests
         Assert.False(req.Stream);
     }
 
+    [Fact]
+    public void ChatCompletionRequest_Deserializes_MultimodalContentPartsAsPromptMarkers()
+    {
+        const string json = """
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            { "type": "text", "text": "What is in this image?" },
+                            { "type": "image_url", "image_url": { "url": "data:image/png;base64,AAAA" } }
+                        ]
+                    }
+                ]
+            }
+            """;
+
+        var req = JsonSerializer.Deserialize(json, CoreJsonContext.Default.OpenAiChatCompletionRequest);
+
+        Assert.NotNull(req);
+        var content = req.Messages[0].Content.ToPromptText();
+        Assert.Contains("What is in this image?", content, StringComparison.Ordinal);
+        Assert.Contains("[IMAGE_URL:data:image/png;base64,AAAA]", content, StringComparison.Ordinal);
+    }
+
     // ── Response Serialization ──────────────────────────────────────────
 
     [Fact]

--- a/src/OpenClaw.Tests/OpenClawToolExecutorTests.cs
+++ b/src/OpenClaw.Tests/OpenClawToolExecutorTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using OpenClaw.Agent;
 using OpenClaw.Core.Abstractions;
@@ -170,10 +171,15 @@ public sealed class OpenClawToolExecutorTests
         Assert.Equal(0, tool.LocalExecutionCount);
     }
 
-    [Fact]
-    public async Task ExecuteAsync_SandboxRequireWithProviderNone_FailsClosed()
+    [Theory]
+    [InlineData("websocket", "Provide a summary of AI news")]
+    [InlineData("cli", "Summarize this local repository")]
+    public async Task ExecuteAsync_SandboxRequireWithProviderNone_RunsLocallyAndLogsResolution(
+        string channelId,
+        string prompt)
     {
         var tool = new SandboxCapableEchoTool(ToolSandboxMode.Require, "local-result");
+        var logger = new ListLogger();
         var executor = CreateExecutor(
             [tool],
             toolSandbox: null,
@@ -191,20 +197,28 @@ public sealed class OpenClawToolExecutorTests
                         }
                     }
                 }
-            });
+            },
+            logger);
 
         var result = await executor.ExecuteAsync(
             "sandbox_echo",
             """{"value":"hi"}""",
             callId: null,
-            CreateSession(),
+            CreateSession(channelId, prompt),
             CreateTurnContext(),
             isStreaming: false,
             approvalCallback: null,
             CancellationToken.None);
 
-        Assert.Contains("requires sandboxing", result.ResultText, StringComparison.OrdinalIgnoreCase);
-        Assert.Equal(0, tool.LocalExecutionCount);
+        Assert.Equal("local-result", result.ResultText);
+        Assert.Equal(1, tool.LocalExecutionCount);
+        Assert.Contains(
+            logger.Messages,
+            message => message.Contains("Sandbox mode resolved for tool sandbox_echo", StringComparison.Ordinal) &&
+                       message.Contains("provider=None", StringComparison.OrdinalIgnoreCase) &&
+                       message.Contains("configured=Require", StringComparison.Ordinal) &&
+                       message.Contains("effective=None", StringComparison.Ordinal) &&
+                       message.Contains("global sandbox off switch", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -292,7 +306,8 @@ public sealed class OpenClawToolExecutorTests
     private static OpenClawToolExecutor CreateExecutor(
         IReadOnlyList<ITool> tools,
         IToolSandbox? toolSandbox = null,
-        GatewayConfig? config = null)
+        GatewayConfig? config = null,
+        ILogger? logger = null)
         => new(
             tools,
             toolTimeoutSeconds: 5,
@@ -300,16 +315,19 @@ public sealed class OpenClawToolExecutorTests
             approvalRequiredTools: [],
             hooks: [],
             metrics: new RuntimeMetrics(),
-            logger: NullLogger.Instance,
+            logger: logger ?? NullLogger.Instance,
             config: config,
             toolSandbox: toolSandbox);
 
-    private static Session CreateSession()
+    private static Session CreateSession(string channelId = "websocket", string? prompt = null)
         => new()
         {
             Id = "sess1",
-            ChannelId = "websocket",
-            SenderId = "user1"
+            ChannelId = channelId,
+            SenderId = "user1",
+            History = string.IsNullOrWhiteSpace(prompt)
+                ? []
+                : [new ChatTurn { Role = "user", Content = prompt }]
         };
 
     private static TurnContext CreateTurnContext()
@@ -374,5 +392,22 @@ public sealed class OpenClawToolExecutorTests
 
         public ValueTask<string> ExecuteAsync(string argumentsJson, CancellationToken ct)
             => throw new InvalidOperationException(message);
+    }
+
+    private sealed class ListLogger : ILogger
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Messages.Add(formatter(state, exception));
     }
 }

--- a/src/OpenClaw.Tests/StartupConsoleCoordinatorTests.cs
+++ b/src/OpenClaw.Tests/StartupConsoleCoordinatorTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using OpenClaw.Core.Models;
 using OpenClaw.Gateway.Bootstrap;
 using Xunit;
 
@@ -25,7 +26,7 @@ public sealed class StartupConsoleCoordinatorTests
             Endpoint: null);
 
         using var output = new StringWriter();
-        coordinator.WriteConfigurationSummary(configuration, "Production", session, output);
+        coordinator.WriteConfigurationSummary(configuration, new GatewayConfig(), "Production", session, output);
 
         var text = output.ToString();
         Assert.Contains("Startup environment: Production", text, StringComparison.Ordinal);
@@ -33,5 +34,40 @@ public sealed class StartupConsoleCoordinatorTests
         Assert.Contains("- appsettings.Production.json", text, StringComparison.Ordinal);
         Assert.Contains("- custom/openclaw.settings.json", text, StringComparison.Ordinal);
         Assert.Contains("- Session-only overrides: active (quickstart)", text, StringComparison.Ordinal);
+        Assert.Contains("Effective configuration winners:", text, StringComparison.Ordinal);
+        Assert.Contains("- Bind address:", text, StringComparison.Ordinal);
+        Assert.Contains("- API key: not configured", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConfigurationSourceDiagnostics_RedactsApiKeyAndReportsCompatibilityOverride()
+    {
+        var previousKey = Environment.GetEnvironmentVariable("MODEL_PROVIDER_KEY");
+        try
+        {
+            Environment.SetEnvironmentVariable("MODEL_PROVIDER_KEY", "sk-test-secret");
+
+            var configuration = new ConfigurationManager();
+            configuration.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["OpenClaw:BindAddress"] = "0.0.0.0",
+                ["OpenClaw:Llm:Provider"] = "openai",
+                ["OpenClaw:Llm:Model"] = "gpt-4o"
+            });
+
+            var config = GatewayBootstrapExtensions.LoadGatewayConfig(configuration);
+            var diagnostics = ConfigurationSourceDiagnosticsBuilder.Build(configuration, config);
+            var text = ConfigurationSourceDiagnosticsBuilder.Render(diagnostics);
+
+            Assert.Contains("Bind address: 0.0.0.0", text, StringComparison.Ordinal);
+            Assert.Contains("Provider: openai", text, StringComparison.Ordinal);
+            Assert.Contains("API key: configured (redacted)", text, StringComparison.Ordinal);
+            Assert.Contains("MODEL_PROVIDER_KEY", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("sk-test-secret", text, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MODEL_PROVIDER_KEY", previousKey);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- fixes sandbox mode selection so `Sandbox.Provider=None` is the global off switch and logs the effective sandbox decision
- fixes chat image prompts by accepting OpenAI-style multimodal content and normalizing image inputs through the existing media marker path
- adds startup and doctor diagnostics that show effective config source winners for bind, storage, provider, model, endpoint, and API key source without secret values

## Root Cause

- sandbox routing allowed per-tool `Require` to override the documented provider-level `None` opt-out
- OpenAI-compatible chat request models only accepted string content, so image content parts broke before the runtime could convert them to `UriContent`
- startup failures did not show which configuration provider or compatibility override supplied the effective local settings

## Validation

- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj`
