### PR TITLE
[codex] Implement voice memo transcription

### DIFF
--- a/src/OpenClaw.Core/Models/MultimodalModels.cs
+++ b/src/OpenClaw.Core/Models/MultimodalModels.cs
@@ -7,9 +7,21 @@ public sealed class MultimodalConfig
     public string LiveProvider { get; set; } = "gemini";
     public string VisionProvider { get; set; } = "gemini";
     public string VisionModel { get; set; } = "gemini-2.5-flash";
+    public AudioTranscriptionConfig Transcription { get; set; } = new();
     public TextToSpeechConfig TextToSpeech { get; set; } = new();
     public GeminiLiveConfig GeminiLive { get; set; } = new();
     public ElevenLabsConfig ElevenLabs { get; set; } = new();
+}
+
+public sealed class AudioTranscriptionConfig
+{
+    public bool Enabled { get; set; } = true;
+    public string Provider { get; set; } = "gemini";
+    public string Model { get; set; } = "gemini-2.5-flash";
+    public int MaxAudioBytes { get; set; } = 25 * 1024 * 1024;
+    public int TimeoutSeconds { get; set; } = 30;
+    public bool InjectAudioMarker { get; set; } = true;
+    public string FailureMode { get; set; } = "degrade";
 }
 
 public sealed class TextToSpeechConfig

--- a/src/OpenClaw.Core/Models/Session.cs
+++ b/src/OpenClaw.Core/Models/Session.cs
@@ -330,6 +330,7 @@ public sealed class SessionDelegationChildSummary
 [JsonSerializable(typeof(BackendFileWriteEvent))]
 [JsonSerializable(typeof(BackendErrorEvent))]
 [JsonSerializable(typeof(BackendSessionCompletedEvent))]
+[JsonSerializable(typeof(AudioTranscriptionConfig))]
 [JsonSerializable(typeof(TextToSpeechConfig))]
 [JsonSerializable(typeof(GeminiLiveConfig))]
 [JsonSerializable(typeof(ElevenLabsConfig))]

--- a/src/OpenClaw.Gateway/AudioTranscriptionService.cs
+++ b/src/OpenClaw.Gateway/AudioTranscriptionService.cs
@@ -1,0 +1,141 @@
+using Microsoft.Extensions.Logging;
+using OpenClaw.Core.Models;
+
+namespace OpenClaw.Gateway;
+
+internal sealed class AudioTranscriptionRequest
+{
+    public required string AudioUrl { get; init; }
+    public string? MimeType { get; init; }
+    public string? FileName { get; init; }
+    public string? Provider { get; init; }
+    public string? Model { get; init; }
+    public int MaxAudioBytes { get; init; }
+}
+
+internal sealed class AudioTranscriptionResult
+{
+    public required string Provider { get; init; }
+    public required string Text { get; init; }
+    public string? MimeType { get; init; }
+    public long SizeBytes { get; init; }
+}
+
+internal interface IAudioTranscriptionProvider
+{
+    string Name { get; }
+    Task<AudioTranscriptionResult> TranscribeAsync(AudioTranscriptionRequest request, CancellationToken ct);
+}
+
+internal sealed class AudioTranscriptionService
+{
+    private readonly GatewayConfig _config;
+    private readonly ILogger<AudioTranscriptionService> _logger;
+    private readonly IReadOnlyDictionary<string, IAudioTranscriptionProvider> _providers;
+
+    public AudioTranscriptionService(
+        GatewayConfig config,
+        IEnumerable<IAudioTranscriptionProvider> providers,
+        ILogger<AudioTranscriptionService> logger)
+    {
+        _config = config;
+        _logger = logger;
+        _providers = providers.ToDictionary(static provider => provider.Name, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public async Task<AudioTranscriptionResult> TranscribeAsync(InboundMessage message, CancellationToken ct)
+    {
+        if (!_config.Multimodal.Enabled || !_config.Multimodal.Transcription.Enabled)
+            throw new InvalidOperationException("Voice transcription is disabled by configuration.");
+
+        if (!IsAudioMessage(message))
+            throw new InvalidOperationException("Only inbound audio messages can be transcribed.");
+
+        var providerName = string.IsNullOrWhiteSpace(_config.Multimodal.Transcription.Provider)
+            ? "gemini"
+            : _config.Multimodal.Transcription.Provider.Trim();
+
+        if (!_providers.TryGetValue(providerName, out var provider))
+            throw new InvalidOperationException($"Unknown audio transcription provider '{providerName}'.");
+
+        var timeoutSeconds = Math.Max(1, _config.Multimodal.Transcription.TimeoutSeconds);
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+
+        try
+        {
+            return await provider.TranscribeAsync(new AudioTranscriptionRequest
+            {
+                AudioUrl = message.MediaUrl!,
+                MimeType = message.MediaMimeType,
+                FileName = message.MediaFileName,
+                Provider = providerName,
+                Model = _config.Multimodal.Transcription.Model,
+                MaxAudioBytes = Math.Max(1, _config.Multimodal.Transcription.MaxAudioBytes)
+            }, timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
+        {
+            _logger.LogWarning("Voice transcription timed out after {TimeoutSeconds}s.", timeoutSeconds);
+            throw new TimeoutException($"Voice transcription timed out after {timeoutSeconds}s.");
+        }
+    }
+
+    public IReadOnlyList<string> ListProviders()
+        => _providers.Keys.OrderBy(static item => item, StringComparer.OrdinalIgnoreCase).ToArray();
+
+    public static bool IsAudioMessage(InboundMessage message)
+        => string.Equals(message.MediaType, "audio", StringComparison.OrdinalIgnoreCase)
+           && !string.IsNullOrWhiteSpace(message.MediaUrl);
+}
+
+internal sealed class GeminiAudioTranscriptionProvider : IAudioTranscriptionProvider
+{
+    private readonly GeminiMultimodalService _gemini;
+
+    public GeminiAudioTranscriptionProvider(GeminiMultimodalService gemini)
+    {
+        _gemini = gemini;
+    }
+
+    public string Name => "gemini";
+
+    public Task<AudioTranscriptionResult> TranscribeAsync(AudioTranscriptionRequest request, CancellationToken ct)
+        => _gemini.TranscribeAudioAsync(
+            request.AudioUrl,
+            request.MimeType,
+            request.Model,
+            request.MaxAudioBytes,
+            ct);
+}
+
+internal static class VoiceMemoTranscriptionText
+{
+    public static string PrependTranscript(string messageText, AudioTranscriptionResult result)
+    {
+        var transcript = result.Text.Trim();
+        var block = $"[VOICE_TRANSCRIPT provider={result.Provider}]\n{transcript}\n[/VOICE_TRANSCRIPT]";
+        return string.IsNullOrWhiteSpace(messageText)
+            ? block
+            : $"{block}\n{messageText}";
+    }
+
+    public static string AppendUnavailable(string messageText, string reason)
+    {
+        var marker = $"[VOICE_TRANSCRIPTION_UNAVAILABLE: {reason}]";
+        return string.IsNullOrWhiteSpace(messageText)
+            ? marker
+            : $"{messageText}\n{marker}";
+    }
+
+    public static string FailureReason(Exception exception)
+        => exception switch
+        {
+            TimeoutException => "timeout",
+            InvalidOperationException invalid when invalid.Message.Contains("disabled", StringComparison.OrdinalIgnoreCase) => "disabled",
+            InvalidOperationException invalid when invalid.Message.Contains("unknown audio transcription provider", StringComparison.OrdinalIgnoreCase) => "unsupported_provider",
+            InvalidOperationException invalid when invalid.Message.Contains("too large", StringComparison.OrdinalIgnoreCase) => "audio_too_large",
+            InvalidOperationException invalid when invalid.Message.Contains("unsupported", StringComparison.OrdinalIgnoreCase) => "unsupported_audio",
+            _ => "transcription_failed"
+        };
+}

--- a/src/OpenClaw.Gateway/AudioTranscriptionService.cs
+++ b/src/OpenClaw.Gateway/AudioTranscriptionService.cs
@@ -11,6 +11,7 @@ internal sealed class AudioTranscriptionRequest
     public string? Provider { get; init; }
     public string? Model { get; init; }
     public int MaxAudioBytes { get; init; }
+    public IReadOnlyList<string> AllowedLocalFileRoots { get; init; } = [];
 }
 
 internal sealed class AudioTranscriptionResult
@@ -51,9 +52,7 @@ internal sealed class AudioTranscriptionService
         if (!IsAudioMessage(message))
             throw new InvalidOperationException("Only inbound audio messages can be transcribed.");
 
-        var providerName = string.IsNullOrWhiteSpace(_config.Multimodal.Transcription.Provider)
-            ? "gemini"
-            : _config.Multimodal.Transcription.Provider.Trim();
+        var providerName = ResolveProviderName(_config.Multimodal.Transcription.Provider);
 
         if (!_providers.TryGetValue(providerName, out var provider))
             throw new InvalidOperationException($"Unknown audio transcription provider '{providerName}'.");
@@ -70,8 +69,9 @@ internal sealed class AudioTranscriptionService
                 MimeType = message.MediaMimeType,
                 FileName = message.MediaFileName,
                 Provider = providerName,
-                Model = _config.Multimodal.Transcription.Model,
-                MaxAudioBytes = Math.Max(1, _config.Multimodal.Transcription.MaxAudioBytes)
+                Model = NormalizeOptional(_config.Multimodal.Transcription.Model),
+                MaxAudioBytes = Math.Max(1, _config.Multimodal.Transcription.MaxAudioBytes),
+                AllowedLocalFileRoots = BuildAllowedLocalFileRoots(_config)
             }, timeoutCts.Token);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !ct.IsCancellationRequested)
@@ -87,6 +87,45 @@ internal sealed class AudioTranscriptionService
     public static bool IsAudioMessage(InboundMessage message)
         => string.Equals(message.MediaType, "audio", StringComparison.OrdinalIgnoreCase)
            && !string.IsNullOrWhiteSpace(message.MediaUrl);
+
+    public static string ResolveProviderName(string? provider)
+        => string.IsNullOrWhiteSpace(provider) ? "gemini" : provider.Trim();
+
+    public static bool ShouldDegrade(string? failureMode)
+    {
+        var normalized = failureMode?.Trim();
+        return !string.Equals(normalized, "strict", StringComparison.OrdinalIgnoreCase)
+               && !string.Equals(normalized, "fail", StringComparison.OrdinalIgnoreCase)
+               && !string.Equals(normalized, "throw", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? NormalizeOptional(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static IReadOnlyList<string> BuildAllowedLocalFileRoots(GatewayConfig config)
+    {
+        var roots = new List<string>();
+        AddRoot(roots, config.Multimodal.MediaCachePath);
+
+        var worker = config.Channels.WhatsApp.FirstPartyWorker;
+        AddRoot(roots, worker.MediaCachePath);
+        if (!string.IsNullOrWhiteSpace(worker.StoragePath))
+            AddRoot(roots, Path.Combine(worker.StoragePath, "media-cache"));
+
+        foreach (var account in worker.Accounts)
+            AddRoot(roots, account.MediaCachePath);
+
+        return roots
+            .Select(static root => Path.GetFullPath(root))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static void AddRoot(List<string> roots, string? root)
+    {
+        if (!string.IsNullOrWhiteSpace(root))
+            roots.Add(root);
+    }
 }
 
 internal sealed class GeminiAudioTranscriptionProvider : IAudioTranscriptionProvider
@@ -106,6 +145,7 @@ internal sealed class GeminiAudioTranscriptionProvider : IAudioTranscriptionProv
             request.MimeType,
             request.Model,
             request.MaxAudioBytes,
+            request.AllowedLocalFileRoots,
             ct);
 }
 

--- a/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
@@ -81,6 +81,9 @@ internal static class CoreServicesExtensions
                 sp.GetRequiredService<ILogger<SessionMetadataStore>>()));
         services.AddSingleton(sp => new MediaCacheStore(config.Multimodal.MediaCachePath));
         services.AddSingleton<GeminiMultimodalService>();
+        services.AddSingleton<GeminiAudioTranscriptionProvider>();
+        services.AddSingleton<IAudioTranscriptionProvider>(sp => sp.GetRequiredService<GeminiAudioTranscriptionProvider>());
+        services.AddSingleton<AudioTranscriptionService>();
         services.AddSingleton<GeminiLiveProxyService>();
         services.AddSingleton<ILiveSessionProvider>(sp => sp.GetRequiredService<GeminiLiveProxyService>());
         services.AddSingleton<GeminiTextToSpeechProvider>();

--- a/src/OpenClaw.Gateway/Extensions/GatewayInboundMessageWorker.cs
+++ b/src/OpenClaw.Gateway/Extensions/GatewayInboundMessageWorker.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenClaw.Agent;
@@ -40,7 +41,8 @@ internal sealed class GatewayInboundMessageWorker
         RuntimeMetrics? runtimeMetrics,
         LearningService? learningService,
         GatewayAutomationService? automationService,
-        ContractGovernanceService? contractGovernance)
+        ContractGovernanceService? contractGovernance,
+        AudioTranscriptionService? audioTranscriptionService = null)
     {
         _ = isNonLoopbackBind;
         _ = sessionLocks;
@@ -431,7 +433,61 @@ internal sealed class GatewayInboundMessageWorker
                             }
 
                             var messageText = mwContext.Text;
-                            if (!string.IsNullOrWhiteSpace(msg.MediaUrl) && !messageText.Contains("[IMAGE_URL:", StringComparison.Ordinal))
+                            var audioTranscriptionSucceeded = false;
+                            if (AudioTranscriptionService.IsAudioMessage(msg))
+                            {
+                                var transcriptionStopwatch = Stopwatch.StartNew();
+                                try
+                                {
+                                    if (audioTranscriptionService is null)
+                                        throw new InvalidOperationException("Voice transcription is unavailable in this runtime.");
+
+                                    var transcription = await audioTranscriptionService.TranscribeAsync(msg, processingCt);
+                                    transcriptionStopwatch.Stop();
+                                    audioTranscriptionSucceeded = true;
+                                    if (!config.Multimodal.Transcription.InjectAudioMarker)
+                                        messageText = RemoveAudioMarkers(messageText);
+                                    messageText = VoiceMemoTranscriptionText.PrependTranscript(messageText, transcription);
+                                    AppendVoiceTranscriptionEvent(
+                                        operations,
+                                        session,
+                                        msg,
+                                        action: "transcription_succeeded",
+                                        severity: "info",
+                                        summary: "Voice memo transcribed.",
+                                        provider: transcription.Provider,
+                                        reason: null,
+                                        elapsed: transcriptionStopwatch.Elapsed,
+                                        sizeBytes: transcription.SizeBytes,
+                                        mimeType: transcription.MimeType ?? msg.MediaMimeType);
+                                }
+                                catch (Exception ex) when (!processingCt.IsCancellationRequested)
+                                {
+                                    transcriptionStopwatch.Stop();
+                                    var reason = VoiceMemoTranscriptionText.FailureReason(ex);
+                                    logger.LogWarning(ex, "Voice memo transcription failed for {ChannelId}:{SenderId}: {Reason}", msg.ChannelId, msg.SenderId, reason);
+                                    messageText = VoiceMemoTranscriptionText.AppendUnavailable(messageText, reason);
+                                    AppendVoiceTranscriptionEvent(
+                                        operations,
+                                        session,
+                                        msg,
+                                        action: "transcription_failed",
+                                        severity: "warning",
+                                        summary: $"Voice memo transcription unavailable: {reason}.",
+                                        provider: config.Multimodal.Transcription.Provider,
+                                        reason: reason,
+                                        elapsed: transcriptionStopwatch.Elapsed,
+                                        sizeBytes: null,
+                                        mimeType: msg.MediaMimeType);
+                                }
+                            }
+
+                            var shouldInjectMediaMarker = !AudioTranscriptionService.IsAudioMessage(msg)
+                                || !audioTranscriptionSucceeded
+                                || config.Multimodal.Transcription.InjectAudioMarker;
+                            if (shouldInjectMediaMarker &&
+                                !string.IsNullOrWhiteSpace(msg.MediaUrl) &&
+                                !ContainsMediaMarker(messageText))
                             {
                                 var marker = BuildMediaMarker(msg);
                                 if (!string.IsNullOrWhiteSpace(marker))
@@ -902,4 +958,73 @@ internal sealed class GatewayInboundMessageWorker
             "document" or "file" => $"[FILE_URL:{message.MediaUrl}]",
             _ => null
         };
+
+    private static bool ContainsMediaMarker(string text)
+        => text.Contains("[IMAGE_URL:", StringComparison.Ordinal)
+           || text.Contains("[AUDIO_URL:", StringComparison.Ordinal)
+           || text.Contains("[VIDEO_URL:", StringComparison.Ordinal)
+           || text.Contains("[FILE_URL:", StringComparison.Ordinal)
+           || text.Contains("[DOCUMENT_URL:", StringComparison.Ordinal)
+           || text.Contains("[STICKER_URL:", StringComparison.Ordinal);
+
+    private static string RemoveAudioMarkers(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text;
+
+        var changed = false;
+        var lines = text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var kept = new List<string>();
+        foreach (var line in lines)
+        {
+            if (MediaMarkerProtocol.TryParseMarker(line.Trim(), out var marker) && marker.Kind == MediaMarkerKind.AudioUrl)
+            {
+                changed = true;
+                continue;
+            }
+
+            kept.Add(line);
+        }
+
+        return changed ? string.Join("\n", kept).Trim() : text;
+    }
+
+    private static void AppendVoiceTranscriptionEvent(
+        RuntimeOperationsState operations,
+        Session session,
+        InboundMessage message,
+        string action,
+        string severity,
+        string summary,
+        string? provider,
+        string? reason,
+        TimeSpan elapsed,
+        long? sizeBytes,
+        string? mimeType)
+    {
+        var metadata = new Dictionary<string, string>
+        {
+            ["provider"] = string.IsNullOrWhiteSpace(provider) ? "unknown" : provider,
+            ["elapsedMs"] = ((long)elapsed.TotalMilliseconds).ToString(System.Globalization.CultureInfo.InvariantCulture)
+        };
+        if (!string.IsNullOrWhiteSpace(reason))
+            metadata["reason"] = reason;
+        if (!string.IsNullOrWhiteSpace(mimeType))
+            metadata["mimeType"] = mimeType;
+        if (sizeBytes.HasValue)
+            metadata["sizeBytes"] = sizeBytes.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        operations.RuntimeEvents.Append(new RuntimeEventEntry
+        {
+            Id = $"evt_{Guid.NewGuid():N}"[..20],
+            SessionId = session.Id,
+            ChannelId = message.ChannelId,
+            SenderId = message.SenderId,
+            Component = "voice_transcription",
+            Action = action,
+            Severity = severity,
+            Summary = summary,
+            Metadata = metadata
+        });
+    }
 }

--- a/src/OpenClaw.Gateway/Extensions/GatewayInboundMessageWorker.cs
+++ b/src/OpenClaw.Gateway/Extensions/GatewayInboundMessageWorker.cs
@@ -433,6 +433,9 @@ internal sealed class GatewayInboundMessageWorker
                             }
 
                             var messageText = mwContext.Text;
+                            var mediaMarker = BuildMediaMarker(msg);
+                            var hasCurrentMediaMarker = ContainsExactMediaMarker(messageText, mediaMarker);
+                            var transcriptionProviderName = AudioTranscriptionService.ResolveProviderName(config.Multimodal.Transcription.Provider);
                             var audioTranscriptionSucceeded = false;
                             if (AudioTranscriptionService.IsAudioMessage(msg))
                             {
@@ -446,7 +449,7 @@ internal sealed class GatewayInboundMessageWorker
                                     transcriptionStopwatch.Stop();
                                     audioTranscriptionSucceeded = true;
                                     if (!config.Multimodal.Transcription.InjectAudioMarker)
-                                        messageText = RemoveAudioMarkers(messageText);
+                                        messageText = RemoveExactMediaMarker(messageText, mediaMarker);
                                     messageText = VoiceMemoTranscriptionText.PrependTranscript(messageText, transcription);
                                     AppendVoiceTranscriptionEvent(
                                         operations,
@@ -466,7 +469,6 @@ internal sealed class GatewayInboundMessageWorker
                                     transcriptionStopwatch.Stop();
                                     var reason = VoiceMemoTranscriptionText.FailureReason(ex);
                                     logger.LogWarning(ex, "Voice memo transcription failed for {ChannelId}:{SenderId}: {Reason}", msg.ChannelId, msg.SenderId, reason);
-                                    messageText = VoiceMemoTranscriptionText.AppendUnavailable(messageText, reason);
                                     AppendVoiceTranscriptionEvent(
                                         operations,
                                         session,
@@ -474,11 +476,15 @@ internal sealed class GatewayInboundMessageWorker
                                         action: "transcription_failed",
                                         severity: "warning",
                                         summary: $"Voice memo transcription unavailable: {reason}.",
-                                        provider: config.Multimodal.Transcription.Provider,
+                                        provider: transcriptionProviderName,
                                         reason: reason,
                                         elapsed: transcriptionStopwatch.Elapsed,
                                         sizeBytes: null,
                                         mimeType: msg.MediaMimeType);
+                                    if (!AudioTranscriptionService.ShouldDegrade(config.Multimodal.Transcription.FailureMode))
+                                        throw;
+
+                                    messageText = VoiceMemoTranscriptionText.AppendUnavailable(messageText, reason);
                                 }
                             }
 
@@ -486,12 +492,10 @@ internal sealed class GatewayInboundMessageWorker
                                 || !audioTranscriptionSucceeded
                                 || config.Multimodal.Transcription.InjectAudioMarker;
                             if (shouldInjectMediaMarker &&
-                                !string.IsNullOrWhiteSpace(msg.MediaUrl) &&
-                                !ContainsMediaMarker(messageText))
+                                !string.IsNullOrWhiteSpace(mediaMarker) &&
+                                !hasCurrentMediaMarker)
                             {
-                                var marker = BuildMediaMarker(msg);
-                                if (!string.IsNullOrWhiteSpace(marker))
-                                    messageText = string.IsNullOrWhiteSpace(messageText) ? marker : $"{marker}\n{messageText}";
+                                messageText = string.IsNullOrWhiteSpace(messageText) ? mediaMarker : $"{mediaMarker}\n{messageText}";
                             }
                             var useStreaming = msg.ChannelId == "websocket" && wsChannel.IsClientUsingEnvelopes(msg.SenderId);
 
@@ -959,17 +963,23 @@ internal sealed class GatewayInboundMessageWorker
             _ => null
         };
 
-    private static bool ContainsMediaMarker(string text)
-        => text.Contains("[IMAGE_URL:", StringComparison.Ordinal)
-           || text.Contains("[AUDIO_URL:", StringComparison.Ordinal)
-           || text.Contains("[VIDEO_URL:", StringComparison.Ordinal)
-           || text.Contains("[FILE_URL:", StringComparison.Ordinal)
-           || text.Contains("[DOCUMENT_URL:", StringComparison.Ordinal)
-           || text.Contains("[STICKER_URL:", StringComparison.Ordinal);
-
-    private static string RemoveAudioMarkers(string text)
+    private static bool ContainsExactMediaMarker(string text, string? marker)
     {
-        if (string.IsNullOrEmpty(text))
+        if (string.IsNullOrWhiteSpace(text) || string.IsNullOrWhiteSpace(marker))
+            return false;
+
+        foreach (var line in text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'))
+        {
+            if (string.Equals(line.Trim(), marker, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string RemoveExactMediaMarker(string text, string? marker)
+    {
+        if (string.IsNullOrEmpty(text) || string.IsNullOrWhiteSpace(marker))
             return text;
 
         var changed = false;
@@ -977,7 +987,7 @@ internal sealed class GatewayInboundMessageWorker
         var kept = new List<string>();
         foreach (var line in lines)
         {
-            if (MediaMarkerProtocol.TryParseMarker(line.Trim(), out var marker) && marker.Kind == MediaMarkerKind.AudioUrl)
+            if (string.Equals(line.Trim(), marker, StringComparison.Ordinal))
             {
                 changed = true;
                 continue;

--- a/src/OpenClaw.Gateway/Extensions/GatewayWorkers.cs
+++ b/src/OpenClaw.Gateway/Extensions/GatewayWorkers.cs
@@ -39,7 +39,8 @@ internal static class GatewayWorkers
         RuntimeMetrics? runtimeMetrics = null,
         LearningService? learningService = null,
         GatewayAutomationService? automationService = null,
-        ContractGovernanceService? contractGovernance = null)
+        ContractGovernanceService? contractGovernance = null,
+        AudioTranscriptionService? audioTranscriptionService = null)
     {
         new GatewaySessionCleanupWorker().Start(lifetime, logger, sessionManager);
 
@@ -67,7 +68,8 @@ internal static class GatewayWorkers
             runtimeMetrics,
             learningService,
             automationService,
-            contractGovernance);
+            contractGovernance,
+            audioTranscriptionService);
 
         new GatewayOutboundDeliveryWorker().Start(
             lifetime,

--- a/src/OpenClaw.Gateway/GeminiMultimodalService.cs
+++ b/src/OpenClaw.Gateway/GeminiMultimodalService.cs
@@ -20,12 +20,13 @@ internal sealed class GeminiMultimodalService
     public GeminiMultimodalService(
         GatewayConfig config,
         MediaCacheStore mediaCache,
-        ILogger<GeminiMultimodalService> logger)
+        ILogger<GeminiMultimodalService> logger,
+        HttpClient? httpClient = null)
     {
         _config = config;
         _mediaCache = mediaCache;
         _logger = logger;
-        _httpClient = new HttpClient();
+        _httpClient = httpClient ?? new HttpClient();
         _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
     }
 
@@ -37,7 +38,13 @@ internal sealed class GeminiMultimodalService
         string? model,
         CancellationToken ct)
     {
-        var (bytes, resolvedMimeType) = await LoadBinaryAsync(imagePath, imageUrl, mimeType, ct);
+        var (bytes, resolvedMimeType) = await LoadBinaryAsync(
+            imagePath,
+            imageUrl,
+            mimeType,
+            defaultMimeType: "image/png",
+            maxBytes: null,
+            ct);
         var requestBody = BuildVisionRequest(prompt, bytes, resolvedMimeType);
         using var response = await _httpClient.PostAsync(
             BuildGenerateContentUri(model ?? _config.Multimodal.VisionModel),
@@ -49,6 +56,43 @@ internal sealed class GeminiMultimodalService
             throw new InvalidOperationException($"Gemini vision request failed: {(int)response.StatusCode} {payload}");
 
         return ExtractText(payload) ?? "No vision response was returned.";
+    }
+
+    public async Task<AudioTranscriptionResult> TranscribeAudioAsync(
+        string audioUrl,
+        string? mimeType,
+        string? model,
+        int maxAudioBytes,
+        CancellationToken ct)
+    {
+        var (bytes, resolvedMimeType) = await LoadBinaryAsync(
+            path: null,
+            url: audioUrl,
+            mimeType,
+            defaultMimeType: "audio/ogg",
+            maxBytes: maxAudioBytes,
+            ct);
+        var requestBody = BuildTranscriptionRequest(bytes, resolvedMimeType);
+        using var response = await _httpClient.PostAsync(
+            BuildGenerateContentUri(model ?? _config.Multimodal.Transcription.Model),
+            new StringContent(requestBody, Encoding.UTF8, "application/json"),
+            ct);
+
+        var payload = await response.Content.ReadAsStringAsync(ct);
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException($"Gemini transcription request failed: {(int)response.StatusCode} {payload}");
+
+        var transcript = ExtractText(payload)?.Trim();
+        if (string.IsNullOrWhiteSpace(transcript))
+            throw new InvalidOperationException("Gemini did not return a transcript.");
+
+        return new AudioTranscriptionResult
+        {
+            Provider = "gemini",
+            Text = transcript,
+            MimeType = resolvedMimeType,
+            SizeBytes = bytes.Length
+        };
     }
 
     public async Task<TextToSpeechSynthesisResult> SynthesizeSpeechAsync(
@@ -122,6 +166,36 @@ internal sealed class GeminiMultimodalService
         return Encoding.UTF8.GetString(buffer.WrittenSpan);
     }
 
+    private static string BuildTranscriptionRequest(ReadOnlyMemory<byte> bytes, string mimeType)
+    {
+        const string Prompt = "Transcribe this voice memo. Return only the transcript text, preserving the speaker's wording as closely as possible.";
+        var buffer = new ArrayBufferWriter<byte>();
+        using var writer = new Utf8JsonWriter(buffer);
+        writer.WriteStartObject();
+        writer.WritePropertyName("contents");
+        writer.WriteStartArray();
+        writer.WriteStartObject();
+        writer.WriteString("role", "user");
+        writer.WritePropertyName("parts");
+        writer.WriteStartArray();
+        writer.WriteStartObject();
+        writer.WriteString("text", Prompt);
+        writer.WriteEndObject();
+        writer.WriteStartObject();
+        writer.WritePropertyName("inline_data");
+        writer.WriteStartObject();
+        writer.WriteString("mime_type", mimeType);
+        writer.WriteString("data", Convert.ToBase64String(bytes.Span));
+        writer.WriteEndObject();
+        writer.WriteEndObject();
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+        writer.Flush();
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
     private static string BuildSpeechRequest(string text, string voiceName)
     {
         var buffer = new ArrayBufferWriter<byte>();
@@ -164,11 +238,14 @@ internal sealed class GeminiMultimodalService
         string? path,
         string? url,
         string? mimeType,
+        string? defaultMimeType,
+        int? maxBytes,
         CancellationToken ct)
     {
         if (!string.IsNullOrWhiteSpace(path))
         {
             var fullPath = Path.GetFullPath(path);
+            EnforceMaxBytes(new FileInfo(fullPath).Length, maxBytes);
             var bytes = await File.ReadAllBytesAsync(fullPath, ct);
             return (bytes, mimeType ?? GuessMimeType(fullPath));
         }
@@ -176,11 +253,60 @@ internal sealed class GeminiMultimodalService
         if (string.IsNullOrWhiteSpace(url))
             throw new InvalidOperationException("image_url or image_path is required.");
 
+        if (url.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+        {
+            var (dataBytes, dataMimeType) = ParseDataUrl(url);
+            EnforceMaxBytes(dataBytes.Length, maxBytes);
+            return (dataBytes, mimeType ?? dataMimeType ?? defaultMimeType ?? "application/octet-stream");
+        }
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && uri.IsFile)
+        {
+            var fullPath = Path.GetFullPath(uri.LocalPath);
+            EnforceMaxBytes(new FileInfo(fullPath).Length, maxBytes);
+            var bytes = await File.ReadAllBytesAsync(fullPath, ct);
+            return (bytes, mimeType ?? GuessMimeType(fullPath));
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var remoteUri) ||
+            (remoteUri.Scheme != Uri.UriSchemeHttp && remoteUri.Scheme != Uri.UriSchemeHttps))
+        {
+            var fullPath = Path.GetFullPath(url);
+            EnforceMaxBytes(new FileInfo(fullPath).Length, maxBytes);
+            var bytes = await File.ReadAllBytesAsync(fullPath, ct);
+            return (bytes, mimeType ?? GuessMimeType(fullPath));
+        }
+
         using var response = await _httpClient.GetAsync(url, ct);
         response.EnsureSuccessStatusCode();
+        if (response.Content.Headers.ContentLength is { } length)
+            EnforceMaxBytes(length, maxBytes);
         var bytesFromUrl = await response.Content.ReadAsByteArrayAsync(ct);
+        EnforceMaxBytes(bytesFromUrl.Length, maxBytes);
         var responseMimeType = response.Content.Headers.ContentType?.MediaType;
-        return (bytesFromUrl, mimeType ?? responseMimeType ?? "image/png");
+        return (bytesFromUrl, mimeType ?? responseMimeType ?? defaultMimeType ?? "image/png");
+    }
+
+    private static (byte[] Data, string? MimeType) ParseDataUrl(string url)
+    {
+        var commaIndex = url.IndexOf(',', StringComparison.Ordinal);
+        if (commaIndex < 0)
+            throw new InvalidOperationException("Unsupported audio data URL.");
+
+        var metadata = url[5..commaIndex];
+        var payload = url[(commaIndex + 1)..];
+        var metadataParts = metadata.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var mimeType = metadataParts.FirstOrDefault(static part => part.Contains('/', StringComparison.Ordinal));
+        var isBase64 = metadataParts.Any(static part => part.Equals("base64", StringComparison.OrdinalIgnoreCase));
+        return isBase64
+            ? (Convert.FromBase64String(payload), mimeType)
+            : (Encoding.UTF8.GetBytes(Uri.UnescapeDataString(payload)), mimeType);
+    }
+
+    private static void EnforceMaxBytes(long sizeBytes, int? maxBytes)
+    {
+        if (maxBytes is > 0 && sizeBytes > maxBytes.Value)
+            throw new InvalidOperationException($"Audio is too large to transcribe ({sizeBytes} bytes > {maxBytes.Value} bytes).");
     }
 
     private static string? ExtractText(string payload)
@@ -249,6 +375,12 @@ internal sealed class GeminiMultimodalService
             ".jpg" or ".jpeg" => "image/jpeg",
             ".webp" => "image/webp",
             ".gif" => "image/gif",
+            ".ogg" or ".oga" => "audio/ogg",
+            ".opus" => "audio/ogg",
+            ".mp3" => "audio/mpeg",
+            ".wav" => "audio/wav",
+            ".m4a" => "audio/mp4",
+            ".webm" => "audio/webm",
             _ => "application/octet-stream"
         };
 }

--- a/src/OpenClaw.Gateway/GeminiMultimodalService.cs
+++ b/src/OpenClaw.Gateway/GeminiMultimodalService.cs
@@ -44,6 +44,7 @@ internal sealed class GeminiMultimodalService
             mimeType,
             defaultMimeType: "image/png",
             maxBytes: null,
+            allowedLocalFileRoots: null,
             ct);
         var requestBody = BuildVisionRequest(prompt, bytes, resolvedMimeType);
         using var response = await _httpClient.PostAsync(
@@ -63,6 +64,7 @@ internal sealed class GeminiMultimodalService
         string? mimeType,
         string? model,
         int maxAudioBytes,
+        IReadOnlyList<string>? allowedLocalFileRoots,
         CancellationToken ct)
     {
         var (bytes, resolvedMimeType) = await LoadBinaryAsync(
@@ -71,10 +73,11 @@ internal sealed class GeminiMultimodalService
             mimeType,
             defaultMimeType: "audio/ogg",
             maxBytes: maxAudioBytes,
+            allowedLocalFileRoots,
             ct);
         var requestBody = BuildTranscriptionRequest(bytes, resolvedMimeType);
         using var response = await _httpClient.PostAsync(
-            BuildGenerateContentUri(model ?? _config.Multimodal.Transcription.Model),
+            BuildGenerateContentUri(ResolveModel(model, _config.Multimodal.Transcription.Model, "gemini-2.5-flash")),
             new StringContent(requestBody, Encoding.UTF8, "application/json"),
             ct);
 
@@ -128,6 +131,9 @@ internal sealed class GeminiMultimodalService
 
     private Uri BuildGenerateContentUri(string model)
     {
+        if (string.IsNullOrWhiteSpace(model))
+            throw new InvalidOperationException("A Gemini model is required for multimodal features.");
+
         var apiKey = SecretResolver.Resolve(_config.Llm.ApiKey)
             ?? Environment.GetEnvironmentVariable("GOOGLE_API_KEY")
             ?? _config.Llm.ApiKey;
@@ -240,6 +246,7 @@ internal sealed class GeminiMultimodalService
         string? mimeType,
         string? defaultMimeType,
         int? maxBytes,
+        IReadOnlyList<string>? allowedLocalFileRoots,
         CancellationToken ct)
     {
         if (!string.IsNullOrWhiteSpace(path))
@@ -251,53 +258,105 @@ internal sealed class GeminiMultimodalService
         }
 
         if (string.IsNullOrWhiteSpace(url))
-            throw new InvalidOperationException("image_url or image_path is required.");
+            throw new InvalidOperationException("url or path is required.");
 
         if (url.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
         {
-            var (dataBytes, dataMimeType) = ParseDataUrl(url);
+            var (dataBytes, dataMimeType) = ParseDataUrl(url, maxBytes);
             EnforceMaxBytes(dataBytes.Length, maxBytes);
             return (dataBytes, mimeType ?? dataMimeType ?? defaultMimeType ?? "application/octet-stream");
         }
 
         if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && uri.IsFile)
         {
-            var fullPath = Path.GetFullPath(uri.LocalPath);
-            EnforceMaxBytes(new FileInfo(fullPath).Length, maxBytes);
-            var bytes = await File.ReadAllBytesAsync(fullPath, ct);
-            return (bytes, mimeType ?? GuessMimeType(fullPath));
+            return await ReadAllowedLocalFileAsync(uri.LocalPath, allowedLocalFileRoots, mimeType, maxBytes, ct);
         }
 
         if (!Uri.TryCreate(url, UriKind.Absolute, out var remoteUri) ||
             (remoteUri.Scheme != Uri.UriSchemeHttp && remoteUri.Scheme != Uri.UriSchemeHttps))
         {
-            var fullPath = Path.GetFullPath(url);
-            EnforceMaxBytes(new FileInfo(fullPath).Length, maxBytes);
-            var bytes = await File.ReadAllBytesAsync(fullPath, ct);
-            return (bytes, mimeType ?? GuessMimeType(fullPath));
+            return await ReadAllowedLocalFileAsync(url, allowedLocalFileRoots, mimeType, maxBytes, ct);
         }
 
-        using var response = await _httpClient.GetAsync(url, ct);
+        using var response = await _httpClient.GetAsync(remoteUri, HttpCompletionOption.ResponseHeadersRead, ct);
         response.EnsureSuccessStatusCode();
         if (response.Content.Headers.ContentLength is { } length)
             EnforceMaxBytes(length, maxBytes);
-        var bytesFromUrl = await response.Content.ReadAsByteArrayAsync(ct);
+        var bytesFromUrl = await ReadContentWithLimitAsync(response.Content, maxBytes, ct);
         EnforceMaxBytes(bytesFromUrl.Length, maxBytes);
         var responseMimeType = response.Content.Headers.ContentType?.MediaType;
         return (bytesFromUrl, mimeType ?? responseMimeType ?? defaultMimeType ?? "image/png");
     }
 
-    private static (byte[] Data, string? MimeType) ParseDataUrl(string url)
+    private static async Task<(ReadOnlyMemory<byte> Data, string MimeType)> ReadAllowedLocalFileAsync(
+        string localPath,
+        IReadOnlyList<string>? allowedLocalFileRoots,
+        string? mimeType,
+        int? maxBytes,
+        CancellationToken ct)
+    {
+        var fullPath = Path.GetFullPath(localPath);
+        if (allowedLocalFileRoots is not { Count: > 0 } ||
+            !allowedLocalFileRoots.Any(root => IsPathUnderRoot(fullPath, root)))
+        {
+            throw new InvalidOperationException("Local media files are not allowed unless they are under a configured media cache root.");
+        }
+
+        EnforceMaxBytes(new FileInfo(fullPath).Length, maxBytes);
+        var bytes = await File.ReadAllBytesAsync(fullPath, ct);
+        return (bytes, mimeType ?? GuessMimeType(fullPath));
+    }
+
+    private static bool IsPathUnderRoot(string path, string root)
+    {
+        var normalizedRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        var normalizedPath = Path.GetFullPath(path);
+        return normalizedPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task<byte[]> ReadContentWithLimitAsync(HttpContent content, int? maxBytes, CancellationToken ct)
+    {
+        await using var stream = await content.ReadAsStreamAsync(ct);
+        using var buffer = new MemoryStream();
+        var chunk = new byte[81920];
+        while (true)
+        {
+            var read = await stream.ReadAsync(chunk, ct);
+            if (read == 0)
+                break;
+
+            if (maxBytes is > 0 && buffer.Length + read > maxBytes.Value)
+                throw new InvalidOperationException($"Media is too large to process ({buffer.Length + read} bytes > {maxBytes.Value} bytes).");
+
+            buffer.Write(chunk, 0, read);
+        }
+
+        return buffer.ToArray();
+    }
+
+    private static (byte[] Data, string? MimeType) ParseDataUrl(string url, int? maxBytes)
     {
         var commaIndex = url.IndexOf(',', StringComparison.Ordinal);
         if (commaIndex < 0)
-            throw new InvalidOperationException("Unsupported audio data URL.");
+            throw new InvalidOperationException("Unsupported data URL.");
 
         var metadata = url[5..commaIndex];
         var payload = url[(commaIndex + 1)..];
         var metadataParts = metadata.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         var mimeType = metadataParts.FirstOrDefault(static part => part.Contains('/', StringComparison.Ordinal));
         var isBase64 = metadataParts.Any(static part => part.Equals("base64", StringComparison.OrdinalIgnoreCase));
+        if (maxBytes is > 0)
+        {
+            if (!isBase64 && payload.Length > maxBytes.Value * 3L)
+                EnforceMaxBytes(payload.Length, maxBytes);
+
+            var estimatedBytes = isBase64
+                ? (long)Math.Ceiling(payload.Length / 4d) * 3
+                : Encoding.UTF8.GetByteCount(Uri.UnescapeDataString(payload));
+            EnforceMaxBytes(estimatedBytes, maxBytes);
+        }
+
         return isBase64
             ? (Convert.FromBase64String(payload), mimeType)
             : (Encoding.UTF8.GetBytes(Uri.UnescapeDataString(payload)), mimeType);
@@ -306,7 +365,16 @@ internal sealed class GeminiMultimodalService
     private static void EnforceMaxBytes(long sizeBytes, int? maxBytes)
     {
         if (maxBytes is > 0 && sizeBytes > maxBytes.Value)
-            throw new InvalidOperationException($"Audio is too large to transcribe ({sizeBytes} bytes > {maxBytes.Value} bytes).");
+            throw new InvalidOperationException($"Media is too large to process ({sizeBytes} bytes > {maxBytes.Value} bytes).");
+    }
+
+    private static string ResolveModel(string? requestedModel, string? configuredModel, string fallbackModel)
+    {
+        if (!string.IsNullOrWhiteSpace(requestedModel))
+            return requestedModel.Trim();
+        if (!string.IsNullOrWhiteSpace(configuredModel))
+            return configuredModel.Trim();
+        return fallbackModel;
     }
 
     private static string? ExtractText(string payload)

--- a/src/OpenClaw.Gateway/Pipeline/PipelineExtensions.cs
+++ b/src/OpenClaw.Gateway/Pipeline/PipelineExtensions.cs
@@ -115,7 +115,8 @@ internal static class PipelineExtensions
             runtime.RuntimeMetrics,
             app.Services.GetService<LearningService>(),
             app.Services.GetService<GatewayAutomationService>(),
-            app.Services.GetService<ContractGovernanceService>());
+            app.Services.GetService<ContractGovernanceService>(),
+            app.Services.GetService<AudioTranscriptionService>());
     }
 
     private static void StartChannels(WebApplication app, GatewayAppRuntime runtime)

--- a/src/OpenClaw.Tests/BrowserToolTests.cs
+++ b/src/OpenClaw.Tests/BrowserToolTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -17,21 +19,32 @@ public class BrowserToolTests
             BrowserHeadless = true,
             BrowserTimeoutSeconds = 30
         };
-        await using var browser = new BrowserTool(config);
+        var previousBrowsersPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
+        var browsersPath = Path.Combine(Path.GetTempPath(), "openclaw-playwright-tests", Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", browsersPath);
 
-        // goto example.com
-        var gotoArgs = "{\"action\": \"goto\", \"url\": \"https://example.com\"}";
-        var gotoRes = await browser.ExecuteAsync(gotoArgs, CancellationToken.None);
-        Assert.Contains("Navigated to", gotoRes);
+        try
+        {
+            await using var browser = new BrowserTool(config);
 
-        // get_text
-        var getTextArgs = "{\"action\": \"get_text\", \"selector\": \"h1\"}";
-        var textRes = await browser.ExecuteAsync(getTextArgs, CancellationToken.None);
-        Assert.Contains("Example Domain", textRes);
-        
-        // evaluate JS
-        var evalArgs = "{\"action\": \"evaluate\", \"script\": \"Math.max(1, 5)\"}";
-        var evalRes = await browser.ExecuteAsync(evalArgs, CancellationToken.None);
-        Assert.Equal("5", evalRes);
+            // goto example.com
+            var gotoArgs = "{\"action\": \"goto\", \"url\": \"https://example.com\"}";
+            var gotoRes = await browser.ExecuteAsync(gotoArgs, CancellationToken.None);
+            Assert.Contains("Navigated to", gotoRes);
+
+            // get_text
+            var getTextArgs = "{\"action\": \"get_text\", \"selector\": \"h1\"}";
+            var textRes = await browser.ExecuteAsync(getTextArgs, CancellationToken.None);
+            Assert.Contains("Example Domain", textRes);
+
+            // evaluate JS
+            var evalArgs = "{\"action\": \"evaluate\", \"script\": \"Math.max(1, 5)\"}";
+            var evalRes = await browser.ExecuteAsync(evalArgs, CancellationToken.None);
+            Assert.Equal("5", evalRes);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", previousBrowsersPath);
+        }
     }
 }

--- a/src/OpenClaw.Tests/MultimodalProviderTests.cs
+++ b/src/OpenClaw.Tests/MultimodalProviderTests.cs
@@ -133,6 +133,115 @@ public sealed class MultimodalProviderTests
     }
 
     [Fact]
+    public async Task GeminiAudioTranscriptionProvider_BlankModelFallsBackToDefault()
+    {
+        var config = new GatewayConfig();
+        config.Llm.ApiKey = "raw:test-key";
+        config.Multimodal.Transcription.Model = "   ";
+        HttpRequestMessage? captured = null;
+        var handler = new CallbackHttpMessageHandler(request =>
+        {
+            captured = request;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"candidates":[{"content":{"parts":[{"text":"fallback model"}]}}]}""",
+                    Encoding.UTF8,
+                    "application/json")
+            };
+        });
+        var gemini = new GeminiMultimodalService(
+            config,
+            new MediaCacheStore(Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"))),
+            NullLogger<GeminiMultimodalService>.Instance,
+            new HttpClient(handler));
+        var provider = new GeminiAudioTranscriptionProvider(gemini);
+
+        await provider.TranscribeAsync(new AudioTranscriptionRequest
+        {
+            AudioUrl = "data:audio/ogg;base64,AQID",
+            MimeType = "audio/ogg",
+            Model = "  ",
+            MaxAudioBytes = 1024
+        }, CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=test-key",
+            captured!.RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task GeminiAudioTranscriptionProvider_RejectsLocalFileOutsideAllowedRoots()
+    {
+        var config = new GatewayConfig();
+        config.Llm.ApiKey = "raw:test-key";
+        var audioPath = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"), "memo.ogg");
+        Directory.CreateDirectory(Path.GetDirectoryName(audioPath)!);
+        await File.WriteAllBytesAsync(audioPath, [1, 2, 3]);
+        var gemini = new GeminiMultimodalService(
+            config,
+            new MediaCacheStore(Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"))),
+            NullLogger<GeminiMultimodalService>.Instance,
+            new HttpClient(new CallbackHttpMessageHandler(_ => throw new InvalidOperationException("HTTP should not be called."))));
+        var provider = new GeminiAudioTranscriptionProvider(gemini);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            provider.TranscribeAsync(new AudioTranscriptionRequest
+            {
+                AudioUrl = new Uri(audioPath).AbsoluteUri,
+                MimeType = "audio/ogg",
+                Model = "gemini-test",
+                MaxAudioBytes = 1024
+            }, CancellationToken.None));
+
+        Assert.Contains("configured media cache root", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GeminiAudioTranscriptionProvider_AllowsLocalFileUnderConfiguredRoot()
+    {
+        var config = new GatewayConfig();
+        config.Llm.ApiKey = "raw:test-key";
+        var root = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
+        var audioPath = Path.Combine(root, "memo.ogg");
+        Directory.CreateDirectory(root);
+        await File.WriteAllBytesAsync(audioPath, [1, 2, 3]);
+        string? capturedBody = null;
+        var handler = new CallbackHttpMessageHandler(request =>
+        {
+            capturedBody = request.Content is null
+                ? null
+                : request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"candidates":[{"content":{"parts":[{"text":"local file transcript"}]}}]}""",
+                    Encoding.UTF8,
+                    "application/json")
+            };
+        });
+        var gemini = new GeminiMultimodalService(
+            config,
+            new MediaCacheStore(Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"))),
+            NullLogger<GeminiMultimodalService>.Instance,
+            new HttpClient(handler));
+        var provider = new GeminiAudioTranscriptionProvider(gemini);
+
+        var result = await provider.TranscribeAsync(new AudioTranscriptionRequest
+        {
+            AudioUrl = new Uri(audioPath).AbsoluteUri,
+            MimeType = "audio/ogg",
+            Model = "gemini-test",
+            MaxAudioBytes = 1024,
+            AllowedLocalFileRoots = [root]
+        }, CancellationToken.None);
+
+        Assert.Contains("\"data\":\"AQID\"", capturedBody, StringComparison.Ordinal);
+        Assert.Equal("local file transcript", result.Text);
+    }
+
+    [Fact]
     public void VoiceMemoTranscriptionText_PrependsTranscriptAndUnavailableMarker()
     {
         var transcribed = VoiceMemoTranscriptionText.PrependTranscript(
@@ -152,6 +261,8 @@ public sealed class MultimodalProviderTests
         Assert.Equal(
             "original text\n[VOICE_TRANSCRIPTION_UNAVAILABLE: timeout]",
             VoiceMemoTranscriptionText.AppendUnavailable("original text", "timeout"));
+        Assert.True(AudioTranscriptionService.ShouldDegrade("degrade"));
+        Assert.False(AudioTranscriptionService.ShouldDegrade("strict"));
     }
 
     [Fact]

--- a/src/OpenClaw.Tests/MultimodalProviderTests.cs
+++ b/src/OpenClaw.Tests/MultimodalProviderTests.cs
@@ -12,6 +12,149 @@ namespace OpenClaw.Tests;
 public sealed class MultimodalProviderTests
 {
     [Fact]
+    public async Task AudioTranscriptionService_Disabled_Throws()
+    {
+        var config = new GatewayConfig();
+        config.Multimodal.Transcription.Enabled = false;
+        var service = new AudioTranscriptionService(
+            config,
+            [new StubAudioTranscriptionProvider("gemini", "ignored")],
+            NullLogger<AudioTranscriptionService>.Instance);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.TranscribeAsync(new InboundMessage
+            {
+                ChannelId = "whatsapp",
+                SenderId = "sender",
+                Text = "",
+                MediaType = "audio",
+                MediaUrl = "data:audio/ogg;base64,AQID"
+            }, CancellationToken.None));
+
+        Assert.Contains("disabled", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AudioTranscriptionService_UsesConfiguredProvider()
+    {
+        var config = new GatewayConfig();
+        config.Multimodal.Transcription.Provider = "other";
+        var providerA = new StubAudioTranscriptionProvider("gemini", "wrong");
+        var providerB = new StubAudioTranscriptionProvider("other", "hello from audio");
+        var service = new AudioTranscriptionService(
+            config,
+            [providerA, providerB],
+            NullLogger<AudioTranscriptionService>.Instance);
+
+        var result = await service.TranscribeAsync(new InboundMessage
+        {
+            ChannelId = "whatsapp",
+            SenderId = "sender",
+            Text = "",
+            MediaType = "audio",
+            MediaUrl = "data:audio/ogg;base64,AQID"
+        }, CancellationToken.None);
+
+        Assert.False(providerA.WasCalled);
+        Assert.True(providerB.WasCalled);
+        Assert.Equal("other", result.Provider);
+        Assert.Equal("hello from audio", result.Text);
+    }
+
+    [Fact]
+    public async Task GeminiAudioTranscriptionProvider_ReturnsTranscript()
+    {
+        var config = new GatewayConfig();
+        config.Llm.ApiKey = "raw:test-key";
+        config.Multimodal.Transcription.Model = "gemini-test";
+        HttpRequestMessage? captured = null;
+        string? capturedBody = null;
+        var handler = new CallbackHttpMessageHandler(request =>
+        {
+            captured = request;
+            capturedBody = request.Content is null
+                ? null
+                : request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"candidates":[{"content":{"parts":[{"text":"Meet me at 4."}]}}]}""",
+                    Encoding.UTF8,
+                    "application/json")
+            };
+        });
+        var gemini = new GeminiMultimodalService(
+            config,
+            new MediaCacheStore(Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"))),
+            NullLogger<GeminiMultimodalService>.Instance,
+            new HttpClient(handler));
+        var provider = new GeminiAudioTranscriptionProvider(gemini);
+
+        var result = await provider.TranscribeAsync(new AudioTranscriptionRequest
+        {
+            AudioUrl = "data:audio/ogg;base64,AQID",
+            MimeType = "audio/ogg",
+            Model = "gemini-test",
+            MaxAudioBytes = 1024
+        }, CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal("https://generativelanguage.googleapis.com/v1beta/models/gemini-test:generateContent?key=test-key", captured!.RequestUri!.ToString());
+        Assert.Contains("\"mime_type\":\"audio/ogg\"", capturedBody, StringComparison.Ordinal);
+        Assert.Contains("\"data\":\"AQID\"", capturedBody, StringComparison.Ordinal);
+        Assert.Equal("gemini", result.Provider);
+        Assert.Equal("Meet me at 4.", result.Text);
+        Assert.Equal("audio/ogg", result.MimeType);
+        Assert.Equal(3, result.SizeBytes);
+    }
+
+    [Fact]
+    public async Task GeminiAudioTranscriptionProvider_RejectsOversizedAudio()
+    {
+        var config = new GatewayConfig();
+        config.Llm.ApiKey = "raw:test-key";
+        var gemini = new GeminiMultimodalService(
+            config,
+            new MediaCacheStore(Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"))),
+            NullLogger<GeminiMultimodalService>.Instance,
+            new HttpClient(new CallbackHttpMessageHandler(_ => throw new InvalidOperationException("HTTP should not be called."))));
+        var provider = new GeminiAudioTranscriptionProvider(gemini);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            provider.TranscribeAsync(new AudioTranscriptionRequest
+            {
+                AudioUrl = "data:audio/ogg;base64,AQID",
+                MimeType = "audio/ogg",
+                Model = "gemini-test",
+                MaxAudioBytes = 2
+            }, CancellationToken.None));
+
+        Assert.Contains("too large", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void VoiceMemoTranscriptionText_PrependsTranscriptAndUnavailableMarker()
+    {
+        var transcribed = VoiceMemoTranscriptionText.PrependTranscript(
+            "original text",
+            new AudioTranscriptionResult
+            {
+                Provider = "gemini",
+                Text = "transcribed text",
+                MimeType = "audio/ogg",
+                SizeBytes = 42
+            });
+
+        Assert.Equal(
+            "[VOICE_TRANSCRIPT provider=gemini]\ntranscribed text\n[/VOICE_TRANSCRIPT]\noriginal text",
+            transcribed);
+
+        Assert.Equal(
+            "original text\n[VOICE_TRANSCRIPTION_UNAVAILABLE: timeout]",
+            VoiceMemoTranscriptionText.AppendUnavailable("original text", "timeout"));
+    }
+
+    [Fact]
     public async Task ElevenLabsProvider_SynthesizeSpeechAsync_UsesConfiguredEndpointAndReturnsDataUrl()
     {
         var storagePath = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
@@ -103,6 +246,32 @@ public sealed class MultimodalProviderTests
         {
             WasCalled = true;
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StubAudioTranscriptionProvider : IAudioTranscriptionProvider
+    {
+        private readonly string _text;
+
+        public StubAudioTranscriptionProvider(string name, string text)
+        {
+            Name = name;
+            _text = text;
+        }
+
+        public string Name { get; }
+        public bool WasCalled { get; private set; }
+
+        public Task<AudioTranscriptionResult> TranscribeAsync(AudioTranscriptionRequest request, CancellationToken ct)
+        {
+            WasCalled = true;
+            return Task.FromResult(new AudioTranscriptionResult
+            {
+                Provider = Name,
+                Text = _text,
+                MimeType = request.MimeType,
+                SizeBytes = 0
+            });
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add configurable inbound voice memo transcription under `Multimodal.Transcription`.
- Add a pluggable `AudioTranscriptionService` with Gemini as the first provider.
- Prepend structured voice transcript blocks before normal agent turns while preserving audio marker behavior by default.
- Record runtime success/failure events and degrade non-fatally when transcription is disabled or unavailable.

## Validation
- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj`