### PR TITLE
[codex] Implement Canvas A2UI visual workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The full documentation map lives at **[docs/README.md](docs/README.md)**. Starti
 | [docs/QUICKSTART.md](docs/QUICKSTART.md) | Shortest supported path to a running local instance |
 | [docs/USER_GUIDE.md](docs/USER_GUIDE.md) | Providers, tools, skills, memory, channels, and day-to-day operation |
 | [docs/TOOLS_GUIDE.md](docs/TOOLS_GUIDE.md) | Native tool catalog and configuration |
+| [docs/CANVAS_A2UI.md](docs/CANVAS_A2UI.md) | Supported Canvas and A2UI visual workspace behavior |
 | [docs/MODEL_PROFILES.md](docs/MODEL_PROFILES.md) | Provider-agnostic named model profiles (including Gemma) |
 | [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md) | Supported upstream skill, plugin, and channel surface |
 | [SECURITY.md](SECURITY.md) | Hardening guidance for public deployments |

--- a/docs/CANVAS_A2UI.md
+++ b/docs/CANVAS_A2UI.md
@@ -1,0 +1,148 @@
+# Canvas and A2UI
+
+Canvas and A2UI are supported as a first-party, session-scoped visual workspace for websocket clients. The v1 implementation focuses on local Canvas content and A2UI v0.8 JSONL rendering. It is not a replacement for the browser tool and does not support arbitrary remote webpage navigation or remote-page script execution.
+
+## What Ships
+
+- Gateway Canvas configuration under `OpenClaw:Canvas`.
+- Typed websocket envelopes for Canvas commands, A2UI pushes, results, and user events.
+- Native agent tools: `canvas_present`, `canvas_hide`, `canvas_navigate`, `canvas_snapshot`, `a2ui_push`, `a2ui_reset`, and `a2ui_eval`.
+- A broker that forwards commands only to the current websocket session, tracks request acknowledgements/results, records runtime events, and times out stalled commands.
+- Webchat Canvas host with a side panel, A2UI renderer, sandboxed local HTML iframe, eval support for local A2UI state, and lightweight snapshots.
+- Companion Canvas tab with native Avalonia A2UI rendering and event/snapshot feedback.
+
+## Capability Scope
+
+Supported:
+
+- A2UI v0.8 JSONL frames.
+- Components: `text`, `markdown`, `card`, `button`, `input`, `select`, `checklist`, `table`, `image`, `progress`, and simple `chart`.
+- Present/hide/reset/push/snapshot command flow.
+- Local HTML navigation by passing `html` to `canvas_navigate` in webchat.
+- `about:blank` navigation.
+- A2UI events returned to the same conversation as structured session turns.
+- Lightweight JSON snapshots containing rendered tree state, component values, diagnostics, and local HTML text when available.
+
+Unsupported:
+
+- `http:` and `https:` Canvas navigation.
+- Script execution against remote webpages.
+- A2UI v0.9 `createSurface`.
+- Cross-session Canvas sharing.
+- Native local HTML/WebView rendering in Companion. Companion returns an explicit unsupported diagnostic for local HTML navigation and A2UI eval.
+
+## Configuration
+
+Canvas settings live under `OpenClaw:Canvas`:
+
+| Setting | Default | Notes |
+| --- | --- | --- |
+| `Enabled` | `true` | Enabled for loopback/local use. |
+| `AllowOnPublicBind` | `false` | Required to keep Canvas enabled on non-loopback binds. |
+| `MaxCommandBytes` | `262144` | Maximum serialized command size. |
+| `MaxSnapshotBytes` | `262144` | Maximum returned snapshot size. |
+| `CommandTimeoutSeconds` | `10` | Pending command timeout. |
+| `MaxFramesPerPush` | `100` | Maximum A2UI frames in one push. |
+| `EnableLocalHtml` | `true` | Allows `canvas_navigate` with inline `html`. |
+| `EnableRemoteNavigation` | `false` | Remote webpage Canvas navigation remains unsupported. |
+| `EnableEval` | `true` | Allows `a2ui_eval` against the local A2UI/webchat sandbox. |
+
+When strict public-bind hardening is applied and `AllowOnPublicBind=false`, Canvas is disabled. Without strict mode, public-bind startup refuses unsafe Canvas forwarding unless you explicitly opt in.
+
+## Protocol
+
+Server-to-client websocket envelope types:
+
+- `canvas_present`
+- `canvas_hide`
+- `canvas_navigate`
+- `canvas_snapshot`
+- `a2ui_push`
+- `a2ui_reset`
+- `a2ui_eval`
+
+Client-to-server websocket envelope types:
+
+- `canvas_ready`
+- `canvas_ack`
+- `canvas_snapshot_result`
+- `canvas_eval_result`
+- `a2ui_event`
+
+Common Canvas fields include `requestId`, `sessionId`, `surfaceId`, `contentType`, `frames`, `html`, `url`, `script`, `snapshotMode`, `snapshotJson`, `componentId`, `event`, `valueJson`, `sequence`, `capabilities`, `success`, and `error`.
+
+Example A2UI push:
+
+```json
+{
+  "type": "a2ui_push",
+  "sessionId": "session_123",
+  "surfaceId": "main",
+  "contentType": "application/x-a2ui+jsonl;version=0.8",
+  "frames": "{\"type\":\"text\",\"id\":\"summary\",\"text\":\"Ready\"}\n{\"type\":\"button\",\"id\":\"approve\",\"label\":\"Approve\"}"
+}
+```
+
+Example event feedback:
+
+```json
+{
+  "type": "a2ui_event",
+  "sessionId": "session_123",
+  "surfaceId": "main",
+  "componentId": "approve",
+  "event": "click",
+  "valueJson": "true",
+  "sequence": 7
+}
+```
+
+## A2UI Validation
+
+`a2ui_push` accepts JSONL only: one JSON object per line. The gateway validates payload size, frame count, required `type` and `id` fields, component-specific required fields, and supported component types before forwarding.
+
+Examples:
+
+```jsonl
+{"type":"markdown","id":"summary","text":"## Run ready\nReview the table before approving."}
+{"type":"table","id":"checks","columns":["Check","Status"],"rows":[["Tests","Passed"],["Policy","Pending"]]}
+{"type":"input","id":"note","label":"Operator note","value":""}
+{"type":"button","id":"approve","label":"Approve"}
+{"type":"progress","id":"deploy","value":0.45}
+```
+
+The validator rejects v0.9 `createSurface` frames with an explicit diagnostic.
+
+## Client Behavior
+
+Webchat advertises:
+
+- `a2ui.v0_8`
+- `canvas.present`
+- `canvas.hide`
+- `canvas.local_html`
+- `a2ui.eval`
+- `snapshot.state`
+
+Companion advertises:
+
+- `a2ui.v0_8`
+- `canvas.present`
+- `canvas.hide`
+- `snapshot.state`
+
+The gateway uses advertised capabilities before forwarding commands. If a session is not websocket-backed, if the client is disconnected, or if the client lacks a required capability, Canvas tools fail with a normal tool error instead of attempting a best-effort send.
+
+## Security Model
+
+Canvas inherits the gateway’s local-first posture:
+
+- Commands are scoped to the current websocket session sender.
+- Non-websocket sessions cannot receive Canvas commands.
+- Public-bind deployments must explicitly opt into Canvas forwarding.
+- Remote webpage Canvas navigation is rejected.
+- A2UI eval is local-sandbox only and never targets third-party pages.
+- Command and result sizes are bounded.
+- Canvas command lifecycle events are written to the runtime event log.
+
+Use the existing browser tool for webpage automation, DOM inspection, and remote navigation.

--- a/docs/CANVAS_A2UI.md
+++ b/docs/CANVAS_A2UI.md
@@ -8,7 +8,7 @@ Canvas and A2UI are supported as a first-party, session-scoped visual workspace 
 - Typed websocket envelopes for Canvas commands, A2UI pushes, results, and user events.
 - Native agent tools: `canvas_present`, `canvas_hide`, `canvas_navigate`, `canvas_snapshot`, `a2ui_push`, `a2ui_reset`, and `a2ui_eval`.
 - A broker that forwards commands only to the current websocket session, tracks request acknowledgements/results, records runtime events, and times out stalled commands.
-- Webchat Canvas host with a side panel, A2UI renderer, sandboxed local HTML iframe, eval support for local A2UI state, and lightweight snapshots.
+- Webchat Canvas host with a side panel, A2UI renderer, sandboxed local HTML iframe, and lightweight snapshots.
 - Companion Canvas tab with native Avalonia A2UI rendering and event/snapshot feedback.
 
 ## Capability Scope
@@ -45,7 +45,7 @@ Canvas settings live under `OpenClaw:Canvas`:
 | `MaxFramesPerPush` | `100` | Maximum A2UI frames in one push. |
 | `EnableLocalHtml` | `true` | Allows `canvas_navigate` with inline `html`. |
 | `EnableRemoteNavigation` | `false` | Remote webpage Canvas navigation remains unsupported. |
-| `EnableEval` | `true` | Allows `a2ui_eval` against the local A2UI/webchat sandbox. |
+| `EnableEval` | `true` | Allows capability-gated `a2ui_eval` commands when a client advertises `a2ui.eval`. First-party v1 clients do not advertise it. |
 
 When strict public-bind hardening is applied and `AllowOnPublicBind=false`, Canvas is disabled. Without strict mode, public-bind startup refuses unsafe Canvas forwarding unless you explicitly opt in.
 
@@ -121,7 +121,6 @@ Webchat advertises:
 - `canvas.present`
 - `canvas.hide`
 - `canvas.local_html`
-- `a2ui.eval`
 - `snapshot.state`
 
 Companion advertises:
@@ -131,7 +130,7 @@ Companion advertises:
 - `canvas.hide`
 - `snapshot.state`
 
-The gateway uses advertised capabilities before forwarding commands. If a session is not websocket-backed, if the client is disconnected, or if the client lacks a required capability, Canvas tools fail with a normal tool error instead of attempting a best-effort send.
+The gateway uses advertised capabilities before forwarding commands. If a session is not websocket-backed, if the client is disconnected, or if the client lacks a required capability, Canvas tools fail with a normal tool error instead of attempting a best-effort send. No first-party v1 client advertises `a2ui.eval`; the tool remains capability-gated for future local sandboxes.
 
 ## Security Model
 
@@ -141,7 +140,7 @@ Canvas inherits the gateway’s local-first posture:
 - Non-websocket sessions cannot receive Canvas commands.
 - Public-bind deployments must explicitly opt into Canvas forwarding.
 - Remote webpage Canvas navigation is rejected.
-- A2UI eval is local-sandbox only and never targets third-party pages.
+- A2UI eval is capability-gated and never targets third-party pages.
 - Command and result sizes are bounded.
 - Canvas command lifecycle events are written to the runtime event log.
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -67,7 +67,7 @@ OpenClaw.NET ships a v1 Canvas/A2UI workspace for websocket clients. The support
 | Remote webpage Canvas navigation/eval | Not supported | `http:` and `https:` URLs are rejected; use the browser tool for remote pages. |
 | A2UI v0.8 JSONL rendering | Supported | Webchat and Companion render text, markdown, card, button, input, select, checklist, table, image, progress, and simple chart frames. |
 | A2UI interaction event feedback | Supported | Client events return as structured `a2ui_event` session turns. |
-| A2UI eval | Supported with caveats | Webchat supports local A2UI sandbox eval; Companion returns an unsupported diagnostic. |
+| A2UI eval | Supported with caveats | The gateway tool is capability-gated, but no first-party v1 client advertises `a2ui.eval`; webchat and Companion return unsupported diagnostics. |
 | A2UI v0.9 `createSurface` | Not supported | Validation rejects it with an explicit diagnostic. |
 
 ## Channel Compatibility

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -56,6 +56,20 @@ These APIs are not bridged. If a plugin uses them, initialization fails fast wit
 | `api.registerGatewayMethod()` | Not supported | `unsupported_gateway_method` |
 | `api.registerCli()` | Not supported | `unsupported_cli_registration` |
 
+## Canvas and A2UI Compatibility
+
+OpenClaw.NET ships a v1 Canvas/A2UI workspace for websocket clients. The supported target is local Canvas content plus A2UI v0.8 JSONL; remote webpage Canvas control and A2UI v0.9 surfaces remain intentionally unsupported. See [CANVAS_A2UI.md](CANVAS_A2UI.md).
+
+| Surface | Status | Notes |
+| --- | --- | --- |
+| Canvas present/hide/snapshot commands | Supported | Typed websocket envelopes routed through the session-scoped broker. |
+| Local Canvas navigation | Supported with caveats | `about:blank` is supported. Inline local HTML is supported in webchat via sandboxed `srcdoc`; Companion reports an unsupported diagnostic without a native WebView. |
+| Remote webpage Canvas navigation/eval | Not supported | `http:` and `https:` URLs are rejected; use the browser tool for remote pages. |
+| A2UI v0.8 JSONL rendering | Supported | Webchat and Companion render text, markdown, card, button, input, select, checklist, table, image, progress, and simple chart frames. |
+| A2UI interaction event feedback | Supported | Client events return as structured `a2ui_event` session turns. |
+| A2UI eval | Supported with caveats | Webchat supports local A2UI sandbox eval; Companion returns an unsupported diagnostic. |
+| A2UI v0.9 `createSurface` | Not supported | Validation rejects it with an explicit diagnostic. |
+
 ## Channel Compatibility
 
 The messaging channels below now share the same operator model for DM policy, recent senders, diagnostics, and dynamic allowlist administration.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Use this page as the map. If you are unsure where to go next, the groups below a
 | [USER_GUIDE.md](USER_GUIDE.md) | Providers, tools, skills, channels, and the day-to-day operator surface. |
 | [TOOLS_GUIDE.md](TOOLS_GUIDE.md) | Native tool catalog, behavior, and configuration. |
 | [SESSIONS.md](SESSIONS.md) | Session lifecycle, the `SessionManager`, and the `sessions_spawn` / `sessions_yield` / `sessions` tools. |
+| [CANVAS_A2UI.md](CANVAS_A2UI.md) | Supported Canvas and A2UI behavior for agent-rendered visual workspaces. |
 | [MODEL_PROFILES.md](MODEL_PROFILES.md) | Provider-agnostic named model profiles, including Gemma-family setups. |
 | [PROMPT_CACHING.md](PROMPT_CACHING.md) | Provider-aware prompt caching hints, dialects, diagnostics. |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,6 +18,7 @@
 - Optional estimated token admission control.
 - Startup/runtime composition split into explicit service, channel, plugin, and runtime assembly stages.
 - Optional native Notion scratchpad integration with scoped read/write tools (`notion`, `notion_write`), allowlists, and write approvals by default.
+- Canvas and A2UI v1 visual workspace with session-scoped websocket command broker, webchat Canvas host, Companion native Canvas tab, A2UI v0.8 JSONL renderer, event feedback, snapshots, and public-bind hardening.
 
 ## Runtime and Platform Expansion
 

--- a/docs/TOOLS_GUIDE.md
+++ b/docs/TOOLS_GUIDE.md
@@ -80,6 +80,15 @@ Admin/ops tool to list active sessions, inspect recent history, or send a cross-
 ### 7. Delegate Agent Tool (`delegate_agent`)
 Spawns a “sub-agent” for multi-agent delegation (only present when `OpenClaw:Delegation:Enabled=true`).
 
+### 7b. Canvas and A2UI Tools (`canvas_present`, `canvas_hide`, `canvas_navigate`, `canvas_snapshot`, `a2ui_push`, `a2ui_reset`, `a2ui_eval`)
+Control the current websocket session's Canvas visual workspace.
+- **Config**: `OpenClaw:Canvas:*`
+- **Scope**: websocket sessions only; commands are routed to the active client sender for the current session.
+- **A2UI**: `a2ui_push` accepts A2UI v0.8 JSONL frames for text, markdown, card, button, input, select, checklist, table, image, progress, and simple chart components.
+- **Navigation**: `canvas_navigate` supports inline local HTML and `about:blank`; remote `http:` / `https:` Canvas navigation is rejected. Use the `browser` tool for remote webpages.
+- **Snapshots**: `canvas_snapshot` returns lightweight JSON state, not a remote browser screenshot.
+- **Safety**: non-loopback deployments must explicitly opt in with `OpenClaw:Canvas:AllowOnPublicBind=true`.
+
 ---
 
 ## 🔌 Native Plugin Tools

--- a/docs/TOOLS_GUIDE.md
+++ b/docs/TOOLS_GUIDE.md
@@ -86,6 +86,7 @@ Control the current websocket session's Canvas visual workspace.
 - **Scope**: websocket sessions only; commands are routed to the active client sender for the current session.
 - **A2UI**: `a2ui_push` accepts A2UI v0.8 JSONL frames for text, markdown, card, button, input, select, checklist, table, image, progress, and simple chart components.
 - **Navigation**: `canvas_navigate` supports inline local HTML and `about:blank`; remote `http:` / `https:` Canvas navigation is rejected. Use the `browser` tool for remote webpages.
+- **Eval**: `a2ui_eval` is capability-gated. First-party v1 clients do not advertise `a2ui.eval`, so browser-side script execution remains disabled by default.
 - **Snapshots**: `canvas_snapshot` returns lightweight JSON state, not a remote browser screenshot.
 - **Safety**: non-loopback deployments must explicitly opt in with `OpenClaw:Canvas:AllowOnPublicBind=true`.
 

--- a/src/OpenClaw.Channels/WebSocketChannel.cs
+++ b/src/OpenClaw.Channels/WebSocketChannel.cs
@@ -69,6 +69,7 @@ public sealed class WebSocketChannel : IChannelAdapter
     public string ChannelId => "websocket";
 
     public event Func<InboundMessage, CancellationToken, ValueTask>? OnMessageReceived;
+    public event Func<string, WsClientEnvelope, CancellationToken, ValueTask>? OnCanvasClientEnvelopeReceived;
 
     public Task StartAsync(CancellationToken ct) => Task.CompletedTask; // Kestrel manages the listener
 
@@ -110,6 +111,13 @@ public sealed class WebSocketChannel : IChannelAdapter
                     break;
                 }
 
+                if (parsed.CanvasEnvelope is not null)
+                {
+                    await HandleCanvasClientEnvelopeAsync(clientId, parsed.CanvasEnvelope, ct);
+                    if (!string.Equals(parsed.CanvasEnvelope.Type, "a2ui_event", StringComparison.Ordinal))
+                        continue;
+                }
+
                 var msg = new InboundMessage
                 {
                     ChannelId = ChannelId,
@@ -119,6 +127,12 @@ public sealed class WebSocketChannel : IChannelAdapter
                     Text = parsed.Text ?? "",
                     MessageId = parsed.MessageId,
                     ReplyToMessageId = parsed.ReplyToMessageId,
+                    RequestId = parsed.CanvasEnvelope?.RequestId,
+                    SurfaceId = parsed.CanvasEnvelope?.SurfaceId,
+                    ComponentId = parsed.CanvasEnvelope?.ComponentId,
+                    Event = parsed.CanvasEnvelope?.Event,
+                    ValueJson = parsed.CanvasEnvelope?.ValueJson,
+                    Sequence = parsed.CanvasEnvelope?.Sequence,
                     ApprovalId = parsed.ApprovalId,
                     Approved = parsed.Approved,
                     RequestCancellation = ct
@@ -220,6 +234,9 @@ public sealed class WebSocketChannel : IChannelAdapter
     /// </summary>
     public bool IsClientUsingEnvelopes(string clientId) =>
         _connections.TryGetValue(clientId, out var state) && state.UseJsonEnvelope;
+
+    public bool IsClientConnected(string clientId) =>
+        _connections.TryGetValue(clientId, out var state) && state.Socket.State == WebSocketState.Open;
 
     /// <summary>
     /// Sends a streaming event to a connected client. Only works for envelope-mode clients.
@@ -498,7 +515,8 @@ public sealed class WebSocketChannel : IChannelAdapter
         string? MessageId,
         string? ReplyToMessageId,
         string? ApprovalId,
-        bool? Approved);
+        bool? Approved,
+        WsClientEnvelope? CanvasEnvelope = null);
 
     private static ParsedWsInbound TryParseClientEnvelope(string payload)
     {
@@ -510,7 +528,7 @@ public sealed class WebSocketChannel : IChannelAdapter
             i++;
 
         if (i >= span.Length || span[i] != '{')
-            return new ParsedWsInbound(false, null, payload, null, null, null, null, null);
+            return new ParsedWsInbound(false, null, payload, null, null, null, null, null, null);
 
         try
         {
@@ -531,14 +549,72 @@ public sealed class WebSocketChannel : IChannelAdapter
             {
                 return new ParsedWsInbound(true, env.Type, "", env.SessionId, env.MessageId, env.ReplyToMessageId, env.ApprovalId, env.Approved);
             }
+
+            if (env is not null && IsCanvasClientEnvelope(env.Type))
+            {
+                var text = string.Equals(env.Type, "a2ui_event", StringComparison.Ordinal)
+                    ? BuildA2UiEventText(env)
+                    : "";
+                return new ParsedWsInbound(
+                    true,
+                    env.Type,
+                    text,
+                    env.SessionId,
+                    env.MessageId ?? env.RequestId,
+                    env.ReplyToMessageId,
+                    null,
+                    null,
+                    env);
+            }
         }
         catch
         {
             // fall through to raw
         }
 
-        return new ParsedWsInbound(false, null, payload, null, null, null, null, null);
+        return new ParsedWsInbound(false, null, payload, null, null, null, null, null, null);
     }
+
+    private async ValueTask HandleCanvasClientEnvelopeAsync(string clientId, WsClientEnvelope envelope, CancellationToken ct)
+    {
+        if (OnCanvasClientEnvelopeReceived is not null)
+            await OnCanvasClientEnvelopeReceived(clientId, envelope, ct);
+    }
+
+    private static bool IsCanvasClientEnvelope(string? type)
+        => type is "canvas_ready" or "canvas_ack" or "canvas_snapshot_result" or "canvas_eval_result" or "a2ui_event";
+
+    private static string BuildA2UiEventText(WsClientEnvelope env)
+    {
+        var value = NormalizeJsonValue(env.ValueJson);
+        return "{\n" +
+               "  \"type\": \"a2ui_event\",\n" +
+               $"  \"surfaceId\": {JsonStringLiteral(env.SurfaceId ?? "main")},\n" +
+               $"  \"componentId\": {JsonStringLiteral(env.ComponentId ?? "")},\n" +
+               $"  \"event\": {JsonStringLiteral(env.Event ?? "")},\n" +
+               $"  \"value\": {value},\n" +
+               $"  \"sequence\": {(env.Sequence ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)}\n" +
+               "}";
+    }
+
+    private static string NormalizeJsonValue(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return "null";
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.GetRawText();
+        }
+        catch (JsonException)
+        {
+            return JsonStringLiteral(json);
+        }
+    }
+
+    private static string JsonStringLiteral(string value)
+        => $"\"{JsonEncodedText.Encode(value)}\"";
 
     private static ValueTask CloseIfOpenAsync(WebSocket ws, WebSocketCloseStatus status, string description, CancellationToken ct)
     {

--- a/src/OpenClaw.Client/OpenClawWebSocketClient.cs
+++ b/src/OpenClaw.Client/OpenClawWebSocketClient.cs
@@ -117,8 +117,7 @@ public sealed class OpenClawWebSocketClient : IAsyncDisposable
     }
 
     public async Task SendUserMessageAsync(string text, string? messageId, string? replyToMessageId, CancellationToken ct)
-    {
-        var payload = JsonSerializer.Serialize(
+        => await SendEnvelopeAsync(
             new WsClientEnvelope
             {
                 Type = "user_message",
@@ -126,7 +125,11 @@ public sealed class OpenClawWebSocketClient : IAsyncDisposable
                 MessageId = messageId,
                 ReplyToMessageId = replyToMessageId
             },
-            CoreJsonContext.Default.WsClientEnvelope);
+            ct);
+
+    public async Task SendEnvelopeAsync(WsClientEnvelope envelope, CancellationToken ct)
+    {
+        var payload = JsonSerializer.Serialize(envelope, CoreJsonContext.Default.WsClientEnvelope);
 
         var bytes = Encoding.UTF8.GetBytes(payload);
         if (bytes.Length > _maxMessageBytes)

--- a/src/OpenClaw.Companion/Services/GatewayWebSocketClient.cs
+++ b/src/OpenClaw.Companion/Services/GatewayWebSocketClient.cs
@@ -1,3 +1,5 @@
+using System.Net.WebSockets;
+
 namespace OpenClaw.Companion.Services;
 
 public sealed class GatewayWebSocketClient : IAsyncDisposable
@@ -8,6 +10,7 @@ public sealed class GatewayWebSocketClient : IAsyncDisposable
     {
         _inner = new OpenClaw.Client.OpenClawWebSocketClient(maxMessageBytes);
         _inner.OnTextMessage += text => OnTextMessage?.Invoke(text);
+        _inner.OnEnvelopeReceived += envelope => OnEnvelopeReceived?.Invoke(envelope);
         _inner.OnError += error => OnError?.Invoke(error);
     }
 
@@ -15,6 +18,7 @@ public sealed class GatewayWebSocketClient : IAsyncDisposable
         => _inner.IsConnected;
 
     public event Action<string>? OnTextMessage;
+    public event Action<OpenClaw.Core.Models.WsServerEnvelope>? OnEnvelopeReceived;
     public event Action<string>? OnError;
 
     public async Task ConnectAsync(Uri wsUri, string? bearerToken, CancellationToken ct)
@@ -26,8 +30,19 @@ public sealed class GatewayWebSocketClient : IAsyncDisposable
     public async Task SendUserMessageAsync(string text, string? messageId, string? replyToMessageId, CancellationToken ct)
         => await _inner.SendUserMessageAsync(text, messageId, replyToMessageId, ct);
 
+    public async Task SendEnvelopeAsync(OpenClaw.Core.Models.WsClientEnvelope envelope, CancellationToken ct)
+        => await _inner.SendEnvelopeAsync(envelope, ct);
+
     public async ValueTask DisposeAsync()
     {
         try { await _inner.DisposeAsync(); } catch { }
+    }
+
+    internal void SetConnectedSocketForTest(WebSocket ws)
+    {
+        var method = typeof(OpenClaw.Client.OpenClawWebSocketClient).GetMethod(
+            "SetConnectedSocketForTest",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        method?.Invoke(_inner, [ws]);
     }
 }

--- a/src/OpenClaw.Companion/ViewModels/A2UiFrameItem.cs
+++ b/src/OpenClaw.Companion/ViewModels/A2UiFrameItem.cs
@@ -1,0 +1,218 @@
+using System.Text.Json;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace OpenClaw.Companion.ViewModels;
+
+public sealed partial class A2UiFrameItem : ObservableObject
+{
+    private readonly Func<A2UiFrameItem, string, string, Task> _onEvent;
+    private bool _suppressEvents;
+
+    public A2UiFrameItem(
+        string surfaceId,
+        string id,
+        string type,
+        Func<A2UiFrameItem, string, string, Task> onEvent)
+    {
+        SurfaceId = surfaceId;
+        Id = id;
+        Type = type;
+        _onEvent = onEvent;
+        ActivateCommand = new AsyncRelayCommand(() => FireEventAsync("click", "true"));
+        CommitValueCommand = new AsyncRelayCommand(() => FireEventAsync("change", JsonSerializer.Serialize(ValueText ?? "")));
+    }
+
+    public string SurfaceId { get; }
+    public string Id { get; }
+    public string Type { get; }
+    public string? Title { get; init; }
+    public string? Body { get; init; }
+    public string? Text { get; init; }
+    public string? Label { get; init; }
+    public string? Url { get; init; }
+    public string? DisplayText { get; init; }
+    public double ProgressValue { get; init; }
+    public IReadOnlyList<A2UiOptionItem> Options { get; init; } = [];
+    public IReadOnlyList<string> Columns { get; init; } = [];
+    public IReadOnlyList<A2UiTableRowItem> Rows { get; init; } = [];
+    public IAsyncRelayCommand ActivateCommand { get; }
+    public IAsyncRelayCommand CommitValueCommand { get; }
+
+    [ObservableProperty]
+    private string? _valueText;
+
+    [ObservableProperty]
+    private string? _selectedValue;
+
+    public bool HasTitle => !string.IsNullOrWhiteSpace(Title);
+    public bool HasBody => !string.IsNullOrWhiteSpace(Body);
+    public bool HasText => !string.IsNullOrWhiteSpace(Text);
+    public bool HasLabel => !string.IsNullOrWhiteSpace(Label);
+    public bool HasUrl => !string.IsNullOrWhiteSpace(Url);
+    public bool HasDisplayText => !string.IsNullOrWhiteSpace(DisplayText);
+    public bool HasOptions => Options.Count > 0;
+    public bool HasTable => Columns.Count > 0 || Rows.Count > 0;
+    public bool IsButton => TypeEquals("button");
+    public bool IsInput => TypeEquals("input");
+    public bool IsSelect => TypeEquals("select");
+    public bool IsChecklist => TypeEquals("checklist");
+    public bool IsProgress => TypeEquals("progress");
+    public bool IsImage => TypeEquals("image");
+    public bool IsChart => TypeEquals("chart");
+
+    public static A2UiFrameItem FromJson(string surfaceId, JsonElement root, Func<A2UiFrameItem, string, string, Task> onEvent)
+    {
+        var type = GetString(root, "type") ?? "text";
+        var item = new A2UiFrameItem(surfaceId, GetString(root, "id") ?? Guid.NewGuid().ToString("N"), type, onEvent)
+        {
+            Title = GetString(root, "title"),
+            Body = GetString(root, "body"),
+            Text = GetString(root, "text"),
+            Label = GetString(root, "label"),
+            Url = GetString(root, "url") ?? GetString(root, "src"),
+            DisplayText = BuildDisplayText(type, root),
+            ProgressValue = BuildProgressValue(root),
+            Columns = BuildColumns(root),
+            Rows = BuildRows(root),
+            Options = BuildOptions(root)
+        };
+
+        item._suppressEvents = true;
+        item.ValueText = GetString(root, "value") ?? "";
+        item.SelectedValue = item.Options.FirstOrDefault(static option => option.IsSelected)?.Value;
+        item._suppressEvents = false;
+        foreach (var option in item.Options)
+            option.AttachParent(item);
+
+        return item;
+    }
+
+    partial void OnValueTextChanged(string? value)
+    {
+        if (!_suppressEvents && IsInput)
+            _ = FireEventAsync("change", JsonSerializer.Serialize(value ?? ""));
+    }
+
+    partial void OnSelectedValueChanged(string? value)
+    {
+        if (!_suppressEvents && IsSelect)
+            _ = FireEventAsync("change", JsonSerializer.Serialize(value ?? ""));
+    }
+
+    internal Task FireEventAsync(string eventName, string valueJson)
+        => _onEvent(this, eventName, valueJson);
+
+    private bool TypeEquals(string expected)
+        => string.Equals(Type, expected, StringComparison.OrdinalIgnoreCase);
+
+    private static string? GetString(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var prop))
+            return null;
+        return prop.ValueKind switch
+        {
+            JsonValueKind.String => prop.GetString(),
+            JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False => prop.GetRawText(),
+            _ => null
+        };
+    }
+
+    private static double BuildProgressValue(JsonElement root)
+    {
+        if (!root.TryGetProperty("value", out var value) || value.ValueKind != JsonValueKind.Number)
+            return 0;
+        var number = value.GetDouble();
+        return number <= 1 ? number * 100 : Math.Clamp(number, 0, 100);
+    }
+
+    private static string BuildDisplayText(string type, JsonElement root)
+    {
+        if (string.Equals(type, "chart", StringComparison.OrdinalIgnoreCase) &&
+            root.TryGetProperty("data", out var data))
+        {
+            return data.GetRawText();
+        }
+
+        return string.Empty;
+    }
+
+    private static IReadOnlyList<string> BuildColumns(JsonElement root)
+    {
+        if (!root.TryGetProperty("columns", out var columns) || columns.ValueKind != JsonValueKind.Array)
+            return [];
+
+        return columns.EnumerateArray()
+            .Select(static item => item.ValueKind == JsonValueKind.String ? item.GetString() ?? "" : item.GetRawText())
+            .Where(static item => item.Length > 0)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<A2UiTableRowItem> BuildRows(JsonElement root)
+    {
+        if (!root.TryGetProperty("rows", out var rows) || rows.ValueKind != JsonValueKind.Array)
+            return [];
+
+        return rows.EnumerateArray()
+            .Select(static row => new A2UiTableRowItem(row.ValueKind == JsonValueKind.Array
+                ? string.Join(" | ", row.EnumerateArray().Select(static cell => cell.ValueKind == JsonValueKind.String ? cell.GetString() : cell.GetRawText()))
+                : row.GetRawText()))
+            .ToArray();
+    }
+
+    private static IReadOnlyList<A2UiOptionItem> BuildOptions(JsonElement root)
+    {
+        if (!root.TryGetProperty("options", out var options) || options.ValueKind != JsonValueKind.Array)
+            return [];
+
+        return options.EnumerateArray()
+            .Select(static option =>
+            {
+                if (option.ValueKind == JsonValueKind.String)
+                {
+                    var value = option.GetString() ?? "";
+                    return new A2UiOptionItem(value, value, false);
+                }
+
+                var label = GetString(option, "label") ?? GetString(option, "text") ?? GetString(option, "value") ?? "option";
+                var valueText = GetString(option, "value") ?? label;
+                var selected = option.TryGetProperty("selected", out var selectedProp) &&
+                    selectedProp.ValueKind == JsonValueKind.True;
+                return new A2UiOptionItem(label, valueText, selected);
+            })
+            .ToArray();
+    }
+}
+
+public sealed partial class A2UiOptionItem : ObservableObject
+{
+    private A2UiFrameItem? _parent;
+
+    public A2UiOptionItem(string label, string value, bool isSelected)
+    {
+        Label = label;
+        Value = value;
+        _isSelected = isSelected;
+    }
+
+    public string Label { get; }
+    public string Value { get; }
+
+    [ObservableProperty]
+    private bool _isSelected;
+
+    internal void AttachParent(A2UiFrameItem parent) => _parent = parent;
+
+    partial void OnIsSelectedChanged(bool value)
+    {
+        if (_parent is null)
+            return;
+
+        if (_parent.IsSelect && value)
+            _parent.SelectedValue = Value;
+        if (_parent.IsChecklist)
+            _ = _parent.FireEventAsync("change", JsonSerializer.Serialize(new { value = Value, selected = value }));
+    }
+}
+
+public sealed record A2UiTableRowItem(string DisplayText);

--- a/src/OpenClaw.Companion/ViewModels/A2UiFrameItem.cs
+++ b/src/OpenClaw.Companion/ViewModels/A2UiFrameItem.cs
@@ -123,7 +123,8 @@ public sealed partial class A2UiFrameItem : ObservableObject
         if (!root.TryGetProperty("value", out var value) || value.ValueKind != JsonValueKind.Number)
             return 0;
         var number = value.GetDouble();
-        return number <= 1 ? number * 100 : Math.Clamp(number, 0, 100);
+        var percent = number <= 1 ? number * 100 : number;
+        return Math.Clamp(percent, 0, 100);
     }
 
     private static string BuildDisplayText(string type, JsonElement root)

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Canvas.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Canvas.cs
@@ -10,6 +10,10 @@ namespace OpenClaw.Companion.ViewModels;
 
 public sealed partial class MainWindowViewModel
 {
+    private const int MaxSnapshotJsonChars = 128 * 1024;
+    private const int MaxSnapshotFrames = 100;
+    private const int MaxSnapshotTextChars = 1_024;
+
     private string? _canvasSessionId;
     private long _canvasEventSequence;
 
@@ -25,6 +29,10 @@ public sealed partial class MainWindowViewModel
     public ObservableCollection<A2UiFrameItem> CanvasFrames { get; } = new();
 
     public bool HasCanvasFrames => CanvasFrames.Count > 0;
+    public bool HasCanvasHtmlStatus => !string.IsNullOrWhiteSpace(CanvasHtmlStatus);
+
+    partial void OnCanvasHtmlStatusChanged(string value)
+        => OnPropertyChanged(nameof(HasCanvasHtmlStatus));
 
     private async Task SendCanvasReadyAsync()
     {
@@ -208,28 +216,51 @@ public sealed partial class MainWindowViewModel
 
     private string BuildCanvasSnapshotJson(string? surfaceId)
     {
-        var frames = CanvasFrames.Select(frame => new
+        var totalFrames = CanvasFrames.Count;
+        var frames = CanvasFrames.Take(MaxSnapshotFrames).Select(frame => new
         {
             frame.SurfaceId,
             frame.Id,
             frame.Type,
-            frame.Title,
-            frame.Text,
-            frame.Label,
-            frame.ValueText,
-            frame.SelectedValue
+            Title = TruncateSnapshotText(frame.Title),
+            Text = TruncateSnapshotText(frame.Text),
+            Label = TruncateSnapshotText(frame.Label),
+            ValueText = TruncateSnapshotText(frame.ValueText),
+            SelectedValue = TruncateSnapshotText(frame.SelectedValue)
         }).ToArray();
+
+        var snapshot = JsonSerializer.Serialize(new
+        {
+            type = "canvas_snapshot",
+            surfaceId = string.IsNullOrWhiteSpace(surfaceId) ? "main" : surfaceId,
+            visible = IsCanvasVisible,
+            frameCount = totalFrames,
+            returnedFrameCount = frames.Length,
+            truncated = totalFrames > frames.Length,
+            frames,
+            diagnostics = string.IsNullOrWhiteSpace(CanvasHtmlStatus) ? Array.Empty<string>() : new[] { CanvasHtmlStatus }
+        });
+
+        if (snapshot.Length <= MaxSnapshotJsonChars)
+            return snapshot;
 
         return JsonSerializer.Serialize(new
         {
             type = "canvas_snapshot",
             surfaceId = string.IsNullOrWhiteSpace(surfaceId) ? "main" : surfaceId,
             visible = IsCanvasVisible,
-            frameCount = frames.Length,
-            frames,
-            diagnostics = string.IsNullOrWhiteSpace(CanvasHtmlStatus) ? Array.Empty<string>() : new[] { CanvasHtmlStatus }
+            frameCount = totalFrames,
+            returnedFrameCount = 0,
+            truncated = true,
+            frames = Array.Empty<object>(),
+            diagnostics = new[] { $"Snapshot exceeded {MaxSnapshotJsonChars} characters and was truncated." }
         });
     }
+
+    private static string? TruncateSnapshotText(string? value)
+        => string.IsNullOrEmpty(value) || value.Length <= MaxSnapshotTextChars
+            ? value
+            : string.Concat(value.AsSpan(0, MaxSnapshotTextChars), "...");
 
     [RelayCommand]
     private void ClearCanvas()

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Canvas.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Canvas.cs
@@ -1,0 +1,245 @@
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using OpenClaw.Core.Canvas;
+using OpenClaw.Core.Models;
+
+namespace OpenClaw.Companion.ViewModels;
+
+public sealed partial class MainWindowViewModel
+{
+    private string? _canvasSessionId;
+    private long _canvasEventSequence;
+
+    [ObservableProperty]
+    private bool _isCanvasVisible;
+
+    [ObservableProperty]
+    private string _canvasStatus = "Canvas idle.";
+
+    [ObservableProperty]
+    private string _canvasHtmlStatus = "";
+
+    public ObservableCollection<A2UiFrameItem> CanvasFrames { get; } = new();
+
+    public bool HasCanvasFrames => CanvasFrames.Count > 0;
+
+    private async Task SendCanvasReadyAsync()
+    {
+        if (!_client.IsConnected)
+            return;
+
+        await _client.SendEnvelopeAsync(new WsClientEnvelope
+        {
+            Type = "canvas_ready",
+            Capabilities =
+            [
+                "a2ui.v0_8",
+                "canvas.present",
+                "canvas.hide",
+                "snapshot.state"
+            ]
+        }, CancellationToken.None);
+    }
+
+    private void HandleCanvasEnvelope(WsServerEnvelope envelope)
+    {
+        if (!IsCanvasServerEnvelope(envelope.Type))
+            return;
+
+        Dispatcher.UIThread.Post(() => _ = ApplyCanvasEnvelopeAsync(envelope));
+    }
+
+    private async Task ApplyCanvasEnvelopeAsync(WsServerEnvelope envelope)
+    {
+        _canvasSessionId = string.IsNullOrWhiteSpace(envelope.SessionId) ? _canvasSessionId : envelope.SessionId;
+        var surfaceId = string.IsNullOrWhiteSpace(envelope.SurfaceId) ? "main" : envelope.SurfaceId!;
+
+        try
+        {
+            switch (envelope.Type)
+            {
+                case "canvas_present":
+                    IsCanvasVisible = true;
+                    CanvasStatus = "Canvas visible.";
+                    await SendCanvasAckAsync(envelope, success: true, error: null);
+                    return;
+
+                case "canvas_hide":
+                    IsCanvasVisible = false;
+                    CanvasStatus = "Canvas hidden.";
+                    await SendCanvasAckAsync(envelope, success: true, error: null);
+                    return;
+
+                case "canvas_navigate":
+                    await ApplyCanvasNavigateAsync(envelope);
+                    return;
+
+                case "a2ui_reset":
+                    CanvasFrames.Clear();
+                    OnPropertyChanged(nameof(HasCanvasFrames));
+                    CanvasStatus = "Canvas reset.";
+                    await SendCanvasAckAsync(envelope, success: true, error: null);
+                    return;
+
+                case "a2ui_push":
+                    await ApplyA2UiPushAsync(envelope, surfaceId);
+                    return;
+
+                case "canvas_snapshot":
+                    await SendCanvasSnapshotResultAsync(envelope);
+                    return;
+
+                case "a2ui_eval":
+                    await SendCanvasEvalResultAsync(envelope, success: false, valueJson: null, error: "Companion native Canvas does not support A2UI eval.");
+                    return;
+            }
+        }
+        catch (Exception ex)
+        {
+            await SendCanvasAckAsync(envelope, success: false, error: ex.Message);
+        }
+    }
+
+    private async Task ApplyCanvasNavigateAsync(WsServerEnvelope envelope)
+    {
+        if (string.Equals(envelope.Url, "about:blank", StringComparison.OrdinalIgnoreCase))
+        {
+            CanvasFrames.Clear();
+            CanvasHtmlStatus = "";
+            CanvasStatus = "Canvas navigated to blank.";
+            OnPropertyChanged(nameof(HasCanvasFrames));
+            await SendCanvasAckAsync(envelope, success: true, error: null);
+            return;
+        }
+
+        var error = !string.IsNullOrWhiteSpace(envelope.Html)
+            ? "Companion native Canvas does not support local HTML navigation without a WebView."
+            : "Companion native Canvas only supports A2UI frames and about:blank navigation.";
+        CanvasHtmlStatus = error;
+        CanvasStatus = error;
+        await SendCanvasAckAsync(envelope, success: false, error: error);
+    }
+
+    private async Task ApplyA2UiPushAsync(WsServerEnvelope envelope, string surfaceId)
+    {
+        var validation = A2UiFrameValidator.ValidateJsonl(envelope.Frames, maxFrames: 1_000, maxBytes: 512 * 1024);
+        if (!validation.IsValid)
+        {
+            await SendCanvasAckAsync(envelope, success: false, error: validation.Error);
+            return;
+        }
+
+        foreach (var line in envelope.Frames!.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            using var doc = JsonDocument.Parse(line);
+            CanvasFrames.Add(A2UiFrameItem.FromJson(surfaceId, doc.RootElement, SendA2UiEventAsync));
+        }
+
+        IsCanvasVisible = true;
+        CanvasStatus = $"Rendered {validation.FrameCount} A2UI frame(s).";
+        OnPropertyChanged(nameof(HasCanvasFrames));
+        await SendCanvasAckAsync(envelope, success: true, error: null);
+    }
+
+    private async Task SendCanvasAckAsync(WsServerEnvelope envelope, bool success, string? error)
+    {
+        await _client.SendEnvelopeAsync(new WsClientEnvelope
+        {
+            Type = "canvas_ack",
+            RequestId = envelope.RequestId,
+            SessionId = _canvasSessionId,
+            SurfaceId = envelope.SurfaceId,
+            Success = success,
+            Error = error
+        }, CancellationToken.None);
+    }
+
+    private async Task SendCanvasEvalResultAsync(WsServerEnvelope envelope, bool success, string? valueJson, string? error)
+    {
+        await _client.SendEnvelopeAsync(new WsClientEnvelope
+        {
+            Type = "canvas_eval_result",
+            RequestId = envelope.RequestId,
+            SessionId = _canvasSessionId,
+            SurfaceId = envelope.SurfaceId,
+            Success = success,
+            ValueJson = valueJson,
+            Error = error
+        }, CancellationToken.None);
+    }
+
+    private async Task SendCanvasSnapshotResultAsync(WsServerEnvelope envelope)
+    {
+        var snapshot = BuildCanvasSnapshotJson(envelope.SurfaceId);
+        await _client.SendEnvelopeAsync(new WsClientEnvelope
+        {
+            Type = "canvas_snapshot_result",
+            RequestId = envelope.RequestId,
+            SessionId = _canvasSessionId,
+            SurfaceId = envelope.SurfaceId,
+            Success = true,
+            SnapshotMode = envelope.SnapshotMode ?? "state",
+            SnapshotJson = snapshot
+        }, CancellationToken.None);
+    }
+
+    private async Task SendA2UiEventAsync(A2UiFrameItem frame, string eventName, string valueJson)
+    {
+        if (!_client.IsConnected)
+            return;
+
+        await _client.SendEnvelopeAsync(new WsClientEnvelope
+        {
+            Type = "a2ui_event",
+            SessionId = _canvasSessionId,
+            SurfaceId = frame.SurfaceId,
+            ComponentId = frame.Id,
+            Event = eventName,
+            ValueJson = valueJson,
+            Sequence = Interlocked.Increment(ref _canvasEventSequence)
+        }, CancellationToken.None);
+    }
+
+    private string BuildCanvasSnapshotJson(string? surfaceId)
+    {
+        var frames = CanvasFrames.Select(frame => new
+        {
+            frame.SurfaceId,
+            frame.Id,
+            frame.Type,
+            frame.Title,
+            frame.Text,
+            frame.Label,
+            frame.ValueText,
+            frame.SelectedValue
+        }).ToArray();
+
+        return JsonSerializer.Serialize(new
+        {
+            type = "canvas_snapshot",
+            surfaceId = string.IsNullOrWhiteSpace(surfaceId) ? "main" : surfaceId,
+            visible = IsCanvasVisible,
+            frameCount = frames.Length,
+            frames,
+            diagnostics = string.IsNullOrWhiteSpace(CanvasHtmlStatus) ? Array.Empty<string>() : new[] { CanvasHtmlStatus }
+        });
+    }
+
+    [RelayCommand]
+    private void ClearCanvas()
+    {
+        CanvasFrames.Clear();
+        CanvasHtmlStatus = "";
+        CanvasStatus = "Canvas cleared.";
+        OnPropertyChanged(nameof(HasCanvasFrames));
+    }
+
+    private static bool IsCanvasServerEnvelope(string type)
+        => type is "canvas_present" or "canvas_hide" or "canvas_navigate" or "canvas_snapshot" or "a2ui_push" or "a2ui_reset" or "a2ui_eval";
+}

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.cs
@@ -99,6 +99,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase
         _adminClientFactory = adminClientFactory ?? ((baseUrl, authToken) => new OpenClawHttpClient(baseUrl, authToken));
 
         _client.OnTextMessage += HandleInboundText;
+        _client.OnEnvelopeReceived += HandleCanvasEnvelope;
         _client.OnError += err => AddSystemMessage($"Error: {err}");
 
         LoadSettings();
@@ -155,6 +156,9 @@ public sealed partial class MainWindowViewModel : ViewModelBase
 
         if (TryParseEnvelope(payload, out var envelope))
         {
+            if (IsCanvasServerEnvelope(envelope.Type))
+                return;
+
             Dispatcher.UIThread.Post(() => ApplyEnvelope(envelope));
             return;
         }
@@ -450,6 +454,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase
             await _client.ConnectAsync(uri, string.IsNullOrWhiteSpace(AuthToken) ? null : AuthToken, CancellationToken.None);
             IsConnected = true;
             Status = "Connected";
+            await SendCanvasReadyAsync();
             await LoadAdminStatusAsyncInternal();
             await LoadWhatsAppSetupAsync();
         }

--- a/src/OpenClaw.Companion/Views/MainWindow.axaml
+++ b/src/OpenClaw.Companion/Views/MainWindow.axaml
@@ -76,6 +76,91 @@
                 </Grid>
             </TabItem>
 
+            <TabItem Header="Canvas">
+                <Grid RowDefinitions="Auto,*" RowSpacing="10">
+                    <Border Grid.Row="0" Padding="10" CornerRadius="8" BorderThickness="1"
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                            <StackPanel Grid.Column="0" Spacing="2">
+                                <TextBlock Text="{Binding CanvasStatus}" TextWrapping="Wrap" />
+                                <TextBlock Text="{Binding CanvasHtmlStatus}" FontSize="11" Opacity="0.65"
+                                           TextWrapping="Wrap"
+                                           IsVisible="{Binding CanvasHtmlStatus, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                            </StackPanel>
+                            <Button Grid.Column="1" Content="Clear"
+                                    Command="{Binding ClearCanvasCommand}" />
+                        </Grid>
+                    </Border>
+
+                    <Border Grid.Row="1" Padding="10" CornerRadius="8" BorderThickness="1"
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
+                        <Grid>
+                            <TextBlock Text="Canvas is empty."
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                       Opacity="0.55" TextWrapping="Wrap" TextAlignment="Center"
+                                       IsVisible="{Binding !HasCanvasFrames}" />
+                            <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto"
+                                          IsVisible="{Binding HasCanvasFrames}">
+                                <ItemsControl ItemsSource="{Binding CanvasFrames}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="vm:A2UiFrameItem">
+                                            <Border Margin="0,0,0,8" Padding="10" CornerRadius="6" BorderThickness="1"
+                                                    BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
+                                                <StackPanel Spacing="8">
+                                                    <TextBlock Text="{Binding Title}" FontWeight="SemiBold"
+                                                               IsVisible="{Binding HasTitle}" TextWrapping="Wrap" />
+                                                    <TextBlock Text="{Binding Text}" TextWrapping="Wrap"
+                                                               IsVisible="{Binding HasText}" />
+                                                    <TextBlock Text="{Binding Body}" TextWrapping="Wrap"
+                                                               IsVisible="{Binding HasBody}" />
+                                                    <Button Content="{Binding Label}" Command="{Binding ActivateCommand}"
+                                                            IsVisible="{Binding IsButton}" HorizontalAlignment="Left" />
+                                                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8"
+                                                          IsVisible="{Binding IsInput}">
+                                                        <TextBox Text="{Binding ValueText}" Watermark="{Binding Label}" />
+                                                        <Button Grid.Column="1" Content="Send" Command="{Binding CommitValueCommand}" />
+                                                    </Grid>
+                                                    <ItemsControl ItemsSource="{Binding Options}"
+                                                                  IsVisible="{Binding HasOptions}">
+                                                        <ItemsControl.ItemTemplate>
+                                                            <DataTemplate DataType="vm:A2UiOptionItem">
+                                                                <CheckBox Content="{Binding Label}"
+                                                                          IsChecked="{Binding IsSelected}" />
+                                                            </DataTemplate>
+                                                        </ItemsControl.ItemTemplate>
+                                                    </ItemsControl>
+                                                    <StackPanel Spacing="5" IsVisible="{Binding HasTable}">
+                                                        <TextBlock Text="{Binding Columns, StringFormat='Columns: {0}'}"
+                                                                   FontSize="11" Opacity="0.65" />
+                                                        <ItemsControl ItemsSource="{Binding Rows}">
+                                                            <ItemsControl.ItemTemplate>
+                                                                <DataTemplate DataType="vm:A2UiTableRowItem">
+                                                                    <TextBlock Text="{Binding DisplayText}" TextWrapping="Wrap"
+                                                                               FontFamily="Consolas, Menlo, monospace"
+                                                                               FontSize="12" />
+                                                                </DataTemplate>
+                                                            </ItemsControl.ItemTemplate>
+                                                        </ItemsControl>
+                                                    </StackPanel>
+                                                    <ProgressBar Minimum="0" Maximum="100" Value="{Binding ProgressValue}"
+                                                                 IsVisible="{Binding IsProgress}" />
+                                                    <TextBlock Text="{Binding Url, StringFormat='Image: {0}'}"
+                                                               TextWrapping="Wrap" IsVisible="{Binding IsImage}" />
+                                                    <TextBlock Text="{Binding DisplayText}" TextWrapping="Wrap"
+                                                               FontFamily="Consolas, Menlo, monospace"
+                                                               FontSize="12"
+                                                               IsVisible="{Binding HasDisplayText}" />
+                                                </StackPanel>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </ScrollViewer>
+                        </Grid>
+                    </Border>
+                </Grid>
+            </TabItem>
+
             <TabItem x:Name="ApprovalsTab">
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal" Spacing="6">

--- a/src/OpenClaw.Companion/Views/MainWindow.axaml
+++ b/src/OpenClaw.Companion/Views/MainWindow.axaml
@@ -85,7 +85,7 @@
                                 <TextBlock Text="{Binding CanvasStatus}" TextWrapping="Wrap" />
                                 <TextBlock Text="{Binding CanvasHtmlStatus}" FontSize="11" Opacity="0.65"
                                            TextWrapping="Wrap"
-                                           IsVisible="{Binding CanvasHtmlStatus, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                           IsVisible="{Binding HasCanvasHtmlStatus}" />
                             </StackPanel>
                             <Button Grid.Column="1" Content="Clear"
                                     Command="{Binding ClearCanvasCommand}" />

--- a/src/OpenClaw.Core/Canvas/A2UiFrameValidator.cs
+++ b/src/OpenClaw.Core/Canvas/A2UiFrameValidator.cs
@@ -1,0 +1,123 @@
+using System.Text;
+using System.Text.Json;
+
+namespace OpenClaw.Core.Canvas;
+
+public sealed record A2UiValidationResult(bool IsValid, string? Error, int FrameCount)
+{
+    public static A2UiValidationResult Valid(int frameCount) => new(true, null, frameCount);
+    public static A2UiValidationResult Invalid(string error, int frameCount = 0) => new(false, error, frameCount);
+}
+
+public static class A2UiFrameValidator
+{
+    public const string ContentTypeV08 = "application/x-a2ui+jsonl;version=0.8";
+
+    private static readonly HashSet<string> SupportedTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "text",
+        "markdown",
+        "card",
+        "button",
+        "input",
+        "select",
+        "checklist",
+        "table",
+        "image",
+        "progress",
+        "chart"
+    };
+
+    public static A2UiValidationResult ValidateJsonl(string? frames, int maxFrames, int maxBytes)
+    {
+        if (string.IsNullOrWhiteSpace(frames))
+            return A2UiValidationResult.Invalid("A2UI frames are required.");
+
+        if (Encoding.UTF8.GetByteCount(frames) > Math.Max(1, maxBytes))
+            return A2UiValidationResult.Invalid($"A2UI frame payload exceeds {maxBytes} bytes.");
+
+        var count = 0;
+        foreach (var rawLine in frames.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0)
+                continue;
+
+            count++;
+            if (count > Math.Max(1, maxFrames))
+                return A2UiValidationResult.Invalid($"A2UI push exceeds {maxFrames} frames.", count);
+
+            JsonDocument doc;
+            try
+            {
+                doc = JsonDocument.Parse(line);
+            }
+            catch (JsonException ex)
+            {
+                return A2UiValidationResult.Invalid($"Frame {count} is not valid JSON: {ex.Message}", count);
+            }
+
+            using (doc)
+            {
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object)
+                    return A2UiValidationResult.Invalid($"Frame {count} must be a JSON object.", count);
+
+                if (HasString(root, "command", "createSurface") || HasString(root, "type", "createSurface"))
+                    return A2UiValidationResult.Invalid("A2UI v0.9 createSurface is not supported; use v0.8 JSONL frames.", count);
+
+                if (!root.TryGetProperty("type", out var typeProp) || typeProp.ValueKind != JsonValueKind.String)
+                    return A2UiValidationResult.Invalid($"Frame {count} is missing string property 'type'.", count);
+
+                var type = typeProp.GetString();
+                if (string.IsNullOrWhiteSpace(type) || !SupportedTypes.Contains(type))
+                    return A2UiValidationResult.Invalid($"Frame {count} has unsupported A2UI type '{type}'.", count);
+
+                if (!HasNonEmptyString(root, "id"))
+                    return A2UiValidationResult.Invalid($"Frame {count} is missing string property 'id'.", count);
+
+                var typeError = ValidateByType(root, type);
+                if (typeError is not null)
+                    return A2UiValidationResult.Invalid($"Frame {count} {typeError}", count);
+            }
+        }
+
+        return count == 0
+            ? A2UiValidationResult.Invalid("A2UI frames are required.")
+            : A2UiValidationResult.Valid(count);
+    }
+
+    private static string? ValidateByType(JsonElement root, string type)
+        => type.ToLowerInvariant() switch
+        {
+            "text" or "markdown" => HasNonEmptyString(root, "text") ? null : "is missing string property 'text'.",
+            "card" => HasNonEmptyString(root, "title") || HasNonEmptyString(root, "body") ? null : "requires 'title' or 'body'.",
+            "button" => HasNonEmptyString(root, "label") ? null : "is missing string property 'label'.",
+            "input" => null,
+            "select" or "checklist" => HasArray(root, "options") ? null : "is missing array property 'options'.",
+            "table" => HasArray(root, "columns") && HasArray(root, "rows") ? null : "requires array properties 'columns' and 'rows'.",
+            "image" => HasNonEmptyString(root, "url") || HasNonEmptyString(root, "src") ? null : "requires 'url' or 'src'.",
+            "progress" => HasNumber(root, "value") ? null : "is missing numeric property 'value'.",
+            "chart" => HasProperty(root, "data") ? null : "is missing property 'data'.",
+            _ => "has unsupported type."
+        };
+
+    private static bool HasProperty(JsonElement root, string propertyName)
+        => root.TryGetProperty(propertyName, out _);
+
+    private static bool HasArray(JsonElement root, string propertyName)
+        => root.TryGetProperty(propertyName, out var prop) && prop.ValueKind == JsonValueKind.Array;
+
+    private static bool HasNumber(JsonElement root, string propertyName)
+        => root.TryGetProperty(propertyName, out var prop) && prop.ValueKind == JsonValueKind.Number;
+
+    private static bool HasNonEmptyString(JsonElement root, string propertyName)
+        => root.TryGetProperty(propertyName, out var prop) &&
+           prop.ValueKind == JsonValueKind.String &&
+           !string.IsNullOrWhiteSpace(prop.GetString());
+
+    private static bool HasString(JsonElement root, string propertyName, string expected)
+        => root.TryGetProperty(propertyName, out var prop) &&
+           prop.ValueKind == JsonValueKind.String &&
+           string.Equals(prop.GetString(), expected, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/OpenClaw.Core/Models/GatewayConfig.cs
+++ b/src/OpenClaw.Core/Models/GatewayConfig.cs
@@ -17,6 +17,7 @@ public sealed class GatewayConfig
     public MemoryConfig Memory { get; set; } = new();
     public SecurityConfig Security { get; set; } = new();
     public WebSocketConfig WebSocket { get; set; } = new();
+    public CanvasConfig Canvas { get; set; } = new();
     public ToolingConfig Tooling { get; set; } = new();
     public SandboxConfig Sandbox { get; set; } = new();
     public ExecutionConfig Execution { get; set; } = new();
@@ -291,6 +292,23 @@ public sealed class WebSocketConfig
     public int MaxConnectionsPerIp { get; set; } = 50;
     public int MessagesPerMinutePerConnection { get; set; } = 120;
     public int ReceiveTimeoutSeconds { get; set; } = 120;
+}
+
+public sealed class CanvasConfig
+{
+    /// <summary>Enables first-party Canvas/A2UI command forwarding on websocket clients.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Canvas is disabled on non-loopback binds unless this is explicitly enabled.</summary>
+    public bool AllowOnPublicBind { get; set; } = false;
+
+    public int MaxCommandBytes { get; set; } = 256 * 1024;
+    public int MaxSnapshotBytes { get; set; } = 256 * 1024;
+    public int CommandTimeoutSeconds { get; set; } = 10;
+    public int MaxFramesPerPush { get; set; } = 100;
+    public bool EnableLocalHtml { get; set; } = true;
+    public bool EnableRemoteNavigation { get; set; } = false;
+    public bool EnableEval { get; set; } = true;
 }
 
 public sealed class ToolingConfig

--- a/src/OpenClaw.Core/Models/Messages.cs
+++ b/src/OpenClaw.Core/Models/Messages.cs
@@ -17,6 +17,12 @@ public sealed record InboundMessage
     public string? SenderName { get; init; }
     public string? MessageId { get; init; }
     public string? ReplyToMessageId { get; init; }
+    public string? RequestId { get; init; }
+    public string? SurfaceId { get; init; }
+    public string? ComponentId { get; init; }
+    public string? Event { get; init; }
+    public string? ValueJson { get; init; }
+    public long? Sequence { get; init; }
     public bool IsSystem { get; init; }
     public string? Subject { get; init; }
     public string? ApprovalId { get; init; }

--- a/src/OpenClaw.Core/Models/Session.cs
+++ b/src/OpenClaw.Core/Models/Session.cs
@@ -233,6 +233,7 @@ public sealed class SessionDelegationChildSummary
 [JsonSerializable(typeof(WsServerEnvelope))]
 [JsonSerializable(typeof(GatewayConfig))]
 [JsonSerializable(typeof(RuntimeConfig))]
+[JsonSerializable(typeof(CanvasConfig))]
 [JsonSerializable(typeof(GatewayRuntimeState))]
 [JsonSerializable(typeof(LlmProviderConfig))]
 [JsonSerializable(typeof(PromptCachingConfig))]

--- a/src/OpenClaw.Core/Models/WebSocketEnvelopes.cs
+++ b/src/OpenClaw.Core/Models/WebSocketEnvelopes.cs
@@ -7,11 +7,27 @@ namespace OpenClaw.Core.Models;
 public sealed record WsClientEnvelope
 {
     public required string Type { get; init; }
+    public string? RequestId { get; init; }
     public string? Text { get; init; }
     public string? Content { get; init; }
     public string? SessionId { get; init; }
     public string? MessageId { get; init; }
     public string? ReplyToMessageId { get; init; }
+    public string? SurfaceId { get; init; }
+    public string? ContentType { get; init; }
+    public string? Frames { get; init; }
+    public string? Html { get; init; }
+    public string? Url { get; init; }
+    public string? Script { get; init; }
+    public string? SnapshotMode { get; init; }
+    public string? SnapshotJson { get; init; }
+    public string? ComponentId { get; init; }
+    public string? Event { get; init; }
+    public string? ValueJson { get; init; }
+    public long? Sequence { get; init; }
+    public string[]? Capabilities { get; init; }
+    public string? Error { get; init; }
+    public bool? Success { get; init; }
 
     // Tool approval decision (client -> server)
     public string? ApprovalId { get; init; }
@@ -24,8 +40,25 @@ public sealed record WsClientEnvelope
 public sealed record WsServerEnvelope
 {
     public required string Type { get; init; }
+    public string? RequestId { get; init; }
     public string? Text { get; init; }
     public string? InReplyToMessageId { get; init; }
+    public string? SessionId { get; init; }
+    public string? SurfaceId { get; init; }
+    public string? ContentType { get; init; }
+    public string? Frames { get; init; }
+    public string? Html { get; init; }
+    public string? Url { get; init; }
+    public string? Script { get; init; }
+    public string? SnapshotMode { get; init; }
+    public string? SnapshotJson { get; init; }
+    public string? ComponentId { get; init; }
+    public string? Event { get; init; }
+    public string? ValueJson { get; init; }
+    public long? Sequence { get; init; }
+    public string[]? Capabilities { get; init; }
+    public string? Error { get; init; }
+    public bool? Success { get; init; }
 
     // Tool approval request/status (server -> client)
     public string? ApprovalId { get; init; }

--- a/src/OpenClaw.Core/Validation/SetupVerificationService.cs
+++ b/src/OpenClaw.Core/Validation/SetupVerificationService.cs
@@ -468,6 +468,8 @@ public static class SetupVerificationService
             issues.Add("Public bind is enabled without an auth token.");
         if (publicBind && !config.Security.RequireRequesterMatchForHttpToolApproval)
             warnings.Add("Requester-matched HTTP tool approvals are disabled.");
+        if (publicBind && config.Canvas.Enabled && !config.Canvas.AllowOnPublicBind)
+            issues.Add("Canvas command forwarding is enabled on a public bind without Canvas.AllowOnPublicBind.");
         if (publicBind && !config.Security.TrustForwardedHeaders)
             warnings.Add("Forwarded headers are not trusted, so browser session cookies may not be marked secure behind TLS termination.");
         if (publicBind &&

--- a/src/OpenClaw.Gateway/CanvasCommandBroker.cs
+++ b/src/OpenClaw.Gateway/CanvasCommandBroker.cs
@@ -1,0 +1,209 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using OpenClaw.Channels;
+using OpenClaw.Core.Models;
+
+namespace OpenClaw.Gateway;
+
+internal sealed record CanvasCommandResult(
+    bool Success,
+    string RequestId,
+    string? Error = null,
+    string? SnapshotJson = null,
+    string? ValueJson = null);
+
+internal sealed class CanvasCommandBroker
+{
+    private readonly GatewayConfig _config;
+    private readonly WebSocketChannel _webSocketChannel;
+    private readonly RuntimeEventStore _runtimeEvents;
+    private readonly ConcurrentDictionary<string, PendingCommand> _pending = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, string[]> _clientCapabilities = new(StringComparer.Ordinal);
+
+    public CanvasCommandBroker(GatewayConfig config, WebSocketChannel webSocketChannel, RuntimeEventStore runtimeEvents)
+    {
+        _config = config;
+        _webSocketChannel = webSocketChannel;
+        _runtimeEvents = runtimeEvents;
+        _webSocketChannel.OnCanvasClientEnvelopeReceived += HandleClientEnvelopeAsync;
+    }
+
+    public IReadOnlyList<string> GetClientCapabilities(string senderId)
+        => _clientCapabilities.TryGetValue(senderId, out var capabilities) ? capabilities : [];
+
+    public async Task<CanvasCommandResult> SendCommandAsync(
+        Session session,
+        WsServerEnvelope command,
+        string expectedResponseType,
+        string? requiredCapability,
+        CancellationToken ct)
+    {
+        if (!_config.Canvas.Enabled)
+            return Fail(command.RequestId, "Canvas is disabled.");
+
+        if (!string.Equals(session.ChannelId, "websocket", StringComparison.Ordinal))
+            return Fail(command.RequestId, "Canvas commands require an active websocket session.");
+
+        if (!_webSocketChannel.IsClientConnected(session.SenderId) || !_webSocketChannel.IsClientUsingEnvelopes(session.SenderId))
+            return Fail(command.RequestId, "Canvas client is not connected in websocket envelope mode.");
+
+        if (!string.IsNullOrWhiteSpace(requiredCapability) && !HasCapability(session.SenderId, requiredCapability))
+        {
+            var advertised = GetClientCapabilities(session.SenderId);
+            return Fail(
+                command.RequestId,
+                advertised.Count == 0
+                    ? "Canvas client has not advertised capabilities yet."
+                    : $"Canvas client does not support capability '{requiredCapability}'.");
+        }
+
+        var requestId = string.IsNullOrWhiteSpace(command.RequestId)
+            ? $"canvas_{Guid.NewGuid():N}"[..24]
+            : command.RequestId!;
+
+        var outbound = command with
+        {
+            RequestId = requestId,
+            SessionId = session.Id,
+            SurfaceId = string.IsNullOrWhiteSpace(command.SurfaceId) ? "main" : command.SurfaceId
+        };
+
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(outbound, CoreJsonContext.Default.WsServerEnvelope);
+        if (bytes.Length > Math.Max(1, _config.Canvas.MaxCommandBytes))
+            return Fail(requestId, $"Canvas command exceeds {_config.Canvas.MaxCommandBytes} bytes.");
+
+        var pending = new PendingCommand(requestId, session.Id, session.SenderId, expectedResponseType);
+        if (!_pending.TryAdd(requestId, pending))
+            return Fail(requestId, "Canvas command request id collision.");
+
+        AppendRuntimeEvent(session, outbound.Type, requestId, "sent", "info", $"Sent Canvas command '{outbound.Type}'.");
+
+        try
+        {
+            await _webSocketChannel.SendEnvelopeAsync(session.SenderId, outbound, ct);
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(Math.Clamp(_config.Canvas.CommandTimeoutSeconds, 1, 300)));
+            var response = await pending.Task.WaitAsync(timeoutCts.Token);
+
+            if (!string.Equals(response.Type, expectedResponseType, StringComparison.Ordinal))
+                return Fail(requestId, $"Unexpected Canvas response '{response.Type}'.");
+
+            if (!string.IsNullOrWhiteSpace(response.SnapshotJson) &&
+                Encoding.UTF8.GetByteCount(response.SnapshotJson) > Math.Max(1, _config.Canvas.MaxSnapshotBytes))
+            {
+                return Fail(requestId, $"Canvas snapshot exceeds {_config.Canvas.MaxSnapshotBytes} bytes.");
+            }
+
+            if (response.Success == false || !string.IsNullOrWhiteSpace(response.Error))
+            {
+                var error = string.IsNullOrWhiteSpace(response.Error) ? "Canvas command failed." : response.Error!;
+                AppendRuntimeEvent(session, outbound.Type, requestId, "failed", "warning", error);
+                return Fail(requestId, error);
+            }
+
+            AppendRuntimeEvent(session, outbound.Type, requestId, "completed", "info", $"Canvas command '{outbound.Type}' completed.");
+            return new CanvasCommandResult(true, requestId, SnapshotJson: response.SnapshotJson, ValueJson: response.ValueJson);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            AppendRuntimeEvent(session, outbound.Type, requestId, "timed_out", "warning", $"Canvas command '{outbound.Type}' timed out.");
+            return Fail(requestId, "Canvas command timed out.");
+        }
+        finally
+        {
+            _pending.TryRemove(requestId, out _);
+        }
+    }
+
+    internal ValueTask HandleClientEnvelopeAsync(string clientId, WsClientEnvelope envelope, CancellationToken ct)
+    {
+        if (string.Equals(envelope.Type, "canvas_ready", StringComparison.Ordinal))
+        {
+            _clientCapabilities[clientId] = NormalizeCapabilities(envelope.Capabilities);
+            return ValueTask.CompletedTask;
+        }
+
+        if (envelope.Capabilities is { Length: > 0 })
+            _clientCapabilities[clientId] = NormalizeCapabilities(envelope.Capabilities);
+
+        if (!string.IsNullOrWhiteSpace(envelope.RequestId) &&
+            _pending.TryGetValue(envelope.RequestId, out var pending) &&
+            string.Equals(pending.SenderId, clientId, StringComparison.Ordinal))
+        {
+            if (!string.IsNullOrWhiteSpace(envelope.SessionId) &&
+                !string.Equals(envelope.SessionId, pending.SessionId, StringComparison.Ordinal))
+            {
+                pending.TrySetResult(envelope with
+                {
+                    Success = false,
+                    Error = "Canvas response session id did not match the pending command."
+                });
+                return ValueTask.CompletedTask;
+            }
+
+            pending.TrySetResult(envelope);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    private bool HasCapability(string senderId, string capability)
+        => _clientCapabilities.TryGetValue(senderId, out var capabilities) &&
+           capabilities.Contains(capability, StringComparer.OrdinalIgnoreCase);
+
+    private static string[] NormalizeCapabilities(string[]? capabilities)
+        => capabilities is null
+            ? []
+            : capabilities
+                .Where(static item => !string.IsNullOrWhiteSpace(item))
+                .Select(static item => item.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+    private void AppendRuntimeEvent(Session session, string action, string requestId, string state, string severity, string summary)
+    {
+        _runtimeEvents.Append(new RuntimeEventEntry
+        {
+            Id = $"evt_{Guid.NewGuid():N}"[..20],
+            SessionId = session.Id,
+            ChannelId = session.ChannelId,
+            SenderId = session.SenderId,
+            Component = "canvas",
+            Action = state,
+            Severity = severity,
+            Summary = summary,
+            Metadata = new Dictionary<string, string>
+            {
+                ["requestId"] = requestId,
+                ["command"] = action
+            }
+        });
+    }
+
+    private static CanvasCommandResult Fail(string? requestId, string error)
+        => new(false, string.IsNullOrWhiteSpace(requestId) ? "" : requestId!, error);
+
+    private sealed class PendingCommand
+    {
+        private readonly TaskCompletionSource<WsClientEnvelope> _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public PendingCommand(string requestId, string sessionId, string senderId, string expectedResponseType)
+        {
+            RequestId = requestId;
+            SessionId = sessionId;
+            SenderId = senderId;
+            ExpectedResponseType = expectedResponseType;
+        }
+
+        public string RequestId { get; }
+        public string SessionId { get; }
+        public string SenderId { get; }
+        public string ExpectedResponseType { get; }
+        public Task<WsClientEnvelope> Task => _tcs.Task;
+
+        public void TrySetResult(WsClientEnvelope envelope)
+            => _tcs.TrySetResult(envelope);
+    }
+}

--- a/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
@@ -156,6 +156,7 @@ internal static class CoreServicesExtensions
         services.AddSingleton<CronSchedulerStartupService>();
         services.AddHostedService(sp => sp.GetRequiredService<CronSchedulerStartupService>());
         services.AddSingleton(new WebSocketChannel(config.WebSocket));
+        services.AddSingleton<CanvasCommandBroker>();
         services.AddSingleton<GatewayRuntimeShutdownCoordinator>();
         services.AddHostedService(sp => sp.GetRequiredService<GatewayRuntimeShutdownCoordinator>());
         services.AddSingleton<ChatCommandProcessor>();

--- a/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.CompositionStages.cs
+++ b/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.CompositionStages.cs
@@ -60,6 +60,7 @@ internal static partial class RuntimeInitializationExtensions
             ToolSandbox = app.Services.GetService<IToolSandbox>(),
             Pipeline = app.Services.GetRequiredService<MessagePipeline>(),
             WebSocketChannel = app.Services.GetRequiredService<WebSocketChannel>(),
+            CanvasBroker = app.Services.GetRequiredService<CanvasCommandBroker>(),
             NativeRegistry = app.Services.GetRequiredService<NativePluginRegistry>(),
             McpRegistry = app.Services.GetRequiredService<McpServerToolRegistry>()
         };
@@ -562,6 +563,7 @@ internal static partial class RuntimeInitializationExtensions
         public IToolSandbox? ToolSandbox { get; init; }
         public required MessagePipeline Pipeline { get; init; }
         public required WebSocketChannel WebSocketChannel { get; init; }
+        public required CanvasCommandBroker CanvasBroker { get; init; }
         public required NativePluginRegistry NativeRegistry { get; init; }
         public required McpServerToolRegistry McpRegistry { get; init; }
     }

--- a/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.RuntimeFactories.cs
+++ b/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.RuntimeFactories.cs
@@ -125,6 +125,13 @@ internal static partial class RuntimeInitializationExtensions
             new AutomationTool(services.AutomationService, services.Pipeline),
             new VisionAnalyzeTool(services.GeminiMultimodalService),
             new TextToSpeechTool(services.TextToSpeechService),
+            new CanvasPresentTool(services.CanvasBroker, config),
+            new CanvasHideTool(services.CanvasBroker, config),
+            new CanvasNavigateTool(services.CanvasBroker, config),
+            new CanvasSnapshotTool(services.CanvasBroker, config),
+            new A2UiPushTool(services.CanvasBroker, config),
+            new A2UiResetTool(services.CanvasBroker, config),
+            new A2UiEvalTool(services.CanvasBroker, config),
 
             new EditFileTool(config.Tooling),
             new ApplyPatchTool(config.Tooling),

--- a/src/OpenClaw.Gateway/Extensions/GatewaySecurityExtensions.cs
+++ b/src/OpenClaw.Gateway/Extensions/GatewaySecurityExtensions.cs
@@ -17,6 +17,8 @@ public static class GatewaySecurityExtensions
         config.Security.AllowUnsafeToolingOnPublicBind = false;
         config.Security.AllowPluginBridgeOnPublicBind = false;
         config.Security.AllowRawSecretRefsOnPublicBind = false;
+        if (!config.Canvas.AllowOnPublicBind)
+            config.Canvas.Enabled = false;
         config.Tooling.RequireToolApproval = true;
         config.Tooling.ApprovalRequiredTools = config.Tooling.ApprovalRequiredTools
             .Concat(["shell", "process", "write_file", "code_exec", "git"])
@@ -28,6 +30,13 @@ public static class GatewaySecurityExtensions
     {
         if (!isNonLoopbackBind)
             return;
+
+        if (config.Canvas.Enabled && !config.Canvas.AllowOnPublicBind)
+        {
+            throw new InvalidOperationException(
+                "Refusing to start with Canvas command forwarding enabled on a non-loopback bind. " +
+                "Disable OpenClaw:Canvas:Enabled or explicitly opt in via OpenClaw:Canvas:AllowOnPublicBind=true.");
+        }
 
         var localShellEnabled = IsUnsafeLocalToolExecutionExposed(config, "shell");
         var localProcessEnabled = IsUnsafeLocalToolExecutionExposed(config, "process");

--- a/src/OpenClaw.Gateway/Tools/CanvasTools.cs
+++ b/src/OpenClaw.Gateway/Tools/CanvasTools.cs
@@ -76,6 +76,9 @@ internal abstract class CanvasToolBase : IToolWithContext
         error = $"Error: '{propertyName}' is required.";
         return false;
     }
+
+    protected int MaxPayloadBytesWithEnvelopeReserve()
+        => Math.Max(1, Config.Canvas.MaxCommandBytes - 4096);
 }
 
 internal sealed class CanvasPresentTool : CanvasToolBase
@@ -185,7 +188,7 @@ internal sealed class A2UiPushTool : CanvasToolBase
         if (!TryGetRequiredString(args.RootElement, "frames", out var frames, out var error))
             return error;
 
-        var validation = A2UiFrameValidator.ValidateJsonl(frames, Config.Canvas.MaxFramesPerPush, Config.Canvas.MaxCommandBytes);
+        var validation = A2UiFrameValidator.ValidateJsonl(frames, Config.Canvas.MaxFramesPerPush, MaxPayloadBytesWithEnvelopeReserve());
         if (!validation.IsValid)
             return $"Error: {validation.Error}";
 

--- a/src/OpenClaw.Gateway/Tools/CanvasTools.cs
+++ b/src/OpenClaw.Gateway/Tools/CanvasTools.cs
@@ -1,0 +1,248 @@
+using System.Text;
+using System.Text.Json;
+using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Canvas;
+using OpenClaw.Core.Models;
+
+namespace OpenClaw.Gateway.Tools;
+
+internal abstract class CanvasToolBase : IToolWithContext
+{
+    protected CanvasToolBase(CanvasCommandBroker broker, GatewayConfig config)
+    {
+        Broker = broker;
+        Config = config;
+    }
+
+    protected CanvasCommandBroker Broker { get; }
+    protected GatewayConfig Config { get; }
+
+    public abstract string Name { get; }
+    public abstract string Description { get; }
+    public abstract string ParameterSchema { get; }
+
+    public ValueTask<string> ExecuteAsync(string argumentsJson, CancellationToken ct)
+        => new("Error: Canvas tools require session context.");
+
+    public abstract ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct);
+
+    protected async ValueTask<string> SendAsync(
+        string argumentsJson,
+        ToolExecutionContext context,
+        WsServerEnvelope command,
+        string expectedResponseType,
+        string? requiredCapability,
+        CancellationToken ct)
+    {
+        var result = await Broker.SendCommandAsync(
+            context.Session,
+            command,
+            expectedResponseType,
+            requiredCapability,
+            ct);
+
+        if (!result.Success)
+            return $"Error: {result.Error}";
+
+        if (!string.IsNullOrWhiteSpace(result.SnapshotJson))
+            return result.SnapshotJson!;
+        if (!string.IsNullOrWhiteSpace(result.ValueJson))
+            return result.ValueJson!;
+
+        return $"Canvas command accepted. requestId={result.RequestId}";
+    }
+
+    protected static JsonDocument ParseArgs(string argumentsJson)
+        => JsonDocument.Parse(string.IsNullOrWhiteSpace(argumentsJson) ? "{}" : argumentsJson);
+
+    protected static string SurfaceId(JsonElement root)
+        => TryGetString(root, "surfaceId") ?? "main";
+
+    protected static string? TryGetString(JsonElement root, string propertyName)
+        => root.TryGetProperty(propertyName, out var prop) && prop.ValueKind == JsonValueKind.String
+            ? prop.GetString()
+            : null;
+
+    protected static bool TryGetRequiredString(JsonElement root, string propertyName, out string value, out string error)
+    {
+        if (TryGetString(root, propertyName) is { Length: > 0 } found)
+        {
+            value = found;
+            error = "";
+            return true;
+        }
+
+        value = "";
+        error = $"Error: '{propertyName}' is required.";
+        return false;
+    }
+}
+
+internal sealed class CanvasPresentTool : CanvasToolBase
+{
+    public CanvasPresentTool(CanvasCommandBroker broker, GatewayConfig config) : base(broker, config) { }
+    public override string Name => "canvas_present";
+    public override string Description => "Show the current session's Canvas visual workspace.";
+    public override string ParameterSchema => """{"type":"object","properties":{"surfaceId":{"type":"string","default":"main"}}}""";
+
+    public override async ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct)
+    {
+        using var args = ParseArgs(argumentsJson);
+        return await SendAsync(argumentsJson, context, new WsServerEnvelope
+        {
+            Type = "canvas_present",
+            SurfaceId = SurfaceId(args.RootElement)
+        }, "canvas_ack", "canvas.present", ct);
+    }
+}
+
+internal sealed class CanvasHideTool : CanvasToolBase
+{
+    public CanvasHideTool(CanvasCommandBroker broker, GatewayConfig config) : base(broker, config) { }
+    public override string Name => "canvas_hide";
+    public override string Description => "Hide the current session's Canvas visual workspace.";
+    public override string ParameterSchema => """{"type":"object","properties":{"surfaceId":{"type":"string","default":"main"}}}""";
+
+    public override async ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct)
+    {
+        using var args = ParseArgs(argumentsJson);
+        return await SendAsync(argumentsJson, context, new WsServerEnvelope
+        {
+            Type = "canvas_hide",
+            SurfaceId = SurfaceId(args.RootElement)
+        }, "canvas_ack", "canvas.hide", ct);
+    }
+}
+
+internal sealed class CanvasNavigateTool : CanvasToolBase
+{
+    public CanvasNavigateTool(CanvasCommandBroker broker, GatewayConfig config) : base(broker, config) { }
+    public override string Name => "canvas_navigate";
+    public override string Description => "Load local Canvas HTML, about:blank, or an openclaw-canvas:// artifact into the session Canvas. Remote HTTP/HTTPS pages are not supported by Canvas v1.";
+    public override string ParameterSchema => """
+        {"type":"object","properties":{"surfaceId":{"type":"string","default":"main"},"html":{"type":"string"},"url":{"type":"string"},"contentType":{"type":"string","default":"text/html"}}}
+        """;
+
+    public override async ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct)
+    {
+        using var args = ParseArgs(argumentsJson);
+        var root = args.RootElement;
+        var html = TryGetString(root, "html");
+        var url = TryGetString(root, "url");
+        if (string.IsNullOrWhiteSpace(html) && string.IsNullOrWhiteSpace(url))
+            return "Error: 'html' or 'url' is required.";
+        if (!string.IsNullOrWhiteSpace(html) && !Config.Canvas.EnableLocalHtml)
+            return "Error: local Canvas HTML is disabled.";
+        if (!string.IsNullOrWhiteSpace(url) && !IsAllowedCanvasUrl(url!))
+            return "Error: Canvas v1 only supports about:blank and openclaw-canvas:// URLs; use the browser tool for remote webpages.";
+
+        return await SendAsync(argumentsJson, context, new WsServerEnvelope
+        {
+            Type = "canvas_navigate",
+            SurfaceId = SurfaceId(root),
+            Html = html,
+            Url = url,
+            ContentType = TryGetString(root, "contentType") ?? "text/html"
+        }, "canvas_ack", string.IsNullOrWhiteSpace(html) ? "canvas.present" : "canvas.local_html", ct);
+    }
+
+    private static bool IsAllowedCanvasUrl(string url)
+        => string.Equals(url, "about:blank", StringComparison.OrdinalIgnoreCase) ||
+           url.StartsWith("openclaw-canvas://", StringComparison.OrdinalIgnoreCase);
+}
+
+internal sealed class CanvasSnapshotTool : CanvasToolBase
+{
+    public CanvasSnapshotTool(CanvasCommandBroker broker, GatewayConfig config) : base(broker, config) { }
+    public override string Name => "canvas_snapshot";
+    public override string Description => "Capture a lightweight JSON state snapshot of the current session Canvas.";
+    public override string ParameterSchema => """{"type":"object","properties":{"surfaceId":{"type":"string","default":"main"},"snapshotMode":{"type":"string","default":"state"}}}""";
+
+    public override async ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct)
+    {
+        using var args = ParseArgs(argumentsJson);
+        return await SendAsync(argumentsJson, context, new WsServerEnvelope
+        {
+            Type = "canvas_snapshot",
+            SurfaceId = SurfaceId(args.RootElement),
+            SnapshotMode = TryGetString(args.RootElement, "snapshotMode") ?? "state"
+        }, "canvas_snapshot_result", "snapshot.state", ct);
+    }
+}
+
+internal sealed class A2UiPushTool : CanvasToolBase
+{
+    public A2UiPushTool(CanvasCommandBroker broker, GatewayConfig config) : base(broker, config) { }
+    public override string Name => "a2ui_push";
+    public override string Description => "Push A2UI v0.8 JSONL frames to the current session Canvas.";
+    public override string ParameterSchema => """
+        {"type":"object","properties":{"surfaceId":{"type":"string","default":"main"},"frames":{"type":"string","description":"A2UI v0.8 JSONL frames"}},"required":["frames"]}
+        """;
+
+    public override async ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct)
+    {
+        using var args = ParseArgs(argumentsJson);
+        if (!TryGetRequiredString(args.RootElement, "frames", out var frames, out var error))
+            return error;
+
+        var validation = A2UiFrameValidator.ValidateJsonl(frames, Config.Canvas.MaxFramesPerPush, Config.Canvas.MaxCommandBytes);
+        if (!validation.IsValid)
+            return $"Error: {validation.Error}";
+
+        return await SendAsync(argumentsJson, context, new WsServerEnvelope
+        {
+            Type = "a2ui_push",
+            SurfaceId = SurfaceId(args.RootElement),
+            ContentType = A2UiFrameValidator.ContentTypeV08,
+            Frames = frames
+        }, "canvas_ack", "a2ui.v0_8", ct);
+    }
+}
+
+internal sealed class A2UiResetTool : CanvasToolBase
+{
+    public A2UiResetTool(CanvasCommandBroker broker, GatewayConfig config) : base(broker, config) { }
+    public override string Name => "a2ui_reset";
+    public override string Description => "Clear A2UI-rendered content from the current session Canvas.";
+    public override string ParameterSchema => """{"type":"object","properties":{"surfaceId":{"type":"string","default":"main"}}}""";
+
+    public override async ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct)
+    {
+        using var args = ParseArgs(argumentsJson);
+        return await SendAsync(argumentsJson, context, new WsServerEnvelope
+        {
+            Type = "a2ui_reset",
+            SurfaceId = SurfaceId(args.RootElement)
+        }, "canvas_ack", "a2ui.v0_8", ct);
+    }
+}
+
+internal sealed class A2UiEvalTool : CanvasToolBase
+{
+    public A2UiEvalTool(CanvasCommandBroker broker, GatewayConfig config) : base(broker, config) { }
+    public override string Name => "a2ui_eval";
+    public override string Description => "Run JavaScript in the local A2UI Canvas sandbox. This does not evaluate scripts on remote webpages.";
+    public override string ParameterSchema => """
+        {"type":"object","properties":{"surfaceId":{"type":"string","default":"main"},"script":{"type":"string"}},"required":["script"]}
+        """;
+
+    public override async ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct)
+    {
+        if (!Config.Canvas.EnableEval)
+            return "Error: A2UI eval is disabled.";
+
+        using var args = ParseArgs(argumentsJson);
+        if (!TryGetRequiredString(args.RootElement, "script", out var script, out var error))
+            return error;
+
+        if (Encoding.UTF8.GetByteCount(script) > Math.Max(1, Config.Canvas.MaxCommandBytes))
+            return $"Error: script exceeds {Config.Canvas.MaxCommandBytes} bytes.";
+
+        return await SendAsync(argumentsJson, context, new WsServerEnvelope
+        {
+            Type = "a2ui_eval",
+            SurfaceId = SurfaceId(args.RootElement),
+            Script = script
+        }, "canvas_eval_result", "a2ui.eval", ct);
+    }
+}

--- a/src/OpenClaw.Gateway/wwwroot/webchat.html
+++ b/src/OpenClaw.Gateway/wwwroot/webchat.html
@@ -1654,7 +1654,7 @@
             if (!ws || ws.readyState !== WebSocket.OPEN) return;
             ws.send(JSON.stringify({
                 type: 'canvas_ready',
-                capabilities: ['a2ui.v0_8', 'canvas.present', 'canvas.hide', 'canvas.local_html', 'a2ui.eval', 'snapshot.state']
+                capabilities: ['a2ui.v0_8', 'canvas.present', 'canvas.hide', 'canvas.local_html', 'snapshot.state']
             }));
         }
 
@@ -1931,12 +1931,10 @@
         }
 
         function renderA2uiImage(parent, frame) {
-            const img = document.createElement('img');
-            img.src = frame.url || frame.src || '';
-            img.alt = frame.alt || frame.label || '';
-            img.style.maxWidth = '100%';
-            img.style.borderRadius = '8px';
-            parent.appendChild(img);
+            const note = document.createElement('div');
+            note.className = 'a2ui-muted';
+            note.textContent = frame.alt || frame.label || 'Image URL omitted by Canvas security policy.';
+            parent.appendChild(note);
         }
 
         function renderA2uiProgress(parent, frame) {
@@ -2009,27 +2007,14 @@
         }
 
         function handleA2uiEval(env) {
-            try {
-                const fn = new Function('root', 'frames', 'values', String(env.script || ''));
-                const result = fn(a2uiRoot, canvasFrames, canvasValues);
-                ws.send(JSON.stringify({
-                    type: 'canvas_eval_result',
-                    requestId: env.requestId,
-                    sessionId: canvasSessionId,
-                    surfaceId: env.surfaceId || 'main',
-                    success: true,
-                    valueJson: JSON.stringify(result ?? null)
-                }));
-            } catch (error) {
-                ws.send(JSON.stringify({
-                    type: 'canvas_eval_result',
-                    requestId: env.requestId,
-                    sessionId: canvasSessionId,
-                    surfaceId: env.surfaceId || 'main',
-                    success: false,
-                    error: String(error?.message || error)
-                }));
-            }
+            ws.send(JSON.stringify({
+                type: 'canvas_eval_result',
+                requestId: env.requestId,
+                sessionId: canvasSessionId,
+                surfaceId: env.surfaceId || 'main',
+                success: false,
+                error: 'Webchat Canvas does not support a2ui_eval because browser-side script execution is disabled.'
+            }));
         }
 
         function connect() {

--- a/src/OpenClaw.Gateway/wwwroot/webchat.html
+++ b/src/OpenClaw.Gateway/wwwroot/webchat.html
@@ -257,6 +257,13 @@
 
         /* ============================== Chat Stream ============================== */
 
+        #workspace {
+            flex-grow: 1;
+            min-height: 0;
+            display: flex;
+            background: var(--bg);
+        }
+
         #chat-wrapper {
             flex-grow: 1;
             overflow-y: auto;
@@ -264,6 +271,124 @@
             justify-content: center;
             scroll-behavior: smooth;
             background: var(--bg);
+        }
+
+        #canvas-panel {
+            width: min(44vw, 560px);
+            min-width: 360px;
+            border-right: 1px solid var(--separator);
+            background: #101012;
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
+        }
+
+        #canvas-panel[hidden] {
+            display: none;
+        }
+
+        #canvas-header {
+            height: 42px;
+            padding: 0 1rem;
+            border-bottom: 1px solid var(--separator);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            color: var(--text-secondary);
+            font-size: 0.8125rem;
+        }
+
+        #canvas-header strong {
+            color: var(--text);
+            font-weight: 600;
+        }
+
+        #canvas-surface {
+            min-height: 0;
+            flex: 1;
+            overflow: auto;
+            padding: 1rem;
+        }
+
+        #canvas-html-frame {
+            width: 100%;
+            min-height: 420px;
+            border: 1px solid var(--separator);
+            border-radius: 8px;
+            background: white;
+        }
+
+        #a2ui-root {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .a2ui-card,
+        .a2ui-frame {
+            border: 1px solid var(--separator-strong);
+            background: rgba(255, 255, 255, 0.045);
+            border-radius: 8px;
+            padding: 0.875rem;
+        }
+
+        .a2ui-title {
+            font-weight: 650;
+            margin-bottom: 0.35rem;
+        }
+
+        .a2ui-muted {
+            color: var(--text-secondary);
+            font-size: 0.8125rem;
+        }
+
+        .a2ui-control {
+            width: 100%;
+            min-height: 34px;
+            border-radius: 8px;
+            border: 1px solid var(--separator-strong);
+            background: var(--bg-field);
+            color: var(--text);
+            padding: 0.45rem 0.6rem;
+            font: inherit;
+        }
+
+        .a2ui-button {
+            min-height: 34px;
+            border: 0;
+            border-radius: 8px;
+            background: var(--accent);
+            color: white;
+            padding: 0.45rem 0.75rem;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .a2ui-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.875rem;
+        }
+
+        .a2ui-table th,
+        .a2ui-table td {
+            border-bottom: 1px solid var(--separator);
+            padding: 0.45rem;
+            text-align: left;
+            vertical-align: top;
+        }
+
+        .a2ui-progress {
+            width: 100%;
+            accent-color: var(--accent);
+        }
+
+        .a2ui-chart-bar {
+            height: 22px;
+            min-width: 2px;
+            border-radius: 5px;
+            background: var(--accent);
         }
 
         #chat-state-bar {
@@ -715,6 +840,18 @@
                 max-width: 82%;
             }
 
+            #workspace {
+                flex-direction: column;
+            }
+
+            #canvas-panel {
+                width: 100%;
+                min-width: 0;
+                max-height: 45vh;
+                border-right: 0;
+                border-bottom: 1px solid var(--separator);
+            }
+
             #token-input,
             #voice-id-input {
                 width: 160px;
@@ -755,16 +892,29 @@
         </div>
     </div>
 
-    <div id="chat-wrapper">
-        <div id="chat-container">
-            <div id="chat-state-bar"></div>
-            <!-- Messages will render here -->
-            <div class="message-row typing-row" id="typing-row">
-                <div class="agent-avatar"><img src="image.png" alt="Agent" /></div>
-                <div class="typing-indicator">
-                    <div class="dot"></div>
-                    <div class="dot"></div>
-                    <div class="dot"></div>
+    <div id="workspace">
+        <section id="canvas-panel" aria-label="Canvas" hidden>
+            <div id="canvas-header">
+                <strong>Canvas</strong>
+                <span id="canvas-status">Ready</span>
+            </div>
+            <div id="canvas-surface">
+                <iframe id="canvas-html-frame" title="Canvas HTML" sandbox="allow-scripts" hidden></iframe>
+                <div id="a2ui-root"></div>
+            </div>
+        </section>
+
+        <div id="chat-wrapper">
+            <div id="chat-container">
+                <div id="chat-state-bar"></div>
+                <!-- Messages will render here -->
+                <div class="message-row typing-row" id="typing-row">
+                    <div class="agent-avatar"><img src="image.png" alt="Agent" /></div>
+                    <div class="typing-indicator">
+                        <div class="dot"></div>
+                        <div class="dot"></div>
+                        <div class="dot"></div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -836,6 +986,10 @@
         const liveStatusBadge = document.getElementById('live-status-badge');
         const chatStateBar = document.getElementById('chat-state-bar');
         const typingRow = document.getElementById('typing-row');
+        const canvasPanel = document.getElementById('canvas-panel');
+        const canvasStatus = document.getElementById('canvas-status');
+        const canvasHtmlFrame = document.getElementById('canvas-html-frame');
+        const a2uiRoot = document.getElementById('a2ui-root');
         const TOKEN_KEY_PERSIST = 'openclaw_token';
         const TOKEN_KEY_SESSION = 'openclaw_token_session';
 
@@ -853,6 +1007,11 @@
         let liveAudioContext = null;
         let liveAudioSource = null;
         let liveAudioProcessor = null;
+        let canvasSessionId = null;
+        let canvasEventSequence = 0;
+        let canvasFrames = [];
+        let canvasValues = {};
+        let canvasDiagnostics = [];
 
         const WEBCHAT_CONFIG = {
             streamRenderDebounceMs: Math.max(20, Number(window.OPENCLAW_WEBCHAT_CONFIG?.streamRenderDebounceMs ?? 120)),
@@ -1491,6 +1650,388 @@
             liveMicButton.textContent = 'Mic';
         }
 
+        function sendCanvasReady() {
+            if (!ws || ws.readyState !== WebSocket.OPEN) return;
+            ws.send(JSON.stringify({
+                type: 'canvas_ready',
+                capabilities: ['a2ui.v0_8', 'canvas.present', 'canvas.hide', 'canvas.local_html', 'a2ui.eval', 'snapshot.state']
+            }));
+        }
+
+        function isCanvasEnvelopeType(type) {
+            return ['canvas_present', 'canvas_hide', 'canvas_navigate', 'canvas_snapshot', 'a2ui_push', 'a2ui_reset', 'a2ui_eval'].includes(type);
+        }
+
+        function sendCanvasAck(env, success = true, error = null) {
+            if (!ws || ws.readyState !== WebSocket.OPEN) return;
+            ws.send(JSON.stringify({
+                type: 'canvas_ack',
+                requestId: env.requestId,
+                sessionId: canvasSessionId,
+                surfaceId: env.surfaceId || 'main',
+                success,
+                error
+            }));
+        }
+
+        function showCanvas() {
+            canvasPanel.hidden = false;
+            canvasStatus.textContent = 'Visible';
+        }
+
+        function hideCanvas() {
+            canvasPanel.hidden = true;
+            canvasStatus.textContent = 'Hidden';
+        }
+
+        function resetA2ui() {
+            canvasFrames = [];
+            canvasValues = {};
+            canvasDiagnostics = [];
+            a2uiRoot.innerHTML = '';
+            a2uiRoot.hidden = false;
+            canvasHtmlFrame.hidden = true;
+            canvasHtmlFrame.removeAttribute('srcdoc');
+            canvasStatus.textContent = 'Reset';
+        }
+
+        function handleCanvasEnvelope(env) {
+            canvasSessionId = env.sessionId || canvasSessionId;
+            try {
+                switch (env.type) {
+                    case 'canvas_present':
+                        showCanvas();
+                        sendCanvasAck(env);
+                        break;
+                    case 'canvas_hide':
+                        hideCanvas();
+                        sendCanvasAck(env);
+                        break;
+                    case 'canvas_navigate':
+                        handleCanvasNavigate(env);
+                        break;
+                    case 'a2ui_reset':
+                        resetA2ui();
+                        sendCanvasAck(env);
+                        break;
+                    case 'a2ui_push':
+                        handleA2uiPush(env);
+                        break;
+                    case 'canvas_snapshot':
+                        sendCanvasSnapshot(env);
+                        break;
+                    case 'a2ui_eval':
+                        handleA2uiEval(env);
+                        break;
+                }
+            } catch (error) {
+                const message = String(error?.message || error);
+                canvasDiagnostics.push(message);
+                sendCanvasAck(env, false, message);
+            }
+        }
+
+        function handleCanvasNavigate(env) {
+            showCanvas();
+            if (env.html) {
+                canvasHtmlFrame.hidden = false;
+                a2uiRoot.hidden = true;
+                canvasHtmlFrame.srcdoc = env.html;
+                canvasStatus.textContent = 'Local HTML';
+                sendCanvasAck(env);
+                return;
+            }
+            if (!env.url || env.url === 'about:blank') {
+                resetA2ui();
+                showCanvas();
+                sendCanvasAck(env);
+                return;
+            }
+            if (String(env.url).startsWith('openclaw-canvas://')) {
+                sendCanvasAck(env, false, 'openclaw-canvas:// artifact loading is not implemented in webchat v1.');
+                return;
+            }
+            sendCanvasAck(env, false, 'Canvas v1 rejects remote webpage navigation; use the browser tool.');
+        }
+
+        function handleA2uiPush(env) {
+            showCanvas();
+            canvasHtmlFrame.hidden = true;
+            a2uiRoot.hidden = false;
+            const lines = String(env.frames || '').split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+            for (const line of lines) {
+                const frame = JSON.parse(line);
+                canvasFrames.push(frame);
+                renderA2uiFrame(frame, env.surfaceId || 'main');
+            }
+            canvasStatus.textContent = `${lines.length} frame${lines.length === 1 ? '' : 's'}`;
+            sendCanvasAck(env);
+        }
+
+        function renderA2uiFrame(frame, surfaceId) {
+            const wrap = document.createElement('div');
+            wrap.className = frame.type === 'card' ? 'a2ui-card' : 'a2ui-frame';
+            wrap.dataset.frameId = frame.id || '';
+            wrap.dataset.type = frame.type || '';
+            const title = frame.title || frame.label;
+            if (title && frame.type !== 'button') {
+                const titleEl = document.createElement('div');
+                titleEl.className = 'a2ui-title';
+                titleEl.textContent = title;
+                wrap.appendChild(titleEl);
+            }
+            switch (frame.type) {
+                case 'text':
+                case 'markdown':
+                    appendMarkdownOrText(wrap, frame.text || '', frame.type === 'markdown');
+                    break;
+                case 'card':
+                    appendMarkdownOrText(wrap, frame.body || frame.text || '', true);
+                    break;
+                case 'button':
+                    renderA2uiButton(wrap, frame, surfaceId);
+                    break;
+                case 'input':
+                    renderA2uiInput(wrap, frame, surfaceId);
+                    break;
+                case 'select':
+                    renderA2uiSelect(wrap, frame, surfaceId);
+                    break;
+                case 'checklist':
+                    renderA2uiChecklist(wrap, frame, surfaceId);
+                    break;
+                case 'table':
+                    renderA2uiTable(wrap, frame);
+                    break;
+                case 'image':
+                    renderA2uiImage(wrap, frame);
+                    break;
+                case 'progress':
+                    renderA2uiProgress(wrap, frame);
+                    break;
+                case 'chart':
+                    renderA2uiChart(wrap, frame);
+                    break;
+                default:
+                    wrap.textContent = `Unsupported A2UI frame: ${frame.type}`;
+                    canvasDiagnostics.push(`Unsupported A2UI frame: ${frame.type}`);
+                    break;
+            }
+            a2uiRoot.appendChild(wrap);
+        }
+
+        function appendMarkdownOrText(parent, value, markdown) {
+            const div = document.createElement('div');
+            if (markdown) {
+                div.innerHTML = sanitizeRenderedHtml(marked.parse(String(value || '')));
+            } else {
+                div.textContent = String(value || '');
+            }
+            parent.appendChild(div);
+        }
+
+        function renderA2uiButton(parent, frame, surfaceId) {
+            const button = document.createElement('button');
+            button.className = 'a2ui-button';
+            button.type = 'button';
+            button.textContent = frame.label || frame.text || 'Button';
+            button.addEventListener('click', () => sendA2uiEvent(surfaceId, frame.id, 'click', true));
+            parent.appendChild(button);
+        }
+
+        function renderA2uiInput(parent, frame, surfaceId) {
+            const input = document.createElement('input');
+            input.className = 'a2ui-control';
+            input.placeholder = frame.placeholder || frame.label || '';
+            input.value = frame.value || '';
+            canvasValues[frame.id] = input.value;
+            input.addEventListener('change', () => {
+                canvasValues[frame.id] = input.value;
+                sendA2uiEvent(surfaceId, frame.id, 'change', input.value);
+            });
+            parent.appendChild(input);
+        }
+
+        function normalizeOptions(frame) {
+            return Array.isArray(frame.options) ? frame.options.map(option => {
+                if (typeof option === 'string') return { label: option, value: option };
+                return {
+                    label: option.label ?? option.text ?? option.value ?? 'option',
+                    value: option.value ?? option.label ?? option.text ?? 'option',
+                    selected: Boolean(option.selected)
+                };
+            }) : [];
+        }
+
+        function renderA2uiSelect(parent, frame, surfaceId) {
+            const select = document.createElement('select');
+            select.className = 'a2ui-control';
+            for (const option of normalizeOptions(frame)) {
+                const el = document.createElement('option');
+                el.value = option.value;
+                el.textContent = option.label;
+                el.selected = option.selected;
+                select.appendChild(el);
+            }
+            canvasValues[frame.id] = select.value;
+            select.addEventListener('change', () => {
+                canvasValues[frame.id] = select.value;
+                sendA2uiEvent(surfaceId, frame.id, 'change', select.value);
+            });
+            parent.appendChild(select);
+        }
+
+        function renderA2uiChecklist(parent, frame, surfaceId) {
+            const group = document.createElement('div');
+            for (const option of normalizeOptions(frame)) {
+                const label = document.createElement('label');
+                label.className = 'a2ui-muted';
+                const checkbox = document.createElement('input');
+                checkbox.type = 'checkbox';
+                checkbox.checked = Boolean(option.selected);
+                checkbox.addEventListener('change', () => {
+                    canvasValues[`${frame.id}:${option.value}`] = checkbox.checked;
+                    sendA2uiEvent(surfaceId, frame.id, 'change', { value: option.value, selected: checkbox.checked });
+                });
+                label.appendChild(checkbox);
+                label.append(` ${option.label}`);
+                group.appendChild(label);
+                group.appendChild(document.createElement('br'));
+            }
+            parent.appendChild(group);
+        }
+
+        function renderA2uiTable(parent, frame) {
+            const table = document.createElement('table');
+            table.className = 'a2ui-table';
+            if (Array.isArray(frame.columns)) {
+                const thead = document.createElement('thead');
+                const tr = document.createElement('tr');
+                for (const column of frame.columns) {
+                    const th = document.createElement('th');
+                    th.textContent = String(column);
+                    tr.appendChild(th);
+                }
+                thead.appendChild(tr);
+                table.appendChild(thead);
+            }
+            const tbody = document.createElement('tbody');
+            for (const row of Array.isArray(frame.rows) ? frame.rows : []) {
+                const tr = document.createElement('tr');
+                const cells = Array.isArray(row) ? row : Object.values(row || {});
+                for (const cell of cells) {
+                    const td = document.createElement('td');
+                    td.textContent = String(cell ?? '');
+                    tr.appendChild(td);
+                }
+                tbody.appendChild(tr);
+            }
+            table.appendChild(tbody);
+            parent.appendChild(table);
+        }
+
+        function renderA2uiImage(parent, frame) {
+            const img = document.createElement('img');
+            img.src = frame.url || frame.src || '';
+            img.alt = frame.alt || frame.label || '';
+            img.style.maxWidth = '100%';
+            img.style.borderRadius = '8px';
+            parent.appendChild(img);
+        }
+
+        function renderA2uiProgress(parent, frame) {
+            const progress = document.createElement('progress');
+            progress.className = 'a2ui-progress';
+            progress.max = Number(frame.max ?? 100);
+            const raw = Number(frame.value ?? 0);
+            progress.value = raw <= 1 && progress.max === 100 ? raw * 100 : raw;
+            parent.appendChild(progress);
+        }
+
+        function renderA2uiChart(parent, frame) {
+            const data = Array.isArray(frame.data) ? frame.data : [];
+            if (!data.length) {
+                appendMarkdownOrText(parent, JSON.stringify(frame.data ?? {}, null, 2), false);
+                return;
+            }
+            const max = Math.max(...data.map(item => Number(item.value ?? item.y ?? 0)), 1);
+            for (const item of data) {
+                const label = document.createElement('div');
+                label.className = 'a2ui-muted';
+                label.textContent = String(item.label ?? item.x ?? '');
+                const bar = document.createElement('div');
+                bar.className = 'a2ui-chart-bar';
+                bar.style.width = `${Math.max(2, (Number(item.value ?? item.y ?? 0) / max) * 100)}%`;
+                parent.appendChild(label);
+                parent.appendChild(bar);
+            }
+        }
+
+        function sendA2uiEvent(surfaceId, componentId, eventName, value) {
+            if (!ws || ws.readyState !== WebSocket.OPEN) return;
+            ws.send(JSON.stringify({
+                type: 'a2ui_event',
+                sessionId: canvasSessionId,
+                surfaceId: surfaceId || 'main',
+                componentId,
+                event: eventName,
+                valueJson: JSON.stringify(value ?? null),
+                sequence: ++canvasEventSequence
+            }));
+        }
+
+        function sendCanvasSnapshot(env) {
+            const snapshot = {
+                type: 'canvas_snapshot',
+                surfaceId: env.surfaceId || 'main',
+                visible: !canvasPanel.hidden,
+                frameCount: canvasFrames.length,
+                frames: canvasFrames.map(frame => ({
+                    id: frame.id,
+                    type: frame.type,
+                    title: frame.title,
+                    label: frame.label,
+                    text: frame.text
+                })),
+                values: canvasValues,
+                diagnostics: canvasDiagnostics,
+                localHtmlText: canvasHtmlFrame.hidden ? null : canvasHtmlFrame.srcdoc
+            };
+            ws.send(JSON.stringify({
+                type: 'canvas_snapshot_result',
+                requestId: env.requestId,
+                sessionId: canvasSessionId,
+                surfaceId: env.surfaceId || 'main',
+                snapshotMode: env.snapshotMode || 'state',
+                success: true,
+                snapshotJson: JSON.stringify(snapshot)
+            }));
+        }
+
+        function handleA2uiEval(env) {
+            try {
+                const fn = new Function('root', 'frames', 'values', String(env.script || ''));
+                const result = fn(a2uiRoot, canvasFrames, canvasValues);
+                ws.send(JSON.stringify({
+                    type: 'canvas_eval_result',
+                    requestId: env.requestId,
+                    sessionId: canvasSessionId,
+                    surfaceId: env.surfaceId || 'main',
+                    success: true,
+                    valueJson: JSON.stringify(result ?? null)
+                }));
+            } catch (error) {
+                ws.send(JSON.stringify({
+                    type: 'canvas_eval_result',
+                    requestId: env.requestId,
+                    sessionId: canvasSessionId,
+                    surfaceId: env.surfaceId || 'main',
+                    success: false,
+                    error: String(error?.message || error)
+                }));
+            }
+        }
+
         function connect() {
             appendSystem('Connecting to OpenClaw.NET Gateway...');
             const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -1512,6 +2053,7 @@
                 }
                 refreshChatState();
                 appendSystem('Connected successfully.');
+                sendCanvasReady();
                 updateComposerAvailability();
                 messageInput.focus();
             };
@@ -1519,6 +2061,11 @@
             ws.onmessage = (event) => {
                 try {
                     const env = JSON.parse(event.data);
+
+                    if (isCanvasEnvelopeType(env.type)) {
+                        handleCanvasEnvelope(env);
+                        return;
+                    }
 
                     switch (env.type) {
                         case 'typing_start':

--- a/src/OpenClaw.Tests/A2UiFrameValidatorTests.cs
+++ b/src/OpenClaw.Tests/A2UiFrameValidatorTests.cs
@@ -1,0 +1,68 @@
+using OpenClaw.Core.Canvas;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class A2UiFrameValidatorTests
+{
+    [Fact]
+    public void ValidateJsonl_AcceptsSupportedV08Frames()
+    {
+        var frames = string.Join('\n',
+            """{"type":"text","id":"txt","text":"Hello"}""",
+            """{"type":"button","id":"ok","label":"OK"}""",
+            """{"type":"table","id":"tbl","columns":["Name"],"rows":[["A"]]}""",
+            """{"type":"progress","id":"prog","value":0.5}""");
+
+        var result = A2UiFrameValidator.ValidateJsonl(frames, maxFrames: 10, maxBytes: 4096);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(4, result.FrameCount);
+    }
+
+    [Fact]
+    public void ValidateJsonl_RejectsInvalidJson()
+    {
+        var result = A2UiFrameValidator.ValidateJsonl("""{"type":"text","id":"bad","text":""", maxFrames: 10, maxBytes: 4096);
+
+        Assert.False(result.IsValid);
+        Assert.Contains("not valid JSON", result.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateJsonl_RejectsCreateSurfaceV09Frame()
+    {
+        var result = A2UiFrameValidator.ValidateJsonl("""{"type":"createSurface","id":"surface"}""", maxFrames: 10, maxBytes: 4096);
+
+        Assert.False(result.IsValid);
+        Assert.Contains("createSurface", result.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateJsonl_RejectsFrameAndSizeLimits()
+    {
+        var tooMany = A2UiFrameValidator.ValidateJsonl(
+            """
+            {"type":"text","id":"a","text":"A"}
+            {"type":"text","id":"b","text":"B"}
+            """,
+            maxFrames: 1,
+            maxBytes: 4096);
+
+        var tooLarge = A2UiFrameValidator.ValidateJsonl("""{"type":"text","id":"a","text":"A"}""", maxFrames: 10, maxBytes: 4);
+
+        Assert.False(tooMany.IsValid);
+        Assert.Contains("exceeds 1 frames", tooMany.Error, StringComparison.Ordinal);
+        Assert.False(tooLarge.IsValid);
+        Assert.Contains("exceeds 4 bytes", tooLarge.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateJsonl_RejectsMissingTypeSpecificFields()
+    {
+        var result = A2UiFrameValidator.ValidateJsonl("""{"type":"select","id":"choice"}""", maxFrames: 10, maxBytes: 4096);
+
+        Assert.False(result.IsValid);
+        Assert.Contains("options", result.Error, StringComparison.Ordinal);
+    }
+}

--- a/src/OpenClaw.Tests/CanvasCommandBrokerTests.cs
+++ b/src/OpenClaw.Tests/CanvasCommandBrokerTests.cs
@@ -1,0 +1,212 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenClaw.Channels;
+using OpenClaw.Core.Models;
+using OpenClaw.Gateway;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class CanvasCommandBrokerTests
+{
+    [Fact]
+    public async Task SendCommandAsync_SendsToEnvelopeClientAndCompletesOnAck()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel);
+        await broker.HandleClientEnvelopeAsync("client", Ready("canvas.present"), CancellationToken.None);
+
+        var task = broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope { Type = "canvas_present" },
+            "canvas_ack",
+            "canvas.present",
+            CancellationToken.None);
+
+        var sent = await WaitForSentEnvelopeAsync(ws);
+        Assert.Equal("canvas_present", sent.Type);
+        Assert.Equal("sess", sent.SessionId);
+
+        await broker.HandleClientEnvelopeAsync("client", new WsClientEnvelope
+        {
+            Type = "canvas_ack",
+            RequestId = sent.RequestId,
+            SessionId = "sess",
+            Success = true
+        }, CancellationToken.None);
+
+        var result = await task;
+
+        Assert.True(result.Success);
+        Assert.Equal(sent.RequestId, result.RequestId);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_TimesOutWhenClientDoesNotRespond()
+    {
+        var config = new GatewayConfig { Canvas = new CanvasConfig { CommandTimeoutSeconds = 1 } };
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel, config);
+        await broker.HandleClientEnvelopeAsync("client", Ready("canvas.present"), CancellationToken.None);
+
+        var result = await broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope { Type = "canvas_present" },
+            "canvas_ack",
+            "canvas.present",
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("timed out", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_RejectsDisconnectedClient()
+    {
+        var broker = CreateBroker(new WebSocketChannel(new WebSocketConfig()));
+
+        var result = await broker.SendCommandAsync(
+            Session("sess", "missing"),
+            new WsServerEnvelope { Type = "canvas_present" },
+            "canvas_ack",
+            "canvas.present",
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("not connected", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_RejectsMissingCapability()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        Assert.True(channel.TryAddConnectionForTest("client", new TestWebSocket(), IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel);
+
+        var result = await broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope { Type = "canvas_present" },
+            "canvas_ack",
+            "canvas.present",
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("not advertised", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_RejectsWrongSessionResult()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel);
+        await broker.HandleClientEnvelopeAsync("client", Ready("canvas.present"), CancellationToken.None);
+
+        var task = broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope { Type = "canvas_present" },
+            "canvas_ack",
+            "canvas.present",
+            CancellationToken.None);
+
+        var sent = await WaitForSentEnvelopeAsync(ws);
+        await broker.HandleClientEnvelopeAsync("client", new WsClientEnvelope
+        {
+            Type = "canvas_ack",
+            RequestId = sent.RequestId,
+            SessionId = "other",
+            Success = true
+        }, CancellationToken.None);
+
+        var result = await task;
+
+        Assert.False(result.Success);
+        Assert.Contains("session id", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_RejectsOversizedSnapshot()
+    {
+        var config = new GatewayConfig
+        {
+            Canvas = new CanvasConfig
+            {
+                MaxSnapshotBytes = 8
+            }
+        };
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel, config);
+        await broker.HandleClientEnvelopeAsync("client", Ready("snapshot.state"), CancellationToken.None);
+
+        var task = broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope { Type = "canvas_snapshot" },
+            "canvas_snapshot_result",
+            "snapshot.state",
+            CancellationToken.None);
+
+        var sent = await WaitForSentEnvelopeAsync(ws);
+        await broker.HandleClientEnvelopeAsync("client", new WsClientEnvelope
+        {
+            Type = "canvas_snapshot_result",
+            RequestId = sent.RequestId,
+            SessionId = "sess",
+            Success = true,
+            SnapshotJson = """{"text":"oversized"}"""
+        }, CancellationToken.None);
+
+        var result = await task;
+
+        Assert.False(result.Success);
+        Assert.Contains("snapshot exceeds", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CanvasCommandBroker CreateBroker(WebSocketChannel channel, GatewayConfig? config = null)
+        => new(
+            config ?? new GatewayConfig(),
+            channel,
+            new RuntimeEventStore(
+                Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N")),
+                NullLogger<RuntimeEventStore>.Instance));
+
+    private static WsClientEnvelope Ready(params string[] capabilities)
+        => new()
+        {
+            Type = "canvas_ready",
+            Capabilities = capabilities
+        };
+
+    private static Session Session(string id, string senderId)
+        => new()
+        {
+            Id = id,
+            ChannelId = "websocket",
+            SenderId = senderId
+        };
+
+    private static async Task<WsServerEnvelope> WaitForSentEnvelopeAsync(TestWebSocket ws)
+    {
+        for (var attempt = 0; attempt < 100; attempt++)
+        {
+            if (ws.Sent.Count > 0)
+            {
+                var payload = Encoding.UTF8.GetString(ws.Sent.Last());
+                return JsonSerializer.Deserialize(payload, CoreJsonContext.Default.WsServerEnvelope)
+                    ?? throw new InvalidOperationException("Sent payload was not a websocket envelope.");
+            }
+
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException("Timed out waiting for websocket send.");
+    }
+}

--- a/src/OpenClaw.Tests/CanvasToolTests.cs
+++ b/src/OpenClaw.Tests/CanvasToolTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenClaw.Channels;
+using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Observability;
+using OpenClaw.Gateway;
+using OpenClaw.Gateway.Tools;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class CanvasToolTests
+{
+    [Fact]
+    public async Task CanvasPresent_RejectsNonWebSocketSession()
+    {
+        var tool = new CanvasPresentTool(CreateBroker(), new GatewayConfig());
+
+        var result = await tool.ExecuteAsync("{}", Context(channelId: "cli"), CancellationToken.None);
+
+        Assert.Contains("websocket session", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("http://example.com")]
+    [InlineData("https://example.com")]
+    public async Task CanvasNavigate_RejectsRemoteWebpageUrls(string url)
+    {
+        var tool = new CanvasNavigateTool(CreateBroker(), new GatewayConfig());
+
+        var result = await tool.ExecuteAsync($$"""{"url":"{{url}}"}""", Context(), CancellationToken.None);
+
+        Assert.Contains("only supports about:blank and openclaw-canvas://", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task A2UiPush_RejectsCreateSurfaceV09()
+    {
+        var tool = new A2UiPushTool(CreateBroker(), new GatewayConfig());
+
+        var result = await tool.ExecuteAsync(
+            """{"frames":"{\"type\":\"createSurface\",\"id\":\"main\"}"}""",
+            Context(),
+            CancellationToken.None);
+
+        Assert.Contains("createSurface", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A2UiPush_MissingFramesReturnsToolError()
+    {
+        var tool = new A2UiPushTool(CreateBroker(), new GatewayConfig());
+
+        var result = await tool.ExecuteAsync("{}", Context(), CancellationToken.None);
+
+        Assert.Contains("'frames' is required", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A2UiEval_RespectsEvalDisableConfig()
+    {
+        var config = new GatewayConfig
+        {
+            Canvas = new CanvasConfig
+            {
+                EnableEval = false
+            }
+        };
+        var tool = new A2UiEvalTool(CreateBroker(config: config), config);
+
+        var result = await tool.ExecuteAsync("""{"script":"return 1"}""", Context(), CancellationToken.None);
+
+        Assert.Contains("eval is disabled", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CanvasCommandBroker CreateBroker(GatewayConfig? config = null)
+        => new(
+            config ?? new GatewayConfig(),
+            new WebSocketChannel(new WebSocketConfig()),
+            new RuntimeEventStore(
+                Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N")),
+                NullLogger<RuntimeEventStore>.Instance));
+
+    private static ToolExecutionContext Context(string channelId = "websocket")
+        => new()
+        {
+            Session = new Session
+            {
+                Id = "sess",
+                ChannelId = channelId,
+                SenderId = "client"
+            },
+            TurnContext = new TurnContext
+            {
+                SessionId = "sess",
+                ChannelId = channelId
+            }
+        };
+}

--- a/src/OpenClaw.Tests/CanvasToolTests.cs
+++ b/src/OpenClaw.Tests/CanvasToolTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenClaw.Channels;
 using OpenClaw.Core.Abstractions;
@@ -54,6 +55,24 @@ public sealed class CanvasToolTests
         var result = await tool.ExecuteAsync("{}", Context(), CancellationToken.None);
 
         Assert.Contains("'frames' is required", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A2UiPush_UsesEnvelopeReserveForPayloadLimit()
+    {
+        var config = new GatewayConfig
+        {
+            Canvas = new CanvasConfig
+            {
+                MaxCommandBytes = 4_200
+            }
+        };
+        var tool = new A2UiPushTool(CreateBroker(config: config), config);
+        var frames = $$"""{"type":"text","id":"large","text":"{{new string('x', 200)}}"}""";
+
+        var result = await tool.ExecuteAsync(JsonSerializer.Serialize(new { frames }), Context(), CancellationToken.None);
+
+        Assert.Contains("exceeds 104 bytes", result, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/OpenClaw.Tests/CompanionCanvasTests.cs
+++ b/src/OpenClaw.Tests/CompanionCanvasTests.cs
@@ -104,6 +104,47 @@ public sealed class CompanionCanvasTests : IDisposable
         Assert.True(doc.RootElement.GetProperty("visible").GetBoolean());
     }
 
+    [Fact]
+    public void A2UiFrameItem_ClampsNegativeProgressToZero()
+    {
+        using var doc = JsonDocument.Parse("""{"type":"progress","id":"p","value":-0.25}""");
+
+        var item = A2UiFrameItem.FromJson("main", doc.RootElement, (_, _, _) => Task.CompletedTask);
+
+        Assert.Equal(0, item.ProgressValue);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_SnapshotBoundsReturnedFrames()
+    {
+        var (viewModel, ws) = CreateViewModel();
+        var frames = string.Join('\n', Enumerable.Range(0, 105)
+            .Select(i => $$"""{"type":"text","id":"f{{i}}","text":"{{new string('x', 2000)}}"}"""));
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_push",
+            RequestId = "req1",
+            SessionId = "sess",
+            SurfaceId = "main",
+            Frames = frames
+        });
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "canvas_snapshot",
+            RequestId = "snap1",
+            SessionId = "sess",
+            SurfaceId = "main"
+        });
+
+        var snapshot = LastSentEnvelope(ws);
+        using var doc = JsonDocument.Parse(snapshot.SnapshotJson!);
+
+        Assert.Equal(105, doc.RootElement.GetProperty("frameCount").GetInt32());
+        Assert.True(doc.RootElement.GetProperty("truncated").GetBoolean());
+        Assert.True(snapshot.SnapshotJson!.Length <= 128 * 1024);
+    }
+
     private (MainWindowViewModel ViewModel, TestWebSocket Socket) CreateViewModel()
     {
         var dir = Path.Combine(Path.GetTempPath(), "openclaw-companion-canvas-tests", Guid.NewGuid().ToString("N"));

--- a/src/OpenClaw.Tests/CompanionCanvasTests.cs
+++ b/src/OpenClaw.Tests/CompanionCanvasTests.cs
@@ -1,0 +1,137 @@
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using OpenClaw.Companion.Services;
+using OpenClaw.Companion.ViewModels;
+using OpenClaw.Core.Models;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class CompanionCanvasTests : IDisposable
+{
+    private readonly List<string> _tempDirs = [];
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            try { Directory.Delete(dir, recursive: true); }
+            catch { }
+        }
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_PushRendersNativeFramesAndAcks()
+    {
+        var (viewModel, ws) = CreateViewModel();
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_push",
+            RequestId = "req1",
+            SessionId = "sess",
+            SurfaceId = "main",
+            Frames = """
+                {"type":"button","id":"save","label":"Save"}
+                {"type":"input","id":"name","label":"Name","value":"Ada"}
+                """
+        });
+
+        Assert.True(viewModel.IsCanvasVisible);
+        Assert.True(viewModel.HasCanvasFrames);
+        Assert.Equal(2, viewModel.CanvasFrames.Count);
+        Assert.Equal("Ada", viewModel.CanvasFrames.Single(frame => frame.Id == "name").ValueText);
+
+        var ack = LastSentEnvelope(ws);
+        Assert.Equal("canvas_ack", ack.Type);
+        Assert.Equal("req1", ack.RequestId);
+        Assert.True(ack.Success);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_ButtonEventSendsA2UiEvent()
+    {
+        var (viewModel, ws) = CreateViewModel();
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_push",
+            RequestId = "req1",
+            SessionId = "sess",
+            SurfaceId = "main",
+            Frames = """{"type":"button","id":"save","label":"Save"}"""
+        });
+
+        await viewModel.CanvasFrames.Single().ActivateCommand.ExecuteAsync(null);
+
+        var evt = LastSentEnvelope(ws);
+        Assert.Equal("a2ui_event", evt.Type);
+        Assert.Equal("sess", evt.SessionId);
+        Assert.Equal("save", evt.ComponentId);
+        Assert.Equal("click", evt.Event);
+        Assert.Equal("true", evt.ValueJson);
+        Assert.Equal(1, evt.Sequence);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_SnapshotReturnsStateJson()
+    {
+        var (viewModel, ws) = CreateViewModel();
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_push",
+            RequestId = "req1",
+            SessionId = "sess",
+            SurfaceId = "main",
+            Frames = """{"type":"text","id":"summary","text":"Ready"}"""
+        });
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "canvas_snapshot",
+            RequestId = "snap1",
+            SessionId = "sess",
+            SurfaceId = "main"
+        });
+
+        var snapshot = LastSentEnvelope(ws);
+        Assert.Equal("canvas_snapshot_result", snapshot.Type);
+        Assert.Equal("snap1", snapshot.RequestId);
+        Assert.NotNull(snapshot.SnapshotJson);
+
+        using var doc = JsonDocument.Parse(snapshot.SnapshotJson!);
+        Assert.Equal(1, doc.RootElement.GetProperty("frameCount").GetInt32());
+        Assert.True(doc.RootElement.GetProperty("visible").GetBoolean());
+    }
+
+    private (MainWindowViewModel ViewModel, TestWebSocket Socket) CreateViewModel()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "openclaw-companion-canvas-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        _tempDirs.Add(dir);
+
+        var client = new GatewayWebSocketClient();
+        var ws = new TestWebSocket();
+        client.SetConnectedSocketForTest(ws);
+        return (new MainWindowViewModel(new SettingsStore(dir), client), ws);
+    }
+
+    private static async Task ApplyCanvasEnvelopeAsync(MainWindowViewModel viewModel, WsServerEnvelope envelope)
+    {
+        var method = typeof(MainWindowViewModel).GetMethod(
+            "ApplyCanvasEnvelopeAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var task = (Task?)method!.Invoke(viewModel, [envelope]);
+        Assert.NotNull(task);
+        await task!;
+    }
+
+    private static WsClientEnvelope LastSentEnvelope(TestWebSocket ws)
+    {
+        var payload = Encoding.UTF8.GetString(ws.Sent.Last());
+        return JsonSerializer.Deserialize(payload, CoreJsonContext.Default.WsClientEnvelope)
+            ?? throw new InvalidOperationException("Sent payload was not a websocket envelope.");
+    }
+}

--- a/src/OpenClaw.Tests/GatewayBootstrapExtensionsTests.cs
+++ b/src/OpenClaw.Tests/GatewayBootstrapExtensionsTests.cs
@@ -17,7 +17,8 @@ public sealed class GatewayBootstrapExtensionsTests
                 ["OpenClaw:Tooling:AllowShell"] = "false",
                 ["OpenClaw:Tooling:AllowedReadRoots:0"] = "/app/workspace",
                 ["OpenClaw:Tooling:AllowedWriteRoots:0"] = "/app/workspace",
-                ["OpenClaw:Plugins:Enabled"] = "false"
+                ["OpenClaw:Plugins:Enabled"] = "false",
+                ["OpenClaw:Canvas:Enabled"] = "false"
             })
             .Build();
 

--- a/src/OpenClaw.Tests/GatewaySecurityHardeningTests.cs
+++ b/src/OpenClaw.Tests/GatewaySecurityHardeningTests.cs
@@ -60,6 +60,29 @@ public sealed class GatewaySecurityHardeningTests
     }
 
     [Fact]
+    public void EnforcePublicBindHardening_CanvasEnabledOnPublicBind_Throws()
+    {
+        var config = CreatePublicBindSafeBaseConfig();
+        config.Canvas.Enabled = true;
+        config.Canvas.AllowOnPublicBind = false;
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            GatewaySecurityExtensions.EnforcePublicBindHardening(config, isNonLoopbackBind: true));
+
+        Assert.Contains("Canvas command forwarding", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EnforcePublicBindHardening_CanvasPublicBindOptIn_IsAllowed()
+    {
+        var config = CreatePublicBindSafeBaseConfig();
+        config.Canvas.Enabled = true;
+        config.Canvas.AllowOnPublicBind = true;
+
+        GatewaySecurityExtensions.EnforcePublicBindHardening(config, isNonLoopbackBind: true);
+    }
+
+    [Fact]
     public void EnforcePublicBindHardening_Loopback_DoesNotApplyPublicChecks()
     {
         var config = new GatewayConfig();
@@ -228,6 +251,7 @@ public sealed class GatewaySecurityHardeningTests
 
         Assert.True(config.Security.RequireRequesterMatchForHttpToolApproval);
         Assert.True(config.Tooling.RequireToolApproval);
+        Assert.False(config.Canvas.Enabled);
         Assert.Contains("process", config.Tooling.ApprovalRequiredTools, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("shell", config.Tooling.ApprovalRequiredTools, StringComparer.OrdinalIgnoreCase);
     }
@@ -241,6 +265,10 @@ public sealed class GatewaySecurityHardeningTests
                 AllowShell = false,
                 AllowedReadRoots = ["/tmp/openclaw-read"],
                 AllowedWriteRoots = ["/tmp/openclaw-write"]
+            },
+            Canvas = new CanvasConfig
+            {
+                Enabled = false
             },
             Channels = new ChannelsConfig
             {

--- a/src/OpenClaw.Tests/WebSocketChannelTests.cs
+++ b/src/OpenClaw.Tests/WebSocketChannelTests.cs
@@ -102,6 +102,101 @@ public sealed class WebSocketChannelTests
     }
 
     [Fact]
+    public async Task HandleConnectionAsync_RoutesCanvasReadyWithoutUserMessage()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig { MaxMessageBytes = 1024 });
+        var ws = new TestWebSocket();
+
+        ws.QueueReceiveText("""{"type":"canvas_ready","capabilities":["a2ui.v0_8","snapshot.state"]}""");
+        ws.QueueClose();
+
+        WsClientEnvelope? canvasEnvelope = null;
+        var messageObserved = false;
+        channel.OnCanvasClientEnvelopeReceived += (_, envelope, _) =>
+        {
+            canvasEnvelope = envelope;
+            return ValueTask.CompletedTask;
+        };
+        channel.OnMessageReceived += (_, _) =>
+        {
+            messageObserved = true;
+            return ValueTask.CompletedTask;
+        };
+
+        await channel.HandleConnectionAsync(ws, "client", IPAddress.Loopback, CancellationToken.None);
+
+        Assert.NotNull(canvasEnvelope);
+        Assert.Equal("canvas_ready", canvasEnvelope!.Type);
+        Assert.Contains("a2ui.v0_8", canvasEnvelope.Capabilities ?? [], StringComparer.Ordinal);
+        Assert.False(messageObserved);
+    }
+
+    [Fact]
+    public async Task HandleConnectionAsync_RoutesCanvasAckAndResultsWithoutUserMessage()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig { MaxMessageBytes = 2048 });
+        var ws = new TestWebSocket();
+
+        ws.QueueReceiveText("""{"type":"canvas_ack","requestId":"req1","success":true}""");
+        ws.QueueReceiveText("""{"type":"canvas_snapshot_result","requestId":"req2","snapshotJson":"{}","success":true}""");
+        ws.QueueReceiveText("""{"type":"canvas_eval_result","requestId":"req3","valueJson":"1","success":true}""");
+        ws.QueueClose();
+
+        var canvasTypes = new List<string>();
+        var messageObserved = false;
+        channel.OnCanvasClientEnvelopeReceived += (_, envelope, _) =>
+        {
+            canvasTypes.Add(envelope.Type);
+            return ValueTask.CompletedTask;
+        };
+        channel.OnMessageReceived += (_, _) =>
+        {
+            messageObserved = true;
+            return ValueTask.CompletedTask;
+        };
+
+        await channel.HandleConnectionAsync(ws, "client", IPAddress.Loopback, CancellationToken.None);
+
+        Assert.Equal(["canvas_ack", "canvas_snapshot_result", "canvas_eval_result"], canvasTypes);
+        Assert.False(messageObserved);
+    }
+
+    [Fact]
+    public async Task HandleConnectionAsync_ConvertsA2UiEventToSessionMessage()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig { MaxMessageBytes = 1024 });
+        var ws = new TestWebSocket();
+
+        ws.QueueReceiveText("""{"type":"a2ui_event","sessionId":"sess","surfaceId":"main","componentId":"btn","event":"click","valueJson":"true","sequence":7}""");
+        ws.QueueClose();
+
+        WsClientEnvelope? canvasEnvelope = null;
+        InboundMessage? received = null;
+        channel.OnCanvasClientEnvelopeReceived += (_, envelope, _) =>
+        {
+            canvasEnvelope = envelope;
+            return ValueTask.CompletedTask;
+        };
+        channel.OnMessageReceived += (msg, _) =>
+        {
+            received = msg;
+            return ValueTask.CompletedTask;
+        };
+
+        await channel.HandleConnectionAsync(ws, "client", IPAddress.Loopback, CancellationToken.None);
+
+        Assert.NotNull(canvasEnvelope);
+        Assert.NotNull(received);
+        Assert.Equal("a2ui_event", received!.Type);
+        Assert.Equal("sess", received.SessionId);
+        Assert.Equal("btn", received.ComponentId);
+        Assert.Equal("click", received.Event);
+        Assert.Equal("true", received.ValueJson);
+        Assert.Equal(7, received.Sequence);
+        Assert.Contains("\"componentId\": \"btn\"", received.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task HandleConnectionAsync_IgnoresPrematureRemoteCloseDuringReceive()
     {
         var channel = new WebSocketChannel(new WebSocketConfig { MaxMessageBytes = 1024 });


### PR DESCRIPTION
## Summary

Implements Canvas + A2UI v1 as a first-party, session-scoped visual workspace for websocket clients.

## Changes

- Adds Canvas configuration, websocket envelope fields, A2UI v0.8 JSONL validation, and structured A2UI event message fields.
- Adds a gateway Canvas command broker and native tools for present, hide, navigate, snapshot, A2UI push/reset, and local A2UI eval.
- Implements public-bind hardening so Canvas forwarding is disabled/refused unless explicitly allowed on public binds.
- Adds webchat Canvas hosting with A2UI rendering, sandboxed local HTML, eval results, snapshots, and interaction events.
- Adds a Companion Canvas tab with native Avalonia A2UI renderers, events, snapshots, and unsupported diagnostics for local HTML/eval.
- Updates docs and compatibility guidance from proposal to supported v1 behavior.

## Validation

- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj --no-restore --filter "FullyQualifiedName~A2UiFrameValidatorTests|FullyQualifiedName~CanvasCommandBrokerTests|FullyQualifiedName~CanvasToolTests|FullyQualifiedName~CompanionCanvasTests|FullyQualifiedName~WebSocketChannelTests|FullyQualifiedName~GatewaySecurityHardeningTests|FullyQualifiedName~GatewayBootstrapExtensionsTests|FullyQualifiedName~DocsConsistencyTests"` passed: 54/54.
- Webchat script syntax check with Node passed.
- Full `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj --no-restore` currently has one unrelated local environment failure: missing Playwright Chromium executable for `BrowserToolTests.BrowserTool_CanNavigateAndGetText`; the remaining 995 tests pass.