### PR TITLE
[codex] Add insights, URL safety, and trajectory export

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ OpenClaw.NET now treats Ollama as a first-class native provider at `http://127.0
 
 When binding to a non-loopback address, the gateway **refuses to start** unless dangerous settings are explicitly hardened (auth token required, tooling roots restricted, signature validation enforced, `raw:` secret refs rejected). See [SECURITY.md](SECURITY.md) before exposing the gateway publicly.
 
+Outbound web fetches and browser navigations run through `OpenClaw:Tooling:UrlSafety` by default. The safe default blocks loopback, private/link-local, multicast, and metadata hosts; operators can disable the policy intentionally or add `BlockedHostGlobs` and `BlockedCidrs` for environment-specific deny lists.
+
 ## Docs
 
 The full documentation map lives at **[docs/README.md](docs/README.md)**. Starting points:

--- a/src/OpenClaw.Agent/Tools/BrowserTool.cs
+++ b/src/OpenClaw.Agent/Tools/BrowserTool.cs
@@ -51,17 +51,65 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
           return (((parts[0] << 24) >>> 0) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0;
         }
 
+        function ipv6ToBigInt(address) {
+          const zoneIndex = address.indexOf('%');
+          let text = (zoneIndex >= 0 ? address.slice(0, zoneIndex) : address).toLowerCase();
+          const lastColon = text.lastIndexOf(':');
+          const tail = lastColon >= 0 ? text.slice(lastColon + 1) : text;
+          if (tail.includes('.')) {
+            const ipv4 = ipv4ToInt(tail);
+            if (ipv4 == null) return null;
+            const high = ((ipv4 >>> 16) & 0xffff).toString(16);
+            const low = (ipv4 & 0xffff).toString(16);
+            text = `${text.slice(0, lastColon)}:${high}:${low}`;
+          }
+
+          const halves = text.split('::');
+          if (halves.length > 2) return null;
+
+          const left = halves[0] ? halves[0].split(':') : [];
+          const right = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+          if (left.concat(right).some((part) => !/^[0-9a-f]{1,4}$/.test(part))) return null;
+
+          const missing = 8 - left.length - right.length;
+          if ((halves.length === 1 && missing !== 0) || (halves.length === 2 && missing < 1)) return null;
+
+          const groups = left.concat(Array(Math.max(0, missing)).fill('0'), right);
+          if (groups.length !== 8) return null;
+
+          let value = 0n;
+          for (const group of groups) {
+            value = (value << 16n) + BigInt(parseInt(group, 16));
+          }
+          return value;
+        }
+
+        function ipToBigInt(address) {
+          const version = net.isIP(address);
+          if (version === 4) {
+            const value = ipv4ToInt(address);
+            return value == null ? null : { value: BigInt(value), bits: 32 };
+          }
+          if (version === 6) {
+            const value = ipv6ToBigInt(address);
+            return value == null ? null : { value, bits: 128 };
+          }
+          return null;
+        }
+
         function cidrMatches(address, cidr) {
-          if (net.isIP(address) !== 4) return false;
           const parts = String(cidr || '').split('/');
-          if (parts.length !== 2 || net.isIP(parts[0]) !== 4) return false;
+          if (parts.length !== 2) return false;
+          const addressValue = ipToBigInt(address);
+          const networkValue = ipToBigInt(parts[0]);
+          if (!addressValue || !networkValue || addressValue.bits !== networkValue.bits) return false;
+
           const prefix = Number(parts[1]);
-          if (!Number.isInteger(prefix) || prefix < 0 || prefix > 32) return false;
-          const value = ipv4ToInt(address);
-          const network = ipv4ToInt(parts[0]);
-          if (value == null || network == null) return false;
-          const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
-          return (value & mask) === (network & mask);
+          if (!Number.isInteger(prefix) || prefix < 0 || prefix > addressValue.bits) return false;
+          if (prefix === 0) return true;
+
+          const shift = BigInt(addressValue.bits - prefix);
+          return (addressValue.value >> shift) === (networkValue.value >> shift);
         }
 
         function isBlockedIp(address) {
@@ -69,12 +117,20 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
           if (version === 4) return isBlockedIpv4(address);
           if (version === 6) {
             const value = address.toLowerCase();
+            const mapped = ipv6ToBigInt(value);
+            if (mapped != null && (mapped >> 32n) === 0xffffn) {
+              const tail = Number(mapped & 0xffffffffn);
+              const dotted = `${(tail >>> 24) & 0xff}.${(tail >>> 16) & 0xff}.${(tail >>> 8) & 0xff}.${tail & 0xff}`;
+              return isBlockedIpv4(dotted);
+            }
+
+            const firstGroup = parseInt(value.split(':', 1)[0] || '0', 16);
             return value === '::' ||
               value === '::1' ||
-              value.startsWith('fe80:') ||
-              value.startsWith('fc') ||
-              value.startsWith('fd') ||
-              value.startsWith('ff');
+              (Number.isInteger(firstGroup) && (firstGroup & 0xffc0) === 0xfe80) ||
+              (Number.isInteger(firstGroup) && (firstGroup & 0xffc0) === 0xfec0) ||
+              (Number.isInteger(firstGroup) && (firstGroup & 0xfe00) === 0xfc00) ||
+              (Number.isInteger(firstGroup) && (firstGroup & 0xff00) === 0xff00);
           }
           return true;
         }
@@ -86,7 +142,8 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
             throw new Error('URL safety blocked non-http(s) navigation.');
           }
 
-          const host = parsed.hostname.toLowerCase().replace(/\.$/, '');
+          let host = parsed.hostname.toLowerCase().replace(/\.$/, '');
+          if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1);
           const builtInBlocked = ['localhost', '*.localhost', 'metadata', 'metadata.google.internal'];
           if (policy.blockPrivateNetworkTargets !== false && builtInBlocked.some((pattern) => globMatches(pattern, host))) {
             throw new Error(`URL safety blocked host '${host}'.`);
@@ -447,11 +504,7 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
 
                 await route.ContinueAsync();
             }
-            catch (PlaywrightException)
-            {
-                await route.AbortAsync();
-            }
-            catch (OperationCanceledException)
+            catch
             {
                 await route.AbortAsync();
             }

--- a/src/OpenClaw.Agent/Tools/BrowserTool.cs
+++ b/src/OpenClaw.Agent/Tools/BrowserTool.cs
@@ -84,6 +84,13 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
           return value;
         }
 
+        function mappedIpv6ToIpv4(address) {
+          const value = ipv6ToBigInt(address);
+          if (value == null || (value >> 32n) !== 0xffffn) return null;
+          const tail = Number(value & 0xffffffffn);
+          return `${(tail >>> 24) & 0xff}.${(tail >>> 16) & 0xff}.${(tail >>> 8) & 0xff}.${tail & 0xff}`;
+        }
+
         function ipToBigInt(address) {
           const version = net.isIP(address);
           if (version === 4) {
@@ -91,6 +98,9 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
             return value == null ? null : { value: BigInt(value), bits: 32 };
           }
           if (version === 6) {
+            const mapped = mappedIpv6ToIpv4(address);
+            if (mapped) return ipToBigInt(mapped);
+
             const value = ipv6ToBigInt(address);
             return value == null ? null : { value, bits: 128 };
           }
@@ -117,12 +127,8 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
           if (version === 4) return isBlockedIpv4(address);
           if (version === 6) {
             const value = address.toLowerCase();
-            const mapped = ipv6ToBigInt(value);
-            if (mapped != null && (mapped >> 32n) === 0xffffn) {
-              const tail = Number(mapped & 0xffffffffn);
-              const dotted = `${(tail >>> 24) & 0xff}.${(tail >>> 16) & 0xff}.${(tail >>> 8) & 0xff}.${tail & 0xff}`;
-              return isBlockedIpv4(dotted);
-            }
+            const mapped = mappedIpv6ToIpv4(value);
+            if (mapped) return isBlockedIpv4(mapped);
 
             const firstGroup = parseInt(value.split(':', 1)[0] || '0', 16);
             return value === '::' ||
@@ -504,11 +510,30 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
 
                 await route.ContinueAsync();
             }
-            catch
+            catch (PlaywrightException)
             {
-                await route.AbortAsync();
+                await AbortRouteBestEffortAsync(route);
+            }
+            catch (System.Net.Http.HttpRequestException)
+            {
+                await AbortRouteBestEffortAsync(route);
+            }
+            catch (TimeoutException)
+            {
+                await AbortRouteBestEffortAsync(route);
             }
         });
+    }
+
+    private static async Task AbortRouteBestEffortAsync(IRoute route)
+    {
+        try
+        {
+            await route.AbortAsync();
+        }
+        catch (PlaywrightException)
+        {
+        }
     }
 
     private async ValueTask<UrlSafetyValidationResult> ValidateBrowserUrlAsync(string url, CancellationToken ct)

--- a/src/OpenClaw.Cli/CliArgs.cs
+++ b/src/OpenClaw.Cli/CliArgs.cs
@@ -36,7 +36,7 @@ internal sealed class CliArgs
                 continue;
             }
 
-            if (a is "--no-stream" or "--apply" or "--non-interactive" or "--offline" or "--require-provider" or "--with-companion" or "--open-browser" or "--skip-verify" or "--json")
+            if (IsFlagOption(a))
             {
                 parsed._flags.Add(a);
                 continue;
@@ -44,7 +44,7 @@ internal sealed class CliArgs
 
             if (i + 1 >= args.Length || args[i + 1].StartsWith("--", StringComparison.Ordinal))
             {
-                if (a is "--no-stream" or "--apply" or "--non-interactive" or "--offline" or "--require-provider" or "--with-companion" or "--open-browser" or "--skip-verify" or "--json")
+                if (IsFlagOption(a))
                 {
                     parsed._flags.Add(a);
                     continue;
@@ -82,4 +82,16 @@ internal sealed class CliArgs
 
     public string? GetOption(string name)
         => _options.TryGetValue(name, out var values) && values.Count > 0 ? values[^1] : null;
+
+    private static bool IsFlagOption(string value)
+        => value is "--no-stream"
+            or "--apply"
+            or "--non-interactive"
+            or "--offline"
+            or "--require-provider"
+            or "--with-companion"
+            or "--open-browser"
+            or "--skip-verify"
+            or "--json"
+            or "--anonymize";
 }

--- a/src/OpenClaw.Cli/CliArgs.cs
+++ b/src/OpenClaw.Cli/CliArgs.cs
@@ -44,12 +44,6 @@ internal sealed class CliArgs
 
             if (i + 1 >= args.Length || args[i + 1].StartsWith("--", StringComparison.Ordinal))
             {
-                if (IsFlagOption(a))
-                {
-                    parsed._flags.Add(a);
-                    continue;
-                }
-
                 throw new ArgumentException($"Missing value for {a}");
             }
 

--- a/src/OpenClaw.Cli/Program.cs
+++ b/src/OpenClaw.Cli/Program.cs
@@ -99,7 +99,7 @@ internal static class Program
               openclaw eval <run|compare> [options]
               openclaw accounts <list|add|remove|probe> [options]
               openclaw backends <list|probe|run|session send> [options]
-              openclaw admin <posture|incident export|approvals simulate> [options]
+              openclaw admin <posture|incident export|trajectory export|approvals simulate> [options]
               openclaw compatibility <catalog> [options]
               openclaw skills <inspect|install|list> [options]
               openclaw clawhub [wrapper options] [--] <clawhub args...>

--- a/src/OpenClaw.Core/Security/UrlSafetyValidator.cs
+++ b/src/OpenClaw.Core/Security/UrlSafetyValidator.cs
@@ -73,18 +73,16 @@ public static class UrlSafetyValidator
         if (string.IsNullOrWhiteSpace(host))
             return UrlSafetyValidationResult.Deny("URL host is empty.");
 
-        if (policy.BlockPrivateNetworkTargets)
+        foreach (var pattern in BuiltInBlockedHostGlobs)
         {
-            foreach (var pattern in BuiltInBlockedHostGlobs)
-            {
-                if (GlobMatcher.IsMatch(pattern, host, StringComparison.OrdinalIgnoreCase))
-                    return UrlSafetyValidationResult.Deny($"host '{host}' is blocked.");
-            }
+            if (policy.BlockPrivateNetworkTargets && GlobMatcher.IsMatch(pattern, host, StringComparison.OrdinalIgnoreCase))
+                return UrlSafetyValidationResult.Deny($"host '{host}' is blocked.");
         }
 
-        foreach (var pattern in policy.BlockedHostGlobs.Where(static p => !string.IsNullOrWhiteSpace(p)))
+        foreach (var pattern in policy.BlockedHostGlobs)
         {
-            if (GlobMatcher.IsMatch(pattern.Trim(), host, StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(pattern) &&
+                GlobMatcher.IsMatch(pattern.Trim(), host, StringComparison.OrdinalIgnoreCase))
             {
                 return UrlSafetyValidationResult.Deny($"host '{host}' matches blocklist entry '{pattern}'.");
             }
@@ -123,8 +121,11 @@ public static class UrlSafetyValidator
             if (policy.BlockPrivateNetworkTargets && IsNonPublicAddress(normalized))
                 return UrlSafetyValidationResult.Deny($"host '{host}' resolves to non-public address {normalized}.");
 
-            foreach (var cidr in policy.BlockedCidrs.Where(static c => !string.IsNullOrWhiteSpace(c)))
+            foreach (var cidr in policy.BlockedCidrs)
             {
+                if (string.IsNullOrWhiteSpace(cidr))
+                    continue;
+
                 if (AddressMatchesCidr(normalized, cidr.Trim()))
                     return UrlSafetyValidationResult.Deny($"host '{host}' resolves to {normalized}, which matches blocked CIDR '{cidr}'.");
             }

--- a/src/OpenClaw.Core/Validation/ConfigValidator.cs
+++ b/src/OpenClaw.Core/Validation/ConfigValidator.cs
@@ -423,8 +423,11 @@ public static class ConfigValidator
 
     private static void ValidateUrlSafety(string path, UrlSafetyConfig config, List<string> errors)
     {
-        foreach (var cidr in config.BlockedCidrs.Where(static c => !string.IsNullOrWhiteSpace(c)))
+        foreach (var cidr in config.BlockedCidrs)
         {
+            if (string.IsNullOrWhiteSpace(cidr))
+                continue;
+
             var parts = cidr.Split('/', 2, StringSplitOptions.TrimEntries);
             if (parts.Length != 2 ||
                 !System.Net.IPAddress.TryParse(parts[0], out var address) ||

--- a/src/OpenClaw.Tests/CliProgramTests.cs
+++ b/src/OpenClaw.Tests/CliProgramTests.cs
@@ -80,6 +80,20 @@ public sealed class CliProgramTests
     }
 
     [Fact]
+    public void CliArgs_Parse_TrajectoryExportAnonymizeFlag()
+    {
+        var parsed = CliArgs.Parse([
+            "--session", "sess-1",
+            "--anonymize",
+            "--output", "trajectory.jsonl"
+        ]);
+
+        Assert.Equal("sess-1", parsed.GetOption("--session"));
+        Assert.Equal("trajectory.jsonl", parsed.GetOption("--output"));
+        Assert.True(parsed.HasFlag("--anonymize"));
+    }
+
+    [Fact]
     public void BuildUserContent_AddsImageMarkersForImageOptions()
     {
         var content = OpenClaw.Cli.Program.BuildUserContent(

--- a/src/OpenClaw.Tests/SandboxToolContractTests.cs
+++ b/src/OpenClaw.Tests/SandboxToolContractTests.cs
@@ -81,6 +81,8 @@ public sealed class SandboxToolContractTests
         Assert.Equal("node", request.Command);
         Assert.Equal("-e", request.Arguments[0]);
         Assert.Contains("playwright", request.Arguments[1], StringComparison.Ordinal);
+        Assert.Contains("mappedIpv6ToIpv4", request.Arguments[1], StringComparison.Ordinal);
+        Assert.Contains("if (mapped) return ipToBigInt(mapped);", request.Arguments[1], StringComparison.Ordinal);
         Assert.Contains("\"action\":\"goto\"", request.Arguments[2], StringComparison.Ordinal);
         Assert.Contains("\"url\":\"https://example.com\"", request.Arguments[2], StringComparison.Ordinal);
     }

--- a/src/OpenClaw.Tests/UrlSafetyValidatorTests.cs
+++ b/src/OpenClaw.Tests/UrlSafetyValidatorTests.cs
@@ -39,6 +39,22 @@ public sealed class UrlSafetyValidatorTests
     }
 
     [Fact]
+    public void ValidateHttpUrl_HonorsConfiguredIpv6CidrBlocklist()
+    {
+        var result = UrlSafetyValidator.ValidateHttpUrl(
+            new Uri("https://[2001:db8::42]/"),
+            new UrlSafetyConfig
+            {
+                BlockPrivateNetworkTargets = false,
+                BlockedCidrs = ["2001:db8::/32"]
+            },
+            resolveDns: false);
+
+        Assert.False(result.Allowed);
+        Assert.Contains("CIDR", result.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task WebFetchTool_BlocksLoopbackBeforeHttpRequest()
     {
         using var tool = new WebFetchTool(new WebFetchConfig { Enabled = true });

--- a/src/OpenClaw.Tui/TerminalUi.cs
+++ b/src/OpenClaw.Tui/TerminalUi.cs
@@ -119,14 +119,21 @@ public static class TerminalUi
         providers.AddColumn("Tokens");
         providers.AddColumn("Cost");
         providers.AddColumn("Errors");
-        foreach (var item in insights.Providers.Take(8))
+        if (insights.Providers.Count == 0)
         {
-            providers.AddRow(
-                $"{Markup.Escape(item.ProviderId)}/{Markup.Escape(item.ModelId)}",
-                item.Requests.ToString(),
-                item.TotalTokens.ToString(),
-                $"${item.EstimatedCostUsd:0.######}",
-                item.Errors.ToString());
+            providers.AddRow("none", "-", "-", "-", "-");
+        }
+        else
+        {
+            foreach (var item in insights.Providers.Take(8))
+            {
+                providers.AddRow(
+                    $"{Markup.Escape(item.ProviderId)}/{Markup.Escape(item.ModelId)}",
+                    item.Requests.ToString(),
+                    item.TotalTokens.ToString(),
+                    $"${item.EstimatedCostUsd:0.######}",
+                    item.Errors.ToString());
+            }
         }
         AnsiConsole.Write(providers);
 
@@ -135,13 +142,20 @@ public static class TerminalUi
         tools.AddColumn("Calls");
         tools.AddColumn("Failures");
         tools.AddColumn("Avg ms");
-        foreach (var item in insights.Tools.Take(10))
+        if (insights.Tools.Count == 0)
         {
-            tools.AddRow(
-                Markup.Escape(item.ToolName),
-                item.Calls.ToString(),
-                item.Failures.ToString(),
-                item.AverageDurationMs.ToString("0.0"));
+            tools.AddRow("none", "-", "-", "-");
+        }
+        else
+        {
+            foreach (var item in insights.Tools.Take(10))
+            {
+                tools.AddRow(
+                    Markup.Escape(item.ToolName),
+                    item.Calls.ToString(),
+                    item.Failures.ToString(),
+                    item.AverageDurationMs.ToString("0.0"));
+            }
         }
         AnsiConsole.Write(tools);
 


### PR DESCRIPTION
## Summary
- Adds the remaining CLI/TUI polish for operator insights and trajectory export, including `--anonymize` flag parsing.
- Hardens URL safety behavior for browser sandbox navigation, including IPv6 CIDR handling and bracketed IPv6 host normalization.
- Documents the global URL safety defaults and fills empty-state output in the TUI insights panel.

## Impact
Operators get clearer insight summaries and a working anonymized trajectory export CLI path. Browser and web fetch tooling now share safer SSRF-oriented behavior across native and sandboxed execution.

## Validation
- `ruby -0777 -ne 'match = $_.match(/private const string SandboxRunnerScript = """\\n(.*?)\\n        """;/m); abort("script not found") unless match; puts match[1].gsub(/^        /, "")' src/OpenClaw.Agent/Tools/BrowserTool.cs | node --check`
- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj --no-restore`
