### PR TITLE
Fix post-merge Docker and AOT smoke failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,14 @@ COPY src/OpenClaw.Core/OpenClaw.Core.csproj        src/OpenClaw.Core/
 COPY src/OpenClaw.Agent/OpenClaw.Agent.csproj       src/OpenClaw.Agent/
 COPY src/OpenClaw.Channels/OpenClaw.Channels.csproj src/OpenClaw.Channels/
 COPY src/OpenClaw.Gateway/OpenClaw.Gateway.csproj   src/OpenClaw.Gateway/
+COPY src/OpenClaw.PluginKit/OpenClaw.PluginKit.csproj src/OpenClaw.PluginKit/
 
 # Restore (cached unless csproj files change)
 RUN dotnet restore src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
 
 # Copy all source
 COPY src/ src/
+COPY compat/ compat/
 
 # Publish Gateway as NativeAOT single-file binary
 RUN dotnet publish src/OpenClaw.Gateway/OpenClaw.Gateway.csproj \

--- a/eng/verify-aot-maf-smoke.sh
+++ b/eng/verify-aot-maf-smoke.sh
@@ -27,13 +27,21 @@ GATEWAY_CONFIG="$WORK_DIR/gateway.maf.aot.smoke.json"
 cat > "$GATEWAY_CONFIG" <<JSON
 {
   "OpenClaw": {
+    "BindAddress": "127.0.0.1",
     "Port": 19929,
     "Runtime": {
       "Mode": "aot",
       "Orchestrator": "maf"
     },
+    "Llm": {
+      "Provider": "ollama",
+      "Model": "llama3.2"
+    },
     "Memory": {
       "StoragePath": "$WORK_DIR/memory"
+    },
+    "Tooling": {
+      "EnableBrowserTool": false
     }
   }
 }
@@ -64,7 +72,10 @@ resolve_binary() {
 GATEWAY_BIN="$(resolve_binary "$ARTIFACTS_DIR/gateway" "OpenClaw.Gateway")"
 
 echo "Running NativeAOT gateway --doctor..."
-MODEL_PROVIDER_KEY="smoke-test-key" "$GATEWAY_BIN" --config "$GATEWAY_CONFIG" --doctor >/tmp/openclaw-aot-maf-doctor.log 2>&1
+if ! MODEL_PROVIDER_KEY="smoke-test-key" "$GATEWAY_BIN" --config "$GATEWAY_CONFIG" --doctor >/tmp/openclaw-aot-maf-doctor.log 2>&1; then
+  cat /tmp/openclaw-aot-maf-doctor.log >&2
+  exit 1
+fi
 
 echo "Starting NativeAOT gateway..."
 MODEL_PROVIDER_KEY="smoke-test-key" "$GATEWAY_BIN" --config "$GATEWAY_CONFIG" >/tmp/openclaw-aot-maf-gateway.log 2>&1 &

--- a/eng/verify-aot-smoke.sh
+++ b/eng/verify-aot-smoke.sh
@@ -27,9 +27,20 @@ GATEWAY_CONFIG="$WORK_DIR/gateway.smoke.json"
 cat > "$GATEWAY_CONFIG" <<JSON
 {
   "OpenClaw": {
+    "BindAddress": "127.0.0.1",
     "Port": 19899,
+    "Runtime": {
+      "Mode": "aot"
+    },
+    "Llm": {
+      "Provider": "ollama",
+      "Model": "llama3.2"
+    },
     "Memory": {
       "StoragePath": "$WORK_DIR/memory"
+    },
+    "Tooling": {
+      "EnableBrowserTool": false
     }
   }
 }
@@ -66,7 +77,10 @@ GATEWAY_BIN="$(resolve_binary "$ARTIFACTS_DIR/gateway" "OpenClaw.Gateway")"
 CLI_BIN="$(resolve_binary "$ARTIFACTS_DIR/cli" "openclaw")"
 
 echo "Running published gateway --doctor..."
-MODEL_PROVIDER_KEY="smoke-test-key" "$GATEWAY_BIN" --config "$GATEWAY_CONFIG" --doctor >/tmp/openclaw-aot-doctor.log 2>&1
+if ! MODEL_PROVIDER_KEY="smoke-test-key" "$GATEWAY_BIN" --config "$GATEWAY_CONFIG" --doctor >/tmp/openclaw-aot-doctor.log 2>&1; then
+  cat /tmp/openclaw-aot-doctor.log >&2
+  exit 1
+fi
 
 echo "Starting published gateway..."
 MODEL_PROVIDER_KEY="smoke-test-key" "$GATEWAY_BIN" --config "$GATEWAY_CONFIG" >/tmp/openclaw-aot-gateway.log 2>&1 &


### PR DESCRIPTION
## Summary
- copy the compatibility catalog into Docker builds so the embedded public-smoke resource is available
- make NativeAOT smoke configs explicit loopback/AOT configs and disable the browser tool for the NativeAOT smoke runtime
- print AOT doctor logs when smoke doctor fails

## Validation
- bash -n eng/verify-aot-smoke.sh eng/verify-aot-maf-smoke.sh
- git diff --check
- local gateway --doctor with the standard AOT smoke config
- local MAF gateway --doctor with -p:OpenClawEnableMafExperiment=true and the MAF AOT smoke config

Docker daemon and local macOS NativeAOT publish were not available/reliable in this environment; CI will validate those Linux paths.