### PR TITLE
[codex] Add URL safety validation for web tools

### DIFF
--- a/src/OpenClaw.Agent/Plugins/NativePluginRegistry.cs
+++ b/src/OpenClaw.Agent/Plugins/NativePluginRegistry.cs
@@ -25,7 +25,7 @@ public sealed class NativePluginRegistry : IDisposable
             RegisterTool(new WebSearchTool(config.WebSearch), "web-search", config.WebSearch.Provider);
 
         if (config.WebFetch.Enabled)
-            RegisterTool(new WebFetchTool(config.WebFetch), "web-fetch");
+            RegisterTool(new WebFetchTool(config.WebFetch, urlSafety: toolingConfig?.UrlSafety), "web-fetch");
 
         if (config.GitTools.Enabled)
             RegisterTool(new GitTool(config.GitTools), "git-tools");

--- a/src/OpenClaw.Agent/Tools/BrowserTool.cs
+++ b/src/OpenClaw.Agent/Tools/BrowserTool.cs
@@ -447,7 +447,11 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
 
                 await route.ContinueAsync();
             }
-            catch
+            catch (PlaywrightException)
+            {
+                await route.AbortAsync();
+            }
+            catch (OperationCanceledException)
             {
                 await route.AbortAsync();
             }

--- a/src/OpenClaw.Agent/Tools/BrowserTool.cs
+++ b/src/OpenClaw.Agent/Tools/BrowserTool.cs
@@ -6,6 +6,7 @@ using Microsoft.Playwright;
 using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Models;
 using OpenClaw.Core.Observability;
+using OpenClaw.Core.Security;
 
 namespace OpenClaw.Agent.Tools;
 
@@ -20,9 +21,104 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
         "Error: Browser tool requires a configured execution backend or sandbox in this runtime. Local Playwright execution is unavailable.";
     private const string SandboxRunnerScript = """
         const { chromium } = require('playwright');
+        const dns = require('dns').promises;
+        const net = require('net');
+
+        function globMatches(pattern, value) {
+          if (!pattern) return false;
+          if (pattern === '*') return true;
+          const escaped = String(pattern).replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+          return new RegExp(`^${escaped}$`, 'i').test(String(value));
+        }
+
+        function isBlockedIpv4(address) {
+          const parts = address.split('.').map((part) => Number(part));
+          if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return true;
+          return parts[0] === 0 ||
+            parts[0] === 10 ||
+            parts[0] === 127 ||
+            (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) ||
+            (parts[0] === 169 && parts[1] === 254) ||
+            (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+            (parts[0] === 192 && parts[1] === 168) ||
+            (parts[0] === 198 && (parts[1] === 18 || parts[1] === 19)) ||
+            parts[0] >= 224;
+        }
+
+        function ipv4ToInt(address) {
+          const parts = address.split('.').map((part) => Number(part));
+          if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return null;
+          return (((parts[0] << 24) >>> 0) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0;
+        }
+
+        function cidrMatches(address, cidr) {
+          if (net.isIP(address) !== 4) return false;
+          const parts = String(cidr || '').split('/');
+          if (parts.length !== 2 || net.isIP(parts[0]) !== 4) return false;
+          const prefix = Number(parts[1]);
+          if (!Number.isInteger(prefix) || prefix < 0 || prefix > 32) return false;
+          const value = ipv4ToInt(address);
+          const network = ipv4ToInt(parts[0]);
+          if (value == null || network == null) return false;
+          const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+          return (value & mask) === (network & mask);
+        }
+
+        function isBlockedIp(address) {
+          const version = net.isIP(address);
+          if (version === 4) return isBlockedIpv4(address);
+          if (version === 6) {
+            const value = address.toLowerCase();
+            return value === '::' ||
+              value === '::1' ||
+              value.startsWith('fe80:') ||
+              value.startsWith('fc') ||
+              value.startsWith('fd') ||
+              value.startsWith('ff');
+          }
+          return true;
+        }
+
+        async function validateUrlSafety(rawUrl, policy) {
+          if (!policy || policy.enabled === false) return;
+          const parsed = new URL(rawUrl);
+          if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            throw new Error('URL safety blocked non-http(s) navigation.');
+          }
+
+          const host = parsed.hostname.toLowerCase().replace(/\.$/, '');
+          const builtInBlocked = ['localhost', '*.localhost', 'metadata', 'metadata.google.internal'];
+          if (policy.blockPrivateNetworkTargets !== false && builtInBlocked.some((pattern) => globMatches(pattern, host))) {
+            throw new Error(`URL safety blocked host '${host}'.`);
+          }
+
+          for (const pattern of policy.blockedHostGlobs || []) {
+            if (globMatches(pattern, host)) throw new Error(`URL safety blocked host '${host}'.`);
+          }
+
+          let addresses;
+          if (net.isIP(host)) {
+            addresses = [host];
+          } else if (policy.blockPrivateNetworkTargets !== false || (policy.blockedCidrs || []).length > 0) {
+            addresses = (await dns.lookup(host, { all: true })).map((item) => item.address);
+          } else {
+            addresses = [];
+          }
+
+          if (policy.blockPrivateNetworkTargets !== false && addresses.some(isBlockedIp)) {
+            throw new Error(`URL safety blocked private or loopback target for '${host}'.`);
+          }
+
+          for (const cidr of policy.blockedCidrs || []) {
+            if (addresses.some((address) => cidrMatches(address, cidr))) {
+              throw new Error(`URL safety blocked CIDR target for '${host}'.`);
+            }
+          }
+        }
 
         (async () => {
           const payload = JSON.parse(process.argv[1] || '{}');
+          payload.urlSafety = JSON.parse(payload.urlSafetyJson || '{}');
           let context;
 
           try {
@@ -30,12 +126,21 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
               headless: payload.headless !== false,
               timeout: payload.timeoutMs || 30000
             });
+            await context.route('**/*', async (route) => {
+              try {
+                await validateUrlSafety(route.request().url(), payload.urlSafety);
+                await route.continue();
+              } catch {
+                await route.abort();
+              }
+            });
 
             const page = context.pages()[0] || await context.newPage();
             let output = '';
 
             switch (payload.action) {
               case 'goto': {
+                await validateUrlSafety(payload.url, payload.urlSafety);
                 await page.goto(payload.url, { waitUntil: 'load' });
                 const title = await page.title();
                 output = `Navigated to ${payload.url}. Title: '${title}'`;
@@ -159,6 +264,7 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
                 Timeout = _config.BrowserTimeoutSeconds * 1000
             });
             _page = await _browser.NewPageAsync();
+            await ConfigureUrlSafetyAsync(_page);
             
             _initialized = true;
         }
@@ -205,6 +311,10 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
                 case "goto":
                 {
                     var url = args.RootElement.GetProperty("url").GetString()!;
+                    var safety = await ValidateBrowserUrlAsync(url, ct);
+                    if (!safety.Allowed)
+                        return safety.ToToolError();
+
                     await WithCancellationAsync(
                         page.GotoAsync(url, new PageGotoOptions { WaitUntil = WaitUntilState.Load }), ct);
                     var title = await WithCancellationAsync(page.TitleAsync(), ct);
@@ -311,7 +421,48 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
 
         ct.ThrowIfCancellationRequested();
         _page = await _browser.NewPageAsync();
+        await ConfigureUrlSafetyAsync(_page);
         return _page;
+    }
+
+    private async Task ConfigureUrlSafetyAsync(IPage page)
+    {
+        if (!_config.UrlSafety.Enabled)
+            return;
+
+        await page.RouteAsync("**/*", async route =>
+        {
+            try
+            {
+                if (Uri.TryCreate(route.Request.Url, UriKind.Absolute, out var uri) &&
+                    (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+                {
+                    var safety = await UrlSafetyValidator.ValidateHttpUrlAsync(uri, _config.UrlSafety, CancellationToken.None);
+                    if (!safety.Allowed)
+                    {
+                        await route.AbortAsync();
+                        return;
+                    }
+                }
+
+                await route.ContinueAsync();
+            }
+            catch
+            {
+                await route.AbortAsync();
+            }
+        });
+    }
+
+    private async ValueTask<UrlSafetyValidationResult> ValidateBrowserUrlAsync(string url, CancellationToken ct)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return UrlSafetyValidationResult.Deny("only absolute http(s) URLs are allowed.");
+        }
+
+        return await UrlSafetyValidator.ValidateHttpUrlAsync(uri, _config.UrlSafety, ct);
     }
 
     private static async Task ClosePageBestEffortAsync(IPage page)
@@ -390,13 +541,14 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
             ["action"] = action,
             ["headless"] = _config.BrowserHeadless,
             ["timeoutMs"] = _config.BrowserTimeoutSeconds * 1000,
-            ["userDataDir"] = SandboxProfileDir
+            ["userDataDir"] = SandboxProfileDir,
+            ["urlSafetyJson"] = JsonSerializer.Serialize(_config.UrlSafety, CoreJsonContext.Default.UrlSafetyConfig)
         };
 
         switch (action)
         {
             case "goto":
-                payload["url"] = ReadRequiredString(args.RootElement, "url");
+                payload["url"] = ReadValidatedHttpUrl(args.RootElement, "url");
                 break;
 
             case "click":
@@ -442,4 +594,20 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
         => element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
             ? property.GetString()
             : null;
+
+    private string ReadValidatedHttpUrl(JsonElement element, string propertyName)
+    {
+        var value = ReadRequiredString(element, propertyName);
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new ToolSandboxException("Error: only absolute http(s) URLs are allowed.");
+        }
+
+        var safety = UrlSafetyValidator.ValidateHttpUrl(uri, _config.UrlSafety);
+        if (!safety.Allowed)
+            throw new ToolSandboxException(safety.ToToolError());
+
+        return value;
+    }
 }

--- a/src/OpenClaw.Agent/Tools/WebFetchTool.cs
+++ b/src/OpenClaw.Agent/Tools/WebFetchTool.cs
@@ -5,7 +5,9 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Http;
+using OpenClaw.Core.Models;
 using OpenClaw.Core.Plugins;
+using OpenClaw.Core.Security;
 
 namespace OpenClaw.Agent.Tools;
 
@@ -16,12 +18,14 @@ namespace OpenClaw.Agent.Tools;
 public sealed partial class WebFetchTool : ITool, IDisposable
 {
     private readonly WebFetchConfig _config;
+    private readonly UrlSafetyConfig _urlSafety;
     private readonly HttpClient _http;
     private const int MaxRedirects = 5;
 
-    public WebFetchTool(WebFetchConfig config, HttpClient? httpClient = null)
+    public WebFetchTool(WebFetchConfig config, HttpClient? httpClient = null, UrlSafetyConfig? urlSafety = null)
     {
         _config = config;
+        _urlSafety = config.UrlSafety ?? urlSafety ?? new UrlSafetyConfig();
         _http = httpClient ?? HttpClientFactory.Create(allowAutoRedirect: false);
         _http.DefaultRequestHeaders.UserAgent.ParseAdd(config.UserAgent);
     }
@@ -61,10 +65,9 @@ public sealed partial class WebFetchTool : ITool, IDisposable
         var redirects = 0;
         while (true)
         {
-            // SSRF protection: block internal/metadata IPs (re-check on each hop)
-            var ssrfError = await CheckSsrfAsync(current);
-            if (ssrfError is not null)
-                return ssrfError;
+            var safety = await UrlSafetyValidator.ValidateHttpUrlAsync(current, _urlSafety, ct);
+            if (!safety.Allowed)
+                return safety.ToToolError();
 
             try
             {
@@ -183,61 +186,6 @@ public sealed partial class WebFetchTool : ITool, IDisposable
         cleaned = MultiNewlineRegex().Replace(cleaned, "\n\n");
 
         return cleaned;
-    }
-
-    /// <summary>
-    /// SSRF protection: resolve the hostname and block internal/metadata IPs.
-    /// </summary>
-    private static async Task<string?> CheckSsrfAsync(Uri uri)
-    {
-        try
-        {
-            var addresses = await Dns.GetHostAddressesAsync(uri.Host);
-            foreach (var ip in addresses)
-            {
-                if (IsBlockedIp(ip))
-                    return $"Error: Access denied — the resolved address ({ip}) is blocked for security reasons.";
-            }
-            return null;
-        }
-        catch (Exception ex)
-        {
-            return $"Error: DNS resolution failed for {uri.Host} — {ex.Message}";
-        }
-    }
-
-    /// <summary>
-    /// Returns true if the IP is loopback, link-local, private (RFC 1918), or a cloud metadata address.
-    /// </summary>
-    private static bool IsBlockedIp(IPAddress ip)
-    {
-        if (ip.IsIPv4MappedToIPv6)
-            return IsBlockedIp(ip.MapToIPv4());
-
-        if (IPAddress.IsLoopback(ip)) return true;
-        if (ip.IsIPv6LinkLocal) return true;
-        if (ip.IsIPv6SiteLocal) return true;
-
-        var bytes = ip.GetAddressBytes();
-        if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork && bytes.Length == 4)
-        {
-            return
-                bytes[0] == 10 || // 10.0.0.0/8
-                (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) || // 172.16.0.0/12
-                (bytes[0] == 192 && bytes[1] == 168) || // 192.168.0.0/16
-                (bytes[0] == 169 && bytes[1] == 254) || // 169.254.0.0/16 (link-local + cloud metadata)
-                bytes[0] == 127 || // 127.0.0.0/8
-                bytes[0] == 0; // 0.0.0.0/8
-        }
-
-        if (ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6 && bytes.Length == 16)
-        {
-            // Unique local addresses fc00::/7
-            if ((bytes[0] & 0xFE) == 0xFC)
-                return true;
-        }
-
-        return false;
     }
 
     private static bool IsRedirectStatus(HttpStatusCode statusCode) =>

--- a/src/OpenClaw.Core/Models/GatewayConfig.cs
+++ b/src/OpenClaw.Core/Models/GatewayConfig.cs
@@ -285,6 +285,21 @@ public sealed class SecurityConfig
     public int BrowserRememberDays { get; set; } = 30;
 }
 
+public sealed class UrlSafetyConfig
+{
+    /// <summary>Enable URL validation for tools that initiate outbound navigation or fetches.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Block loopback, private, link-local, metadata, and other non-public address ranges.</summary>
+    public bool BlockPrivateNetworkTargets { get; set; } = true;
+
+    /// <summary>Additional host globs to block. Examples: ["*.internal", "metadata.google.internal"].</summary>
+    public string[] BlockedHostGlobs { get; set; } = [];
+
+    /// <summary>Additional CIDR ranges to block. Examples: ["203.0.113.0/24", "2001:db8::/32"].</summary>
+    public string[] BlockedCidrs { get; set; } = [];
+}
+
 public sealed class WebSocketConfig
 {
     public int MaxMessageBytes { get; set; } = 256 * 1024;
@@ -352,6 +367,7 @@ public sealed class ToolingConfig
     public bool AllowBrowserEvaluate { get; set; } = true;
     public bool BrowserHeadless { get; set; } = true;
     public int BrowserTimeoutSeconds { get; set; } = 30;
+    public UrlSafetyConfig UrlSafety { get; set; } = new();
     public Dictionary<string, ToolsetConfig> Toolsets { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     public Dictionary<string, ToolPresetConfig> Presets { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     public Dictionary<string, string> SurfaceBindings { get; set; } = new(StringComparer.OrdinalIgnoreCase);

--- a/src/OpenClaw.Core/Models/Session.cs
+++ b/src/OpenClaw.Core/Models/Session.cs
@@ -314,6 +314,7 @@ public sealed class SessionDelegationChildSummary
 [JsonSerializable(typeof(MemoryRecallConfig))]
 [JsonSerializable(typeof(MemoryRetentionConfig))]
 [JsonSerializable(typeof(SecurityConfig))]
+[JsonSerializable(typeof(UrlSafetyConfig))]
 [JsonSerializable(typeof(WebSocketConfig))]
 [JsonSerializable(typeof(ToolingConfig))]
 [JsonSerializable(typeof(ToolsetConfig))]

--- a/src/OpenClaw.Core/Plugins/PluginModels.cs
+++ b/src/OpenClaw.Core/Plugins/PluginModels.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using OpenClaw.Core.Models;
 
 namespace OpenClaw.Core.Plugins;
 
@@ -358,6 +359,9 @@ public sealed class WebFetchConfig
 
     /// <summary>User-Agent header for outbound requests.</summary>
     public string UserAgent { get; set; } = "OpenClaw/1.0";
+
+    /// <summary>Optional tool-specific URL safety override. Falls back to Tooling.UrlSafety when unset.</summary>
+    public UrlSafetyConfig? UrlSafety { get; set; }
 }
 
 public sealed class GitToolsConfig

--- a/src/OpenClaw.Core/Security/UrlSafetyValidator.cs
+++ b/src/OpenClaw.Core/Security/UrlSafetyValidator.cs
@@ -73,16 +73,18 @@ public static class UrlSafetyValidator
         if (string.IsNullOrWhiteSpace(host))
             return UrlSafetyValidationResult.Deny("URL host is empty.");
 
-        foreach (var pattern in BuiltInBlockedHostGlobs)
+        if (policy.BlockPrivateNetworkTargets)
         {
-            if (policy.BlockPrivateNetworkTargets && GlobMatcher.IsMatch(pattern, host, StringComparison.OrdinalIgnoreCase))
-                return UrlSafetyValidationResult.Deny($"host '{host}' is blocked.");
+            foreach (var pattern in BuiltInBlockedHostGlobs)
+            {
+                if (GlobMatcher.IsMatch(pattern, host, StringComparison.OrdinalIgnoreCase))
+                    return UrlSafetyValidationResult.Deny($"host '{host}' is blocked.");
+            }
         }
 
-        foreach (var pattern in policy.BlockedHostGlobs)
+        foreach (var pattern in policy.BlockedHostGlobs.Where(static p => !string.IsNullOrWhiteSpace(p)))
         {
-            if (!string.IsNullOrWhiteSpace(pattern) &&
-                GlobMatcher.IsMatch(pattern.Trim(), host, StringComparison.OrdinalIgnoreCase))
+            if (GlobMatcher.IsMatch(pattern.Trim(), host, StringComparison.OrdinalIgnoreCase))
             {
                 return UrlSafetyValidationResult.Deny($"host '{host}' matches blocklist entry '{pattern}'.");
             }
@@ -121,11 +123,8 @@ public static class UrlSafetyValidator
             if (policy.BlockPrivateNetworkTargets && IsNonPublicAddress(normalized))
                 return UrlSafetyValidationResult.Deny($"host '{host}' resolves to non-public address {normalized}.");
 
-            foreach (var cidr in policy.BlockedCidrs)
+            foreach (var cidr in policy.BlockedCidrs.Where(static c => !string.IsNullOrWhiteSpace(c)))
             {
-                if (string.IsNullOrWhiteSpace(cidr))
-                    continue;
-
                 if (AddressMatchesCidr(normalized, cidr.Trim()))
                     return UrlSafetyValidationResult.Deny($"host '{host}' resolves to {normalized}, which matches blocked CIDR '{cidr}'.");
             }

--- a/src/OpenClaw.Core/Security/UrlSafetyValidator.cs
+++ b/src/OpenClaw.Core/Security/UrlSafetyValidator.cs
@@ -1,0 +1,218 @@
+using System.Net;
+using System.Net.Sockets;
+using OpenClaw.Core.Models;
+
+namespace OpenClaw.Core.Security;
+
+public sealed record UrlSafetyValidationResult(bool Allowed, string? Reason)
+{
+    public static UrlSafetyValidationResult Allow { get; } = new(true, null);
+
+    public static UrlSafetyValidationResult Deny(string reason) => new(false, reason);
+
+    public string ToToolError()
+        => Allowed ? "" : $"Error: URL blocked by safety policy - {Reason}";
+}
+
+public static class UrlSafetyValidator
+{
+    private static readonly string[] BuiltInBlockedHostGlobs =
+    [
+        "localhost",
+        "*.localhost",
+        "metadata",
+        "metadata.google.internal"
+    ];
+
+    public static async ValueTask<UrlSafetyValidationResult> ValidateHttpUrlAsync(
+        Uri uri,
+        UrlSafetyConfig? config,
+        CancellationToken ct = default)
+    {
+        var preliminary = ValidateHttpUrl(uri, config, resolveDns: false);
+        if (!preliminary.Allowed)
+            return preliminary;
+
+        var policy = config ?? new UrlSafetyConfig();
+        if (!policy.Enabled || (!policy.BlockPrivateNetworkTargets && policy.BlockedCidrs.Length == 0))
+            return UrlSafetyValidationResult.Allow;
+
+        var host = NormalizeHost(uri);
+        if (IPAddress.TryParse(host, out _))
+            return preliminary;
+
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await Dns.GetHostAddressesAsync(host, ct);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        {
+            return UrlSafetyValidationResult.Deny($"DNS resolution failed for '{host}': {ex.Message}");
+        }
+
+        if (addresses.Length == 0)
+            return UrlSafetyValidationResult.Deny($"DNS resolution returned no addresses for '{host}'.");
+
+        return ValidateAddresses(addresses, policy, host);
+    }
+
+    public static UrlSafetyValidationResult ValidateHttpUrl(
+        Uri uri,
+        UrlSafetyConfig? config,
+        bool resolveDns = true)
+    {
+        var policy = config ?? new UrlSafetyConfig();
+        if (!policy.Enabled)
+            return UrlSafetyValidationResult.Allow;
+
+        if (!uri.IsAbsoluteUri || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+            return UrlSafetyValidationResult.Deny("only absolute http(s) URLs are allowed.");
+
+        var host = NormalizeHost(uri);
+        if (string.IsNullOrWhiteSpace(host))
+            return UrlSafetyValidationResult.Deny("URL host is empty.");
+
+        foreach (var pattern in BuiltInBlockedHostGlobs)
+        {
+            if (policy.BlockPrivateNetworkTargets && GlobMatcher.IsMatch(pattern, host, StringComparison.OrdinalIgnoreCase))
+                return UrlSafetyValidationResult.Deny($"host '{host}' is blocked.");
+        }
+
+        foreach (var pattern in policy.BlockedHostGlobs)
+        {
+            if (!string.IsNullOrWhiteSpace(pattern) &&
+                GlobMatcher.IsMatch(pattern.Trim(), host, StringComparison.OrdinalIgnoreCase))
+            {
+                return UrlSafetyValidationResult.Deny($"host '{host}' matches blocklist entry '{pattern}'.");
+            }
+        }
+
+        if (IPAddress.TryParse(host, out var literalIp))
+            return ValidateAddresses([literalIp], policy, host);
+
+        if (!resolveDns || (!policy.BlockPrivateNetworkTargets && policy.BlockedCidrs.Length == 0))
+            return UrlSafetyValidationResult.Allow;
+
+        IPAddress[] addresses;
+        try
+        {
+            addresses = Dns.GetHostAddresses(host);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        {
+            return UrlSafetyValidationResult.Deny($"DNS resolution failed for '{host}': {ex.Message}");
+        }
+
+        if (addresses.Length == 0)
+            return UrlSafetyValidationResult.Deny($"DNS resolution returned no addresses for '{host}'.");
+
+        return ValidateAddresses(addresses, policy, host);
+    }
+
+    private static UrlSafetyValidationResult ValidateAddresses(
+        IReadOnlyList<IPAddress> addresses,
+        UrlSafetyConfig policy,
+        string host)
+    {
+        foreach (var address in addresses)
+        {
+            var normalized = address.IsIPv4MappedToIPv6 ? address.MapToIPv4() : address;
+            if (policy.BlockPrivateNetworkTargets && IsNonPublicAddress(normalized))
+                return UrlSafetyValidationResult.Deny($"host '{host}' resolves to non-public address {normalized}.");
+
+            foreach (var cidr in policy.BlockedCidrs)
+            {
+                if (string.IsNullOrWhiteSpace(cidr))
+                    continue;
+
+                if (AddressMatchesCidr(normalized, cidr.Trim()))
+                    return UrlSafetyValidationResult.Deny($"host '{host}' resolves to {normalized}, which matches blocked CIDR '{cidr}'.");
+            }
+        }
+
+        return UrlSafetyValidationResult.Allow;
+    }
+
+    private static string NormalizeHost(Uri uri)
+        => uri.Host.Trim().TrimEnd('.').ToLowerInvariant();
+
+    private static bool IsNonPublicAddress(IPAddress ip)
+    {
+        if (IPAddress.IsLoopback(ip))
+            return true;
+
+        if (ip.Equals(IPAddress.Any) || ip.Equals(IPAddress.IPv6Any) || ip.Equals(IPAddress.None))
+            return true;
+
+        if (ip.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var bytes = ip.GetAddressBytes();
+            return bytes[0] == 0 ||
+                   bytes[0] == 10 ||
+                   bytes[0] == 127 ||
+                   (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) ||
+                   (bytes[0] == 169 && bytes[1] == 254) ||
+                   (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) ||
+                   (bytes[0] == 192 && bytes[1] == 168) ||
+                   (bytes[0] == 198 && (bytes[1] == 18 || bytes[1] == 19)) ||
+                   bytes[0] >= 224;
+        }
+
+        if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            if (ip.IsIPv6LinkLocal || ip.IsIPv6SiteLocal || ip.IsIPv6Multicast)
+                return true;
+
+            var bytes = ip.GetAddressBytes();
+            return ip.Equals(IPAddress.IPv6None) ||
+                   (bytes[0] & 0xFE) == 0xFC;
+        }
+
+        return true;
+    }
+
+    private static bool AddressMatchesCidr(IPAddress address, string cidr)
+    {
+        var separator = cidr.IndexOf('/', StringComparison.Ordinal);
+        if (separator <= 0 || separator == cidr.Length - 1)
+            return false;
+
+        var networkText = cidr[..separator];
+        var prefixText = cidr[(separator + 1)..];
+        if (!IPAddress.TryParse(networkText, out var network) ||
+            !int.TryParse(prefixText, out var prefixLength))
+        {
+            return false;
+        }
+
+        if (address.IsIPv4MappedToIPv6)
+            address = address.MapToIPv4();
+        if (network.IsIPv4MappedToIPv6)
+            network = network.MapToIPv4();
+
+        if (address.AddressFamily != network.AddressFamily)
+            return false;
+
+        var addressBytes = address.GetAddressBytes();
+        var networkBytes = network.GetAddressBytes();
+        var maxPrefix = addressBytes.Length * 8;
+        if (prefixLength < 0 || prefixLength > maxPrefix)
+            return false;
+
+        var fullBytes = prefixLength / 8;
+        var remainingBits = prefixLength % 8;
+
+        for (var i = 0; i < fullBytes; i++)
+        {
+            if (addressBytes[i] != networkBytes[i])
+                return false;
+        }
+
+        if (remainingBits == 0)
+            return true;
+
+        var mask = (byte)(0xFF << (8 - remainingBits));
+        return (addressBytes[fullBytes] & mask) == (networkBytes[fullBytes] & mask);
+    }
+}

--- a/src/OpenClaw.Core/Validation/ConfigValidator.cs
+++ b/src/OpenClaw.Core/Validation/ConfigValidator.cs
@@ -423,11 +423,8 @@ public static class ConfigValidator
 
     private static void ValidateUrlSafety(string path, UrlSafetyConfig config, List<string> errors)
     {
-        foreach (var cidr in config.BlockedCidrs)
+        foreach (var cidr in config.BlockedCidrs.Where(static c => !string.IsNullOrWhiteSpace(c)))
         {
-            if (string.IsNullOrWhiteSpace(cidr))
-                continue;
-
             var parts = cidr.Split('/', 2, StringSplitOptions.TrimEntries);
             if (parts.Length != 2 ||
                 !System.Net.IPAddress.TryParse(parts[0], out var address) ||

--- a/src/OpenClaw.Core/Validation/ConfigValidator.cs
+++ b/src/OpenClaw.Core/Validation/ConfigValidator.cs
@@ -109,6 +109,10 @@ public static class ConfigValidator
         if (config.Tooling.ToolTimeoutSeconds < 0)
             errors.Add($"Tooling.ToolTimeoutSeconds must be >= 0 (got {config.Tooling.ToolTimeoutSeconds}).");
 
+        ValidateUrlSafety("Tooling.UrlSafety", config.Tooling.UrlSafety, errors);
+        if (config.Plugins.Native.WebFetch.UrlSafety is not null)
+            ValidateUrlSafety("Plugins.Native.WebFetch.UrlSafety", config.Plugins.Native.WebFetch.UrlSafety, errors);
+
         if (config.Tooling.WorkspaceOnly)
         {
             var resolvedWorkspaceRoot = ResolveConfiguredPath(config.Tooling.WorkspaceRoot);
@@ -414,6 +418,28 @@ public static class ConfigValidator
 
             if (credentialSourceCount > 1)
                 errors.Add($"CodingBackends.{backend.BackendId}.Credentials must specify at most one of SecretRef, TokenFilePath, or ConnectedAccountId.");
+        }
+    }
+
+    private static void ValidateUrlSafety(string path, UrlSafetyConfig config, List<string> errors)
+    {
+        foreach (var cidr in config.BlockedCidrs)
+        {
+            if (string.IsNullOrWhiteSpace(cidr))
+                continue;
+
+            var parts = cidr.Split('/', 2, StringSplitOptions.TrimEntries);
+            if (parts.Length != 2 ||
+                !System.Net.IPAddress.TryParse(parts[0], out var address) ||
+                !int.TryParse(parts[1], out var prefixLength))
+            {
+                errors.Add($"{path}.BlockedCidrs entry '{cidr}' must be a valid CIDR block.");
+                continue;
+            }
+
+            var maxPrefix = address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork ? 32 : 128;
+            if (prefixLength < 0 || prefixLength > maxPrefix)
+                errors.Add($"{path}.BlockedCidrs entry '{cidr}' has an invalid prefix length.");
         }
     }
 

--- a/src/OpenClaw.Tests/UrlSafetyValidatorTests.cs
+++ b/src/OpenClaw.Tests/UrlSafetyValidatorTests.cs
@@ -1,0 +1,61 @@
+using OpenClaw.Agent.Tools;
+using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Plugins;
+using OpenClaw.Core.Security;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class UrlSafetyValidatorTests
+{
+    [Theory]
+    [InlineData("http://127.0.0.1:8080")]
+    [InlineData("http://localhost:8080")]
+    [InlineData("http://10.0.0.2")]
+    [InlineData("http://169.254.169.254/latest/meta-data")]
+    public async Task ValidateHttpUrlAsync_BlocksPrivateTargetsByDefault(string url)
+    {
+        var result = await UrlSafetyValidator.ValidateHttpUrlAsync(new Uri(url), new UrlSafetyConfig(), CancellationToken.None);
+
+        Assert.False(result.Allowed);
+        Assert.Contains("blocked", result.ToToolError(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ValidateHttpUrlAsync_HonorsConfiguredHostBlocklist()
+    {
+        var result = await UrlSafetyValidator.ValidateHttpUrlAsync(
+            new Uri("https://docs.example.com"),
+            new UrlSafetyConfig
+            {
+                BlockPrivateNetworkTargets = false,
+                BlockedHostGlobs = ["*.example.com"]
+            },
+            CancellationToken.None);
+
+        Assert.False(result.Allowed);
+        Assert.Contains("blocklist", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task WebFetchTool_BlocksLoopbackBeforeHttpRequest()
+    {
+        using var tool = new WebFetchTool(new WebFetchConfig { Enabled = true });
+
+        var result = await tool.ExecuteAsync("""{"url":"http://127.0.0.1:18789"}""", CancellationToken.None);
+
+        Assert.Contains("URL blocked", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BrowserTool_CreateSandboxRequest_BlocksLoopbackGoto()
+    {
+        var tool = new BrowserTool(new ToolingConfig { EnableBrowserTool = true });
+
+        var ex = Assert.Throws<ToolSandboxException>(() =>
+            ((ISandboxCapableTool)tool).CreateSandboxRequest("""{"action":"goto","url":"http://127.0.0.1:18789"}"""));
+
+        Assert.Contains("URL blocked", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## What changed

Adds a shared URL safety validator for tool-initiated HTTP(S) traffic and wires it into web fetch and browser tooling.

- Blocks loopback, private, link-local, metadata, multicast, and other non-public targets by default.
- Supports global `Tooling.UrlSafety` policy plus per-web-fetch overrides and custom host/CIDR blocklists.
- Rechecks web fetch redirects and browser navigation/subresource requests.
- Adds config validation and focused coverage for validator, web fetch, and browser sandbox request behavior.

## Why

Outbound fetch/navigation tools need SSRF-oriented validation that is easy to enable globally while still configurable for operators.

## Validation

- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj --filter "FullyQualifiedName~UrlSafetyValidatorTests"` in `/tmp/openclaw-url-safety`: 7 passed
- `dotnet test OpenClaw.Net.slnx --no-build` in `/Users/telli/Desktop/openclaw.net`: 1,019 passed
- `git diff --check`