### PR TITLE
[codex] Add desktop release onboarding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
+permissions:
+  contents: read
+
 jobs:
   build-release-assets:
     name: Build ${{ matrix.asset }} assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,249 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to create or update, for example v0.1.0"
+        required: false
+        type: string
+      create_release:
+        description: "Create or update a GitHub Release"
+        required: true
+        default: true
+        type: boolean
+      draft:
+        description: "Create the release as a draft"
+        required: true
+        default: true
+        type: boolean
+      prerelease:
+        description: "Mark the release as a prerelease"
+        required: true
+        default: false
+        type: boolean
+
+env:
+  DOTNET_VERSION: "10.0.x"
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  build-release-assets:
+    name: Build ${{ matrix.asset }} assets
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - asset: linux-x64
+            os: ubuntu-latest
+            rid: linux-x64
+          - asset: windows-x64
+            os: windows-latest
+            rid: win-x64
+          - asset: macos-arm64
+            os: macos-latest
+            rid: osx-arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install Linux NativeAOT prerequisites
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Publish, smoke-test, and package assets
+        shell: pwsh
+        env:
+          WINDOWS_SIGNING_CERT_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT_BASE64 }}
+          WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERT_PASSWORD }}
+          APPLE_DEVELOPER_ID_CERT_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_BASE64 }}
+          APPLE_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
+          APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $rid = "${{ matrix.rid }}"
+          $root = (Get-Location).Path
+          $staging = Join-Path $root "artifacts/release/$rid"
+          $archives = Join-Path $root "artifacts/release-archives"
+          $exe = if ($IsWindows) { ".exe" } else { "" }
+
+          New-Item -ItemType Directory -Force -Path $staging, $archives | Out-Null
+
+          $gatewayStandard = Join-Path $staging "gateway-standard"
+          $gatewayMaf = Join-Path $staging "gateway-maf"
+          $cli = Join-Path $staging "cli"
+          $companion = Join-Path $staging "desktop/companion"
+          $desktopGateway = Join-Path $staging "desktop/gateway"
+          $desktopCli = Join-Path $staging "desktop/cli"
+
+          dotnet publish "$root/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj" -c Release -r $rid -p:PublishAot=true -p:OpenClawEnableMafExperiment=false -o $gatewayStandard
+          dotnet publish "$root/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj" -c Release -r $rid -p:PublishAot=true -p:OpenClawEnableMafExperiment=true -o $gatewayMaf
+          dotnet publish "$root/src/OpenClaw.Cli/OpenClaw.Cli.csproj" -c Release -r $rid -p:PublishAot=true -o $cli
+          dotnet publish "$root/src/OpenClaw.Companion/OpenClaw.Companion.csproj" -c Release -r $rid --self-contained true -p:PublishAot=false -p:PublishSingleFile=false -o $companion
+
+          Copy-Item -Path $gatewayStandard -Destination $desktopGateway -Recurse -Force
+          Copy-Item -Path $cli -Destination $desktopCli -Recurse -Force
+
+          if ($IsWindows -and $env:WINDOWS_SIGNING_CERT_BASE64 -and $env:WINDOWS_SIGNING_CERT_PASSWORD) {
+            $certPath = Join-Path $env:RUNNER_TEMP "openclaw-signing.pfx"
+            [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:WINDOWS_SIGNING_CERT_BASE64))
+            $signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe" |
+              Sort-Object FullName -Descending |
+              Select-Object -First 1
+            if (-not $signtool) {
+              throw "signtool.exe was not found on the Windows runner."
+            }
+            Get-ChildItem $staging -Recurse -File | Where-Object { $_.Extension -in ".exe", ".dll" } | ForEach-Object {
+              & $signtool.FullName sign /fd SHA256 /td SHA256 /tr http://timestamp.digicert.com /f $certPath /p $env:WINDOWS_SIGNING_CERT_PASSWORD $_.FullName
+              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            }
+          } elseif ($IsWindows) {
+            Write-Host "Windows signing secrets are not configured; producing unsigned archives."
+          }
+
+          if ($IsMacOS -and $env:APPLE_DEVELOPER_ID_CERT_BASE64 -and $env:APPLE_DEVELOPER_ID_CERT_PASSWORD -and $env:APPLE_CODESIGN_IDENTITY) {
+            $certPath = Join-Path $env:RUNNER_TEMP "openclaw-developer-id.p12"
+            $keychainPath = Join-Path $env:RUNNER_TEMP "openclaw-signing.keychain-db"
+            $keychainPassword = [Guid]::NewGuid().ToString("N")
+            [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:APPLE_DEVELOPER_ID_CERT_BASE64))
+            security create-keychain -p $keychainPassword $keychainPath
+            security set-keychain-settings -lut 21600 $keychainPath
+            security unlock-keychain -p $keychainPassword $keychainPath
+            security import $certPath -k $keychainPath -P $env:APPLE_DEVELOPER_ID_CERT_PASSWORD -T /usr/bin/codesign
+            security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $keychainPassword $keychainPath
+            security list-keychains -d user -s $keychainPath
+
+            Get-ChildItem $staging -Recurse -File | ForEach-Object {
+              $kind = (& file -b $_.FullName) -join " "
+              if ($kind -match "Mach-O") {
+                codesign --force --timestamp --options runtime --sign $env:APPLE_CODESIGN_IDENTITY $_.FullName
+                if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+              }
+            }
+          } elseif ($IsMacOS) {
+            Write-Host "Apple signing secrets are not configured; producing unsigned archives."
+          }
+
+          $work = Join-Path ([System.IO.Path]::GetTempPath()) ("openclaw-release-smoke-" + [System.Guid]::NewGuid().ToString("N"))
+          $memory = Join-Path $work "memory"
+          New-Item -ItemType Directory -Force -Path $memory | Out-Null
+          $configPath = Join-Path $work "gateway.smoke.json"
+          @{
+            OpenClaw = @{
+              BindAddress = "127.0.0.1"
+              Port = 19899
+              Runtime = @{ Mode = "aot" }
+              Llm = @{
+                Provider = "ollama"
+                Model = "llama3.2"
+              }
+              Memory = @{ StoragePath = $memory }
+              Tooling = @{ EnableBrowserTool = $false }
+            }
+          } | ConvertTo-Json -Depth 10 | Set-Content -Path $configPath -Encoding UTF8
+
+          $gatewayBin = Join-Path $gatewayStandard ("OpenClaw.Gateway" + $exe)
+          $cliBin = Join-Path $cli ("openclaw" + $exe)
+          & $gatewayBin --config $configPath --doctor
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & $cliBin version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          $desktopArchive = Join-Path $archives "openclaw-desktop-$rid.zip"
+          $gatewayStandardArchive = Join-Path $archives "openclaw-gateway-standard-aot-$rid.zip"
+          $gatewayMafArchive = Join-Path $archives "openclaw-gateway-maf-enabled-aot-$rid.zip"
+          $cliArchive = Join-Path $archives "openclaw-cli-aot-$rid.zip"
+          Compress-Archive -Path (Join-Path $staging "desktop/*") -DestinationPath $desktopArchive -Force
+          Compress-Archive -Path (Join-Path $gatewayStandard "*") -DestinationPath $gatewayStandardArchive -Force
+          Compress-Archive -Path (Join-Path $gatewayMaf "*") -DestinationPath $gatewayMafArchive -Force
+          Compress-Archive -Path (Join-Path $cli "*") -DestinationPath $cliArchive -Force
+
+          if ($IsMacOS -and $env:APPLE_ID -and $env:APPLE_TEAM_ID -and $env:APPLE_APP_SPECIFIC_PASSWORD -and $env:APPLE_CODESIGN_IDENTITY) {
+            xcrun notarytool submit $desktopArchive --apple-id $env:APPLE_ID --team-id $env:APPLE_TEAM_ID --password $env:APPLE_APP_SPECIFIC_PASSWORD --wait
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          } elseif ($IsMacOS) {
+            Write-Host "Apple notarization secrets are not configured; skipping notarization."
+          }
+
+          Get-ChildItem $archives -Filter *.zip | ForEach-Object {
+            $hash = Get-FileHash -Algorithm SHA256 -Path $_.FullName
+            "$($hash.Hash.ToLowerInvariant())  $($_.Name)" | Set-Content -Path ($_.FullName + ".sha256") -Encoding ascii
+          }
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.rid }}
+          path: artifacts/release-archives/*
+
+  publish-github-release:
+    name: Publish GitHub Release
+    needs: build-release-assets
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.create_release)
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ inputs.tag }}"
+            if [[ -z "$TAG" ]]; then
+              echo "workflow_dispatch releases require the tag input." >&2
+              exit 2
+            fi
+            DRAFT="${{ inputs.draft }}"
+            PRERELEASE="${{ inputs.prerelease }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+            DRAFT="false"
+            PRERELEASE="false"
+          fi
+
+          NOTES_FILE="$(mktemp)"
+          cat > "$NOTES_FILE" <<EOF
+          OpenClaw.NET desktop and runtime downloads.
+
+          Start with the desktop bundle for your platform:
+          - openclaw-desktop-win-x64.zip
+          - openclaw-desktop-osx-arm64.zip
+          - openclaw-desktop-linux-x64.zip
+
+          These archives bundle Companion, the standard NativeAOT gateway, and the NativeAOT CLI. Standalone gateway and CLI archives are also attached for operators.
+
+          Windows and macOS assets are currently unsigned unless this workflow is extended with signing secrets. See docs/RELEASES.md for the expected first-run warnings and the signing path.
+          EOF
+
+          args=(release create "$TAG" --target "$GITHUB_SHA" --title "$TAG" --notes-file "$NOTES_FILE")
+          if [[ "$DRAFT" == "true" ]]; then args+=(--draft); fi
+          if [[ "$PRERELEASE" == "true" ]]; then args+=(--prerelease); fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" release-assets/* --clobber
+          else
+            gh "${args[@]}" release-assets/*
+          fi

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ When the gateway finishes startup it now prints explicit phase markers, a final 
 
 The root URL redirects to `/chat`. For the full first-run walkthrough (including the "First 10 Minutes" runbook and debugging flow), see [docs/QUICKSTART.md](docs/QUICKSTART.md). For the project shape and repository map before changing code, see [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
 
+For the lowest-friction desktop start, download the platform desktop bundle from GitHub Releases instead of cloning the repo. The desktop bundle includes Companion, the standard NativeAOT gateway, and the NativeAOT CLI; Companion's **Setup** tab can write the local config, start the bundled gateway, and connect to it. See [docs/RELEASES.md](docs/RELEASES.md).
+
 If you want a direct gateway fallback instead of the full CLI onboarding flow, run:
 
 ```bash
@@ -113,6 +115,7 @@ The full documentation map lives at **[docs/README.md](docs/README.md)**. Starti
 | [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) | Project shape, repository map, and first-run debugging flow |
 | [docs/QUICKSTART.md](docs/QUICKSTART.md) | Shortest supported path to a running local instance |
 | [docs/USER_GUIDE.md](docs/USER_GUIDE.md) | Providers, tools, skills, memory, channels, and day-to-day operation |
+| [docs/RELEASES.md](docs/RELEASES.md) | Desktop downloads, release assets, and signing status |
 | [docs/TOOLS_GUIDE.md](docs/TOOLS_GUIDE.md) | Native tool catalog and configuration |
 | [docs/CANVAS_A2UI.md](docs/CANVAS_A2UI.md) | Supported Canvas and A2UI visual workspace behavior |
 | [docs/MODEL_PROFILES.md](docs/MODEL_PROFILES.md) | Provider-agnostic named model profiles (including Gemma) |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -41,6 +41,57 @@ dotnet run --project src/OpenClaw.Gateway -c Release -- --quickstart
 
 `--quickstart` is the direct terminal fallback. It keeps the gateway on `127.0.0.1`, prompts for missing provider values, retries in-process on the common local startup failures, and after a successful start can save the resulting config to the standard `~/.openclaw/config/openclaw.settings.json`.
 
+## Prebuilt GitHub Release Downloads
+
+For non-technical desktop users, start from a GitHub Release desktop bundle instead of a source checkout or Actions artifact.
+
+Download the matching asset:
+
+- `openclaw-desktop-win-x64.zip`
+- `openclaw-desktop-osx-arm64.zip`
+- `openclaw-desktop-linux-x64.zip`
+
+Extract the archive and launch Companion from the `companion` folder. Open the **Setup** tab, enter the provider/model/key or choose Ollama, then click **Set Up and Start**. Companion writes the local config, starts the bundled gateway on `127.0.0.1`, and connects to it.
+
+Current Windows and macOS archives are unsigned until signing/notarization secrets are configured in the release workflow. Windows users may see SmartScreen warnings; macOS users may need to right-click Open or remove quarantine for local testing. See [RELEASES.md](RELEASES.md) for the signing path.
+
+Operators can still download standalone AOT archives from the same release:
+
+```bash
+gh release download <tag> \
+  --repo clawdotnet/openclaw.net \
+  --pattern 'openclaw-gateway-standard-aot-linux-x64.zip' \
+  --dir ./openclaw-gateway-aot
+
+gh release download <tag> \
+  --repo clawdotnet/openclaw.net \
+  --pattern 'openclaw-cli-aot-linux-x64.zip' \
+  --dir ./openclaw-cli-aot
+```
+
+After extracting those standalone archives:
+
+```bash
+chmod +x ./openclaw-gateway-aot/OpenClaw.Gateway
+chmod +x ./openclaw-cli-aot/openclaw
+```
+
+For the fastest interactive local run:
+
+```bash
+export MODEL_PROVIDER_KEY="sk-..."
+./openclaw-gateway-aot/OpenClaw.Gateway --quickstart
+```
+
+For a reusable config:
+
+```bash
+./openclaw-cli-aot/openclaw setup
+./openclaw-gateway-aot/OpenClaw.Gateway --config ~/.openclaw/config/openclaw.settings.json
+```
+
+GitHub Actions artifacts remain available for commit validation, but they are not the supported user download surface because they can expire and may require GitHub access.
+
 You explicitly do **not** need any of these to get started:
 
 - Docker

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Use this page as the map. If you are unsure where to go next, the groups below a
 | Doc | What it covers |
 | --- | --- |
 | [USER_GUIDE.md](USER_GUIDE.md) | Providers, tools, skills, channels, and the day-to-day operator surface. |
+| [RELEASES.md](RELEASES.md) | Desktop download bundles, release assets, and signing/notarization status. |
 | [TOOLS_GUIDE.md](TOOLS_GUIDE.md) | Native tool catalog, behavior, and configuration. |
 | [SESSIONS.md](SESSIONS.md) | Session lifecycle, the `SessionManager`, and the `sessions_spawn` / `sessions_yield` / `sessions` tools. |
 | [CANVAS_A2UI.md](CANVAS_A2UI.md) | Supported Canvas and A2UI behavior for agent-rendered visual workspaces. |

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,75 @@
+# Release Downloads
+
+OpenClaw.NET's low-friction desktop path is the **desktop bundle** published on GitHub Releases. It bundles:
+
+- Companion
+- the standard NativeAOT gateway
+- the NativeAOT CLI
+
+Users should start with the desktop bundle for their platform instead of GitHub Actions artifacts.
+
+| Asset | Audience |
+| --- | --- |
+| `openclaw-desktop-win-x64.zip` | Windows desktop users |
+| `openclaw-desktop-osx-arm64.zip` | Apple Silicon macOS desktop users |
+| `openclaw-desktop-linux-x64.zip` | Linux desktop users |
+| `openclaw-gateway-standard-aot-*.zip` | Operators who only want the native gateway |
+| `openclaw-gateway-maf-enabled-aot-*.zip` | Operators who need optional `Runtime.Orchestrator=maf` |
+| `openclaw-cli-aot-*.zip` | CLI-only installs and scripting |
+
+Each archive has a matching `.sha256` checksum file.
+
+## User First Run
+
+1. Download the desktop bundle from the latest GitHub Release.
+2. Extract the archive.
+3. Launch Companion from the `companion` folder.
+4. Use the **Setup** tab to enter a provider, model, workspace, and provider key.
+5. Click **Set Up and Start**.
+
+Companion writes the normal local OpenClaw config, starts the bundled gateway on `127.0.0.1`, and connects to it. If a config already exists, Companion can auto-start the local gateway on launch.
+
+## Current Signing State
+
+The release workflow builds Windows and macOS archives and has optional signing/notarization hooks. Assets are unsigned unless the required repository secrets are configured.
+
+- Windows archives are unsigned until Authenticode signing secrets are configured. Some users may see SmartScreen warnings.
+- macOS archives are unsigned and not notarized until Apple Developer ID signing secrets are configured. Users may need to right-click Open or remove quarantine for local testing.
+
+Release-grade onboarding requires these secrets:
+
+| Secret | Used for |
+| --- | --- |
+| `WINDOWS_SIGNING_CERT_BASE64` | Base64-encoded Authenticode `.pfx` |
+| `WINDOWS_SIGNING_CERT_PASSWORD` | Authenticode certificate password |
+| `APPLE_DEVELOPER_ID_CERT_BASE64` | Base64-encoded Apple Developer ID `.p12` |
+| `APPLE_DEVELOPER_ID_CERT_PASSWORD` | Apple certificate password |
+| `APPLE_CODESIGN_IDENTITY` | Developer ID Application identity |
+| `APPLE_ID` | Apple ID for notarization |
+| `APPLE_TEAM_ID` | Apple team ID for notarization |
+| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password for notarization |
+
+Installer polish is still a follow-up: `.exe`/`.msix` for Windows and `.dmg` for macOS.
+
+## Maintainer Flow
+
+Tagged releases build and publish assets automatically:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+Maintainers can also run the `Release` workflow manually. Manual runs can create or update a draft release when a tag is supplied.
+
+The workflow currently builds:
+
+- `linux-x64` on `ubuntu-latest`
+- `win-x64` on `windows-latest`
+- `osx-arm64` on `macos-latest`
+
+The macOS runner label is intentionally ARM-native for the `osx-arm64` artifact. Add an Intel macOS row only if you want to support older Intel Macs and have a runner that can NativeAOT publish that RID reliably.
+
+## CI Artifacts vs Releases
+
+Actions artifacts are useful for validating a commit, but they are not a user-friendly distribution channel. They can expire, may require GitHub access, and are harder for users to find. GitHub Releases are the supported download surface for normal users.

--- a/src/OpenClaw.Companion/App.axaml.cs
+++ b/src/OpenClaw.Companion/App.axaml.cs
@@ -13,6 +13,7 @@ namespace OpenClaw.Companion;
 public partial class App : Application
 {
     private GatewayWebSocketClient? _client;
+    private ManagedGatewayService? _managedGateway;
 
     public override void Initialize()
     {
@@ -28,8 +29,9 @@ public partial class App : Application
             DisableAvaloniaDataAnnotationValidation();
 
             _client = new GatewayWebSocketClient();
+            _managedGateway = new ManagedGatewayService();
             var settings = new SettingsStore();
-            var viewModel = new MainWindowViewModel(settings, _client);
+            var viewModel = new MainWindowViewModel(settings, _client, managedGateway: _managedGateway);
             viewModel.AttachDesktopNotifier(new DesktopNotifier());
 
             desktop.MainWindow = new MainWindow
@@ -38,12 +40,15 @@ public partial class App : Application
             };
 
             viewModel.StartApprovalsPolling();
+            _ = viewModel.InitializeLocalGatewayAsync();
 
             desktop.Exit += async (_, _) =>
             {
                 viewModel.StopApprovalsPolling();
                 if (_client is not null)
                     await _client.DisposeAsync();
+                if (_managedGateway is not null)
+                    await _managedGateway.DisposeAsync();
             };
         }
 

--- a/src/OpenClaw.Companion/Models/CompanionSettings.cs
+++ b/src/OpenClaw.Companion/Models/CompanionSettings.cs
@@ -12,6 +12,11 @@ public sealed class CompanionSettings
     public bool DebugMode { get; set; } = false;
     public bool ApprovalDesktopNotificationsEnabled { get; set; } = true;
     public bool ApprovalDesktopNotificationsOnlyWhenUnfocused { get; set; } = true;
+    public bool AutoStartLocalGateway { get; set; } = true;
+    public string SetupProvider { get; set; } = "openai";
+    public string SetupModel { get; set; } = "gpt-4o";
+    public string SetupModelPreset { get; set; } = "";
+    public string SetupWorkspacePath { get; set; } = "";
 
     [JsonIgnore]
     public string? AuthToken { get; set; }

--- a/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
+++ b/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
@@ -118,7 +118,15 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
         {
             _gatewayProcess.Start();
         }
-        catch (Exception ex)
+        catch (ObjectDisposedException ex)
+        {
+            return ManagedGatewayStartResult.Fail($"Gateway launch failed: {ex.Message}");
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            return ManagedGatewayStartResult.Fail($"Gateway launch failed: {ex.Message}");
+        }
+        catch (InvalidOperationException ex)
         {
             return ManagedGatewayStartResult.Fail($"Gateway launch failed: {ex.Message}");
         }

--- a/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
+++ b/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
@@ -148,7 +148,13 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
                 await process.WaitForExitAsync(ct);
             }
         }
-        catch
+        catch (ObjectDisposedException)
+        {
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+        }
+        catch (InvalidOperationException)
         {
         }
         finally

--- a/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
+++ b/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
@@ -1,0 +1,404 @@
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace OpenClaw.Companion.Services;
+
+public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
+{
+    private readonly HttpClient _httpClient;
+    private Process? _gatewayProcess;
+
+    public ManagedGatewayService(
+        string? baseDirectory = null,
+        HttpClient? httpClient = null,
+        string? configPath = null,
+        string? workspacePath = null)
+    {
+        BaseDirectory = Path.GetFullPath(baseDirectory ?? AppContext.BaseDirectory);
+        _httpClient = httpClient ?? new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
+        ConfigPath = configPath ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".openclaw",
+            "config",
+            "openclaw.settings.json");
+        WorkspacePath = workspacePath ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".openclaw",
+            "workspace");
+        GatewayExecutable = ResolveGatewayExecutable(BaseDirectory);
+        CliExecutable = ResolveCliExecutable(BaseDirectory);
+    }
+
+    public string BaseDirectory { get; }
+    public string ConfigPath { get; }
+    public string WorkspacePath { get; }
+    public ManagedExecutable? GatewayExecutable { get; }
+    public ManagedExecutable? CliExecutable { get; }
+
+    public bool HasConfig => File.Exists(ConfigPath);
+    public bool CanStartGateway => GatewayExecutable is not null;
+    public bool CanRunSetup => CliExecutable is not null;
+
+    public string BaseUrl => ReadBaseUrlFromConfig() ?? "http://127.0.0.1:18789";
+
+    public string WebSocketUrl
+    {
+        get
+        {
+            var builder = new UriBuilder(BaseUrl.TrimEnd('/') + "/ws")
+            {
+                Scheme = BaseUrl.StartsWith("https:", StringComparison.OrdinalIgnoreCase) ? "wss" : "ws"
+            };
+            return builder.Uri.ToString();
+        }
+    }
+
+    public async Task<ManagedGatewaySetupResult> RunSetupAsync(ManagedGatewaySetupRequest request, CancellationToken ct)
+    {
+        if (CliExecutable is null)
+            return ManagedGatewaySetupResult.Fail("The bundled OpenClaw CLI was not found.");
+
+        var provider = string.IsNullOrWhiteSpace(request.Provider) ? "openai" : request.Provider.Trim();
+        var model = string.IsNullOrWhiteSpace(request.Model) ? "gpt-4o" : request.Model.Trim();
+        var workspace = string.IsNullOrWhiteSpace(request.WorkspacePath) ? WorkspacePath : request.WorkspacePath.Trim();
+        var config = string.IsNullOrWhiteSpace(request.ConfigPath) ? ConfigPath : request.ConfigPath.Trim();
+        var apiKey = request.ApiKey?.Trim();
+
+        if (!provider.Equals("ollama", StringComparison.OrdinalIgnoreCase) && string.IsNullOrWhiteSpace(apiKey))
+            return ManagedGatewaySetupResult.Fail("A provider API key is required unless you choose Ollama.");
+
+        var args = new List<string>
+        {
+            "setup",
+            "--non-interactive",
+            "--profile", "local",
+            "--workspace", workspace,
+            "--provider", provider,
+            "--model", model,
+            "--config", config
+        };
+
+        if (!string.IsNullOrWhiteSpace(request.ModelPresetId))
+        {
+            args.Add("--model-preset");
+            args.Add(request.ModelPresetId.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(apiKey))
+        {
+            args.Add("--api-key");
+            args.Add(apiKey);
+        }
+
+        var result = await RunProcessToCompletionAsync(CliExecutable, args, TimeSpan.FromMinutes(2), ct);
+        return result.ExitCode == 0
+            ? ManagedGatewaySetupResult.Success(result.Output)
+            : ManagedGatewaySetupResult.Fail(string.IsNullOrWhiteSpace(result.Error) ? result.Output : result.Error);
+    }
+
+    public async Task<ManagedGatewayStartResult> StartAsync(string? authToken, CancellationToken ct)
+    {
+        if (GatewayExecutable is null)
+            return ManagedGatewayStartResult.Fail("The bundled OpenClaw gateway was not found.");
+        if (!HasConfig)
+            return ManagedGatewayStartResult.Fail("Local setup has not been completed yet.");
+        if (await IsHealthyAsync(authToken, ct))
+            return ManagedGatewayStartResult.Success("Gateway is already running.");
+
+        if (_gatewayProcess is { HasExited: false })
+            return await WaitForReadyAsync(authToken, "Gateway is starting.", ct);
+
+        var startInfo = CreateStartInfo(GatewayExecutable, ["--config", ConfigPath]);
+        startInfo.RedirectStandardOutput = false;
+        startInfo.RedirectStandardError = false;
+
+        _gatewayProcess = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+        try
+        {
+            _gatewayProcess.Start();
+        }
+        catch (Exception ex)
+        {
+            return ManagedGatewayStartResult.Fail($"Gateway launch failed: {ex.Message}");
+        }
+
+        return await WaitForReadyAsync(authToken, "Gateway started.", ct);
+    }
+
+    public async Task StopAsync(CancellationToken ct)
+    {
+        var process = _gatewayProcess;
+        if (process is null)
+            return;
+
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync(ct);
+            }
+        }
+        catch
+        {
+        }
+        finally
+        {
+            process.Dispose();
+            if (ReferenceEquals(_gatewayProcess, process))
+                _gatewayProcess = null;
+        }
+    }
+
+    public async Task<bool> IsHealthyAsync(string? authToken, CancellationToken ct)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl.TrimEnd('/')}/health");
+            if (!string.IsNullOrWhiteSpace(authToken))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
+            using var response = await _httpClient.SendAsync(request, ct);
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public string DescribeAvailability()
+    {
+        var gateway = GatewayExecutable is null ? "gateway missing" : $"gateway: {GatewayExecutable.DisplayPath}";
+        var cli = CliExecutable is null ? "CLI missing" : $"CLI: {CliExecutable.DisplayPath}";
+        var config = HasConfig ? $"config: {ConfigPath}" : $"config missing: {ConfigPath}";
+        return $"{gateway}; {cli}; {config}";
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync(CancellationToken.None);
+        _httpClient.Dispose();
+    }
+
+    public void Dispose()
+    {
+        StopAsync(CancellationToken.None).GetAwaiter().GetResult();
+        _httpClient.Dispose();
+    }
+
+    internal static ManagedExecutable? ResolveGatewayExecutable(string baseDirectory)
+        => ResolveExecutable(
+            baseDirectory,
+            "OpenClaw.Gateway",
+            "src/OpenClaw.Gateway/OpenClaw.Gateway.csproj",
+            [
+                ["gateway"],
+                ["..", "gateway"],
+                ["Resources", "gateway"],
+                ["..", "Resources", "gateway"],
+                []
+            ]);
+
+    internal static ManagedExecutable? ResolveCliExecutable(string baseDirectory)
+        => ResolveExecutable(
+            baseDirectory,
+            "openclaw",
+            "src/OpenClaw.Cli/OpenClaw.Cli.csproj",
+            [
+                ["cli"],
+                ["..", "cli"],
+                ["Resources", "cli"],
+                ["..", "Resources", "cli"],
+                []
+            ]);
+
+    private async Task<ManagedGatewayStartResult> WaitForReadyAsync(string? authToken, string successMessage, CancellationToken ct)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(45);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (_gatewayProcess is { HasExited: true })
+                return ManagedGatewayStartResult.Fail($"Gateway exited with code {_gatewayProcess.ExitCode}.");
+            if (await IsHealthyAsync(authToken, ct))
+                return ManagedGatewayStartResult.Success(successMessage);
+            await Task.Delay(750, ct);
+        }
+
+        return ManagedGatewayStartResult.Fail("Gateway did not become ready before the startup timeout.");
+    }
+
+    private async Task<ProcessRunResult> RunProcessToCompletionAsync(
+        ManagedExecutable executable,
+        IReadOnlyList<string> args,
+        TimeSpan timeout,
+        CancellationToken ct)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(timeout);
+
+        using var process = new Process
+        {
+            StartInfo = CreateStartInfo(executable, args),
+            EnableRaisingEvents = true
+        };
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+
+        try
+        {
+            process.Start();
+            var stdout = process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
+            var stderr = process.StandardError.ReadToEndAsync(timeoutCts.Token);
+            await process.WaitForExitAsync(timeoutCts.Token);
+            return new ProcessRunResult(process.ExitCode, await stdout, await stderr);
+        }
+        catch (OperationCanceledException)
+        {
+            TryKill(process);
+            return new ProcessRunResult(124, "", "Command timed out.");
+        }
+        catch (Exception ex)
+        {
+            return new ProcessRunResult(1, "", ex.Message);
+        }
+    }
+
+    private static ProcessStartInfo CreateStartInfo(ManagedExecutable executable, IReadOnlyList<string> args)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable.FileName,
+            WorkingDirectory = executable.WorkingDirectory,
+            UseShellExecute = false
+        };
+
+        foreach (var prefix in executable.ArgumentPrefix)
+            startInfo.ArgumentList.Add(prefix);
+        foreach (var arg in args)
+            startInfo.ArgumentList.Add(arg);
+
+        return startInfo;
+    }
+
+    private string? ReadBaseUrlFromConfig()
+    {
+        if (!File.Exists(ConfigPath))
+            return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(ConfigPath));
+            if (!document.RootElement.TryGetProperty("OpenClaw", out var openClaw))
+                return null;
+
+            var bind = openClaw.TryGetProperty("BindAddress", out var bindProperty) && bindProperty.ValueKind == JsonValueKind.String
+                ? bindProperty.GetString()
+                : "127.0.0.1";
+            var port = openClaw.TryGetProperty("Port", out var portProperty) && portProperty.TryGetInt32(out var parsedPort)
+                ? parsedPort
+                : 18789;
+            var host = string.IsNullOrWhiteSpace(bind) || bind is "0.0.0.0" or "::"
+                ? "127.0.0.1"
+                : bind;
+            return $"http://{host}:{port}";
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static ManagedExecutable? ResolveExecutable(
+        string baseDirectory,
+        string binaryBaseName,
+        string projectRelativePath,
+        IReadOnlyList<string[]> binaryRelativeDirectories)
+    {
+        foreach (var relativeDirectory in binaryRelativeDirectories)
+        {
+            var directory = Path.GetFullPath(Path.Combine([baseDirectory, .. relativeDirectory]));
+            var binary = FindBinary(directory, binaryBaseName);
+            if (binary is not null)
+                return new ManagedExecutable(binary, [], directory, binary);
+        }
+
+        var repoRoot = FindRepoRoot(baseDirectory, projectRelativePath);
+        if (repoRoot is null)
+            return null;
+
+        var projectPath = Path.Combine(repoRoot, projectRelativePath);
+        return new ManagedExecutable(
+            "dotnet",
+            ["run", "--project", projectPath, "-c", "Release", "--"],
+            repoRoot,
+            projectPath);
+    }
+
+    private static string? FindBinary(string directory, string binaryBaseName)
+    {
+        var plain = Path.Combine(directory, binaryBaseName);
+        if (File.Exists(plain))
+            return plain;
+
+        var windows = Path.Combine(directory, binaryBaseName + ".exe");
+        if (File.Exists(windows))
+            return windows;
+
+        return null;
+    }
+
+    private static string? FindRepoRoot(string startDirectory, string projectRelativePath)
+    {
+        var directory = new DirectoryInfo(Path.GetFullPath(startDirectory));
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, projectRelativePath)))
+                return directory.FullName;
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+        }
+    }
+
+    private sealed record ProcessRunResult(int ExitCode, string Output, string Error);
+}
+
+public sealed record ManagedExecutable(
+    string FileName,
+    IReadOnlyList<string> ArgumentPrefix,
+    string WorkingDirectory,
+    string DisplayPath);
+
+public sealed record ManagedGatewaySetupRequest(
+    string Provider,
+    string Model,
+    string? ApiKey,
+    string? ModelPresetId,
+    string? WorkspacePath,
+    string? ConfigPath);
+
+public sealed record ManagedGatewaySetupResult(bool IsSuccess, string Message)
+{
+    public static ManagedGatewaySetupResult Success(string message) => new(true, message);
+    public static ManagedGatewaySetupResult Fail(string message) => new(false, message);
+}
+
+public sealed record ManagedGatewayStartResult(bool IsSuccess, string Message)
+{
+    public static ManagedGatewayStartResult Success(string message) => new(true, message);
+    public static ManagedGatewayStartResult Fail(string message) => new(false, message);
+}

--- a/src/OpenClaw.Companion/Services/SettingsStore.cs
+++ b/src/OpenClaw.Companion/Services/SettingsStore.cs
@@ -57,7 +57,14 @@ public sealed class SettingsStore
             OperatorTokenLabel = settings.OperatorTokenLabel,
             RememberToken = settings.RememberToken,
             AllowPlaintextTokenFallback = settings.AllowPlaintextTokenFallback,
-            DebugMode = settings.DebugMode
+            DebugMode = settings.DebugMode,
+            ApprovalDesktopNotificationsEnabled = settings.ApprovalDesktopNotificationsEnabled,
+            ApprovalDesktopNotificationsOnlyWhenUnfocused = settings.ApprovalDesktopNotificationsOnlyWhenUnfocused,
+            AutoStartLocalGateway = settings.AutoStartLocalGateway,
+            SetupProvider = settings.SetupProvider,
+            SetupModel = settings.SetupModel,
+            SetupModelPreset = settings.SetupModelPreset,
+            SetupWorkspacePath = settings.SetupWorkspacePath
         };
 
         var json = JsonSerializer.Serialize(toSave, JsonOptions);

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.ManagedGateway.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.ManagedGateway.cs
@@ -1,0 +1,231 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using OpenClaw.Companion.Services;
+
+namespace OpenClaw.Companion.ViewModels;
+
+public sealed partial class MainWindowViewModel
+{
+    [ObservableProperty]
+    private string _localGatewayStatus = "Local gateway not checked.";
+
+    [ObservableProperty]
+    private string _localGatewayAvailability = "";
+
+    [ObservableProperty]
+    private string _localGatewayConfigPath = "";
+
+    [ObservableProperty]
+    private bool _localGatewayConfigExists;
+
+    [ObservableProperty]
+    private bool _localGatewayCanStart;
+
+    [ObservableProperty]
+    private bool _localGatewayCanRunSetup;
+
+    [ObservableProperty]
+    private bool _localGatewayIsHealthy;
+
+    [ObservableProperty]
+    private bool _isManagedGatewayBusy;
+
+    [ObservableProperty]
+    private bool _autoStartLocalGateway = true;
+
+    [ObservableProperty]
+    private string _setupProvider = "openai";
+
+    [ObservableProperty]
+    private string _setupModel = "gpt-4o";
+
+    [ObservableProperty]
+    private string _setupModelPreset = "";
+
+    [ObservableProperty]
+    private string _setupWorkspacePath = "";
+
+    [ObservableProperty]
+    private string _setupApiKey = "";
+
+    public async Task InitializeLocalGatewayAsync()
+    {
+        await RefreshLocalGatewayAsync();
+        if (AutoStartLocalGateway && LocalGatewayConfigExists && LocalGatewayCanStart && !IsConnected)
+            await StartLocalGatewayCoreAsync(connectAfterStart: true);
+    }
+
+    [RelayCommand]
+    private async Task RefreshLocalGatewayAsync()
+    {
+        RefreshManagedGatewayStateCore();
+        LocalGatewayIsHealthy = await _managedGateway.IsHealthyAsync(AuthToken, CancellationToken.None);
+        LocalGatewayStatus = LocalGatewayIsHealthy
+            ? $"Local gateway is running at {_managedGateway.BaseUrl}."
+            : LocalGatewayConfigExists
+                ? "Local gateway is configured but not running."
+                : "Local gateway is not set up.";
+    }
+
+    [RelayCommand]
+    private async Task SetupAndStartLocalGatewayAsync()
+    {
+        if (IsManagedGatewayBusy)
+            return;
+
+        IsManagedGatewayBusy = true;
+        try
+        {
+            SaveSettings();
+            LocalGatewayStatus = "Writing local setup...";
+            var result = await _managedGateway.RunSetupAsync(new ManagedGatewaySetupRequest(
+                SetupProvider,
+                SetupModel,
+                string.IsNullOrWhiteSpace(SetupApiKey) ? null : SetupApiKey,
+                string.IsNullOrWhiteSpace(SetupModelPreset) ? null : SetupModelPreset,
+                string.IsNullOrWhiteSpace(SetupWorkspacePath) ? _managedGateway.WorkspacePath : SetupWorkspacePath,
+                _managedGateway.ConfigPath), CancellationToken.None);
+
+            if (!result.IsSuccess)
+            {
+                LocalGatewayStatus = "Local setup failed.";
+                AddSystemMessageCore($"Local setup failed: {result.Message}");
+                return;
+            }
+
+            SetupApiKey = "";
+            RefreshManagedGatewayStateCore();
+            AddSystemMessageCore("Local setup completed.");
+            await StartLocalGatewayCoreAsync(connectAfterStart: true);
+        }
+        finally
+        {
+            IsManagedGatewayBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task StartLocalGatewayAsync()
+    {
+        if (IsManagedGatewayBusy)
+            return;
+
+        IsManagedGatewayBusy = true;
+        try
+        {
+            await StartLocalGatewayCoreAsync(connectAfterStart: true);
+        }
+        finally
+        {
+            IsManagedGatewayBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task StopLocalGatewayAsync()
+    {
+        if (IsManagedGatewayBusy)
+            return;
+
+        IsManagedGatewayBusy = true;
+        try
+        {
+            if (IsConnected)
+                await DisconnectAsync();
+            await _managedGateway.StopAsync(CancellationToken.None);
+            LocalGatewayIsHealthy = false;
+            LocalGatewayStatus = "Local gateway stopped.";
+        }
+        finally
+        {
+            IsManagedGatewayBusy = false;
+        }
+    }
+
+    private async Task StartLocalGatewayCoreAsync(bool connectAfterStart)
+    {
+        RefreshManagedGatewayStateCore();
+        if (!LocalGatewayCanStart)
+        {
+            LocalGatewayStatus = "Bundled gateway is unavailable.";
+            AddSystemMessageCore("The bundled OpenClaw gateway was not found in this Companion build.");
+            return;
+        }
+
+        if (!LocalGatewayConfigExists)
+        {
+            LocalGatewayStatus = "Local setup is required before the gateway can start.";
+            return;
+        }
+
+        LocalGatewayStatus = "Starting local gateway...";
+        var result = await _managedGateway.StartAsync(AuthToken, CancellationToken.None);
+        LocalGatewayStatus = result.Message;
+        if (!result.IsSuccess)
+        {
+            AddSystemMessageCore(result.Message);
+            return;
+        }
+
+        LocalGatewayIsHealthy = true;
+        ServerUrl = _managedGateway.WebSocketUrl;
+        SaveSettings();
+
+        if (connectAfterStart && !IsConnected)
+            await ConnectAsync();
+    }
+
+    private void RefreshManagedGatewayStateCore()
+    {
+        LocalGatewayCanStart = _managedGateway.CanStartGateway;
+        LocalGatewayCanRunSetup = _managedGateway.CanRunSetup;
+        LocalGatewayConfigExists = _managedGateway.HasConfig;
+        LocalGatewayConfigPath = _managedGateway.ConfigPath;
+        LocalGatewayAvailability = _managedGateway.DescribeAvailability();
+        if (string.IsNullOrWhiteSpace(SetupWorkspacePath))
+            SetupWorkspacePath = _managedGateway.WorkspacePath;
+    }
+
+    partial void OnAutoStartLocalGatewayChanged(bool value)
+    {
+        if (!_isLoadingSettings)
+            SaveSettings();
+    }
+
+    partial void OnSetupProviderChanged(string value)
+    {
+        if (value.Equals("ollama", StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrWhiteSpace(SetupModel) || SetupModel.Equals("gpt-4o", StringComparison.OrdinalIgnoreCase))
+                SetupModel = "llama3.2";
+            if (string.IsNullOrWhiteSpace(SetupModelPreset))
+                SetupModelPreset = "ollama-general";
+        }
+        else if (string.IsNullOrWhiteSpace(SetupModel) || SetupModel.Equals("llama3.2", StringComparison.OrdinalIgnoreCase))
+        {
+            SetupModel = "gpt-4o";
+            SetupModelPreset = "";
+        }
+
+        if (!_isLoadingSettings)
+            SaveSettings();
+    }
+
+    partial void OnSetupModelChanged(string value)
+    {
+        if (!_isLoadingSettings)
+            SaveSettings();
+    }
+
+    partial void OnSetupModelPresetChanged(string value)
+    {
+        if (!_isLoadingSettings)
+            SaveSettings();
+    }
+
+    partial void OnSetupWorkspacePathChanged(string value)
+    {
+        if (!_isLoadingSettings)
+            SaveSettings();
+    }
+}

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.cs
@@ -14,6 +14,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase
 {
     private readonly SettingsStore _settingsStore;
     private readonly GatewayWebSocketClient _client;
+    private readonly ManagedGatewayService _managedGateway;
     private bool _isLoadingSettings;
     private int? _activeAssistantMessageIndex;
     private string? _activeAssistantReplyToMessageId;
@@ -85,17 +86,19 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     public ObservableCollection<ChatMessage> Messages { get; } = new();
 
     public MainWindowViewModel()
-        : this(new SettingsStore(), new GatewayWebSocketClient(), null)
+        : this(new SettingsStore(), new GatewayWebSocketClient(), null, null)
     {
     }
 
     public MainWindowViewModel(
         SettingsStore settingsStore,
         GatewayWebSocketClient client,
-        Func<string, string?, OpenClawHttpClient>? adminClientFactory = null)
+        Func<string, string?, OpenClawHttpClient>? adminClientFactory = null,
+        ManagedGatewayService? managedGateway = null)
     {
         _settingsStore = settingsStore;
         _client = client;
+        _managedGateway = managedGateway ?? new ManagedGatewayService();
         _adminClientFactory = adminClientFactory ?? ((baseUrl, authToken) => new OpenClawHttpClient(baseUrl, authToken));
 
         _client.OnTextMessage += HandleInboundText;
@@ -103,6 +106,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase
         _client.OnError += err => AddSystemMessage($"Error: {err}");
 
         LoadSettings();
+        RefreshManagedGatewayStateCore();
     }
 
     private void LoadSettings()
@@ -120,6 +124,14 @@ public sealed partial class MainWindowViewModel : ViewModelBase
             DebugMode = settings.DebugMode;
             ApprovalDesktopNotificationsEnabled = settings.ApprovalDesktopNotificationsEnabled;
             ApprovalDesktopNotificationsOnlyWhenUnfocused = settings.ApprovalDesktopNotificationsOnlyWhenUnfocused;
+            AutoStartLocalGateway = settings.AutoStartLocalGateway;
+            SetupProvider = string.IsNullOrWhiteSpace(settings.SetupProvider) ? "openai" : settings.SetupProvider;
+            SetupModel = string.IsNullOrWhiteSpace(settings.SetupModel) ? "gpt-4o" : settings.SetupModel;
+            SetupModelPreset = settings.SetupModelPreset ?? "";
+            SetupWorkspacePath = string.IsNullOrWhiteSpace(settings.SetupWorkspacePath)
+                ? _managedGateway.WorkspacePath
+                : settings.SetupWorkspacePath;
+            ApplyEnvironmentSettings();
         }
         finally
         {
@@ -141,9 +153,37 @@ public sealed partial class MainWindowViewModel : ViewModelBase
             DebugMode = DebugMode,
             ApprovalDesktopNotificationsEnabled = ApprovalDesktopNotificationsEnabled,
             ApprovalDesktopNotificationsOnlyWhenUnfocused = ApprovalDesktopNotificationsOnlyWhenUnfocused,
+            AutoStartLocalGateway = AutoStartLocalGateway,
+            SetupProvider = SetupProvider,
+            SetupModel = SetupModel,
+            SetupModelPreset = SetupModelPreset,
+            SetupWorkspacePath = SetupWorkspacePath,
             AuthToken = string.IsNullOrWhiteSpace(AuthToken) ? null : AuthToken
         });
         ShowSettingsWarningIfNeeded();
+    }
+
+    private void ApplyEnvironmentSettings()
+    {
+        var baseUrl = Environment.GetEnvironmentVariable("OPENCLAW_BASE_URL");
+        if (!string.IsNullOrWhiteSpace(baseUrl))
+            ServerUrl = ConvertBaseUrlToWebSocketUrl(baseUrl);
+
+        var authToken = Environment.GetEnvironmentVariable("OPENCLAW_AUTH_TOKEN");
+        if (!string.IsNullOrWhiteSpace(authToken))
+            AuthToken = authToken;
+    }
+
+    private static string ConvertBaseUrlToWebSocketUrl(string baseUrl)
+    {
+        if (!Uri.TryCreate(baseUrl.TrimEnd('/') + "/ws", UriKind.Absolute, out var uri))
+            return baseUrl;
+
+        var builder = new UriBuilder(uri)
+        {
+            Scheme = uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ? "wss" : "ws"
+        };
+        return builder.Uri.ToString();
     }
 
     private void HandleInboundText(string payload)

--- a/src/OpenClaw.Companion/Views/MainWindow.axaml
+++ b/src/OpenClaw.Companion/Views/MainWindow.axaml
@@ -51,6 +51,60 @@
         </Border>
 
         <TabControl Grid.Row="1">
+            <TabItem Header="Setup">
+                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Spacing="12" Margin="0,4,0,0">
+                        <Border Padding="10" CornerRadius="8" BorderThickness="1"
+                                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
+                            <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="8" ColumnSpacing="10">
+                                <StackPanel Grid.Row="0" Grid.Column="0" Spacing="3">
+                                    <TextBlock Text="Local Gateway" FontWeight="SemiBold" />
+                                    <TextBlock Text="{Binding LocalGatewayStatus}" TextWrapping="Wrap" />
+                                    <TextBlock Text="{Binding LocalGatewayAvailability}" FontSize="11" Opacity="0.65" TextWrapping="Wrap" />
+                                    <TextBlock Text="{Binding LocalGatewayConfigPath, StringFormat='Config: {0}'}"
+                                               FontSize="11" Opacity="0.65" TextWrapping="Wrap" />
+                                </StackPanel>
+                                <CheckBox Grid.Row="0" Grid.Column="1"
+                                          Content="Auto-start"
+                                          IsChecked="{Binding AutoStartLocalGateway}" />
+                                <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="8">
+                                    <Button Content="Refresh"
+                                            Command="{Binding RefreshLocalGatewayCommand}"
+                                            IsEnabled="{Binding IsManagedGatewayBusy, Converter={StaticResource InverseBool}}" />
+                                    <Button Content="Start"
+                                            Command="{Binding StartLocalGatewayCommand}"
+                                            IsEnabled="{Binding IsManagedGatewayBusy, Converter={StaticResource InverseBool}}" />
+                                    <Button Content="Stop"
+                                            Command="{Binding StopLocalGatewayCommand}"
+                                            IsEnabled="{Binding IsManagedGatewayBusy, Converter={StaticResource InverseBool}}" />
+                                </StackPanel>
+                            </Grid>
+                        </Border>
+
+                        <Border Padding="10" CornerRadius="8" BorderThickness="1"
+                                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
+                            <StackPanel Spacing="10">
+                                <TextBlock Text="First Run" FontWeight="SemiBold" />
+                                <Grid ColumnDefinitions="*,*,*" ColumnSpacing="10">
+                                    <TextBox Grid.Column="0" Text="{Binding SetupProvider}" Watermark="openai / anthropic / gemini / ollama" />
+                                    <TextBox Grid.Column="1" Text="{Binding SetupModel}" Watermark="gpt-4o" />
+                                    <TextBox Grid.Column="2" Text="{Binding SetupModelPreset}" Watermark="ollama-general" />
+                                </Grid>
+                                <Grid ColumnDefinitions="2*,*" ColumnSpacing="10">
+                                    <TextBox Grid.Column="0" Text="{Binding SetupWorkspacePath}" Watermark="Workspace path" />
+                                    <TextBox Grid.Column="1" Text="{Binding SetupApiKey}" PasswordChar="•" Watermark="Provider API key" />
+                                </Grid>
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <Button Content="Set Up and Start"
+                                            Command="{Binding SetupAndStartLocalGatewayCommand}"
+                                            IsEnabled="{Binding IsManagedGatewayBusy, Converter={StaticResource InverseBool}}" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
             <TabItem Header="Chat">
                 <Grid RowDefinitions="*,Auto" RowSpacing="12">
                     <Border Grid.Row="0" Padding="10" CornerRadius="8" BorderThickness="1"

--- a/src/OpenClaw.SemanticKernelAdapter/OpenClaw.SemanticKernelAdapter.csproj
+++ b/src/OpenClaw.SemanticKernelAdapter/OpenClaw.SemanticKernelAdapter.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />

--- a/src/OpenClaw.Tests/ManagedGatewayServiceTests.cs
+++ b/src/OpenClaw.Tests/ManagedGatewayServiceTests.cs
@@ -1,0 +1,84 @@
+using OpenClaw.Companion.Services;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class ManagedGatewayServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ManagedGatewayServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "openclaw-managed-gateway-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [Fact]
+    public void ResolveExecutables_FindsReleaseSiblingLayout()
+    {
+        var companionDir = Path.Combine(_tempDir, "companion");
+        var gatewayDir = Path.Combine(_tempDir, "gateway");
+        var cliDir = Path.Combine(_tempDir, "cli");
+        Directory.CreateDirectory(companionDir);
+        Directory.CreateDirectory(gatewayDir);
+        Directory.CreateDirectory(cliDir);
+        File.WriteAllText(Path.Combine(gatewayDir, BinaryName("OpenClaw.Gateway")), "");
+        File.WriteAllText(Path.Combine(cliDir, BinaryName("openclaw")), "");
+
+        var gateway = ManagedGatewayService.ResolveGatewayExecutable(companionDir);
+        var cli = ManagedGatewayService.ResolveCliExecutable(companionDir);
+
+        Assert.NotNull(gateway);
+        Assert.NotNull(cli);
+        Assert.Equal(gatewayDir, gateway.WorkingDirectory);
+        Assert.Equal(cliDir, cli.WorkingDirectory);
+    }
+
+    [Fact]
+    public void WebSocketUrl_UsesConfiguredPort()
+    {
+        var configPath = Path.Combine(_tempDir, "openclaw.settings.json");
+        File.WriteAllText(configPath, """
+        {
+          "OpenClaw": {
+            "BindAddress": "0.0.0.0",
+            "Port": 19001
+          }
+        }
+        """);
+
+        using var service = new ManagedGatewayService(_tempDir, configPath: configPath);
+
+        Assert.Equal("http://127.0.0.1:19001", service.BaseUrl);
+        Assert.Equal("ws://127.0.0.1:19001/ws", service.WebSocketUrl.TrimEnd('/'));
+    }
+
+    [Fact]
+    public async Task RunSetupAsync_RequiresApiKeyForRemoteProviders()
+    {
+        var cliDir = Path.Combine(_tempDir, "cli");
+        Directory.CreateDirectory(cliDir);
+        File.WriteAllText(Path.Combine(cliDir, BinaryName("openclaw")), "");
+        using var service = new ManagedGatewayService(_tempDir);
+
+        var result = await service.RunSetupAsync(new ManagedGatewaySetupRequest(
+            "openai",
+            "gpt-4o",
+            ApiKey: null,
+            ModelPresetId: null,
+            WorkspacePath: Path.Combine(_tempDir, "workspace"),
+            ConfigPath: Path.Combine(_tempDir, "config.json")), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("API key", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private static string BinaryName(string name)
+        => OperatingSystem.IsWindows() ? name + ".exe" : name;
+}

--- a/src/OpenClaw.Tests/OpenClaw.Tests.csproj
+++ b/src/OpenClaw.Tests/OpenClaw.Tests.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.0-preview.3.25172.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />


### PR DESCRIPTION
## Summary
- add a Release workflow that builds Linux x64, Windows x64, and macOS ARM64 desktop/runtime archives with checksums
- add optional Windows Authenticode and macOS signing/notarization hooks driven by repository secrets
- add Companion-managed local gateway setup/start flow so desktop users can configure, launch, and connect without terminal setup
- document release downloads, signing state, and first-run desktop flow

## Validation
- `dotnet build src/OpenClaw.Companion/OpenClaw.Companion.csproj -c Release`
- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj -c Release --filter ManagedGatewayServiceTests`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release workflow yaml ok'"`
- `git diff --check`

## Notes
- Release assets remain unsigned unless the documented Windows/macOS signing secrets are configured.
- The test restore required aligning direct `Microsoft.Extensions.DependencyInjection.Abstractions` references with the transitive `10.0.6` dependency.
