### PR TITLE
[codex] Address release onboarding follow-up comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
             os: windows-latest
             rid: win-x64
           - asset: macos-arm64
-            os: macos-latest
+            os: macos-14
             rid: osx-arm64
 
     steps:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ When the gateway finishes startup it now prints explicit phase markers, a final 
 
 The root URL redirects to `/chat`. For the full first-run walkthrough (including the "First 10 Minutes" runbook and debugging flow), see [docs/QUICKSTART.md](docs/QUICKSTART.md). For the project shape and repository map before changing code, see [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md).
 
-For the lowest-friction desktop start, download the platform desktop bundle from GitHub Releases instead of cloning the repo. The desktop bundle includes Companion, the standard NativeAOT gateway, and the NativeAOT CLI; Companion's **Setup** tab can write the local config, start the bundled gateway, and connect to it. See [docs/RELEASES.md](docs/RELEASES.md).
+For the lowest-friction desktop start, download the platform desktop bundle from [GitHub Releases](https://github.com/clawdotnet/openclaw.net/releases/latest) instead of cloning the repo. The desktop bundle includes Companion, the standard NativeAOT gateway, and the NativeAOT CLI; Companion's **Setup** tab can write the local config, start the bundled gateway, and connect to it. See [docs/RELEASES.md](docs/RELEASES.md).
 
 If you want a direct gateway fallback instead of the full CLI onboarding flow, run:
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -43,13 +43,13 @@ dotnet run --project src/OpenClaw.Gateway -c Release -- --quickstart
 
 ## Prebuilt GitHub Release Downloads
 
-For non-technical desktop users, start from a GitHub Release desktop bundle instead of a source checkout or Actions artifact.
+For non-technical desktop users, start from the [latest GitHub Release](https://github.com/clawdotnet/openclaw.net/releases/latest) desktop bundle instead of a source checkout or Actions artifact.
 
 Download the matching asset:
 
-- `openclaw-desktop-win-x64.zip`
-- `openclaw-desktop-osx-arm64.zip`
-- `openclaw-desktop-linux-x64.zip`
+- Windows: [`openclaw-desktop-win-x64.zip`](https://github.com/clawdotnet/openclaw.net/releases/latest/download/openclaw-desktop-win-x64.zip)
+- Apple Silicon macOS: [`openclaw-desktop-osx-arm64.zip`](https://github.com/clawdotnet/openclaw.net/releases/latest/download/openclaw-desktop-osx-arm64.zip)
+- Linux: [`openclaw-desktop-linux-x64.zip`](https://github.com/clawdotnet/openclaw.net/releases/latest/download/openclaw-desktop-linux-x64.zip)
 
 Extract the archive and launch Companion from the `companion` folder. Open the **Setup** tab, enter the provider/model/key or choose Ollama, then click **Set Up and Start**. Companion writes the local config, starts the bundled gateway on `127.0.0.1`, and connects to it.
 
@@ -58,12 +58,12 @@ Current Windows and macOS archives are unsigned until signing/notarization secre
 Operators can still download standalone AOT archives from the same release:
 
 ```bash
-gh release download <tag> \
+gh release download \
   --repo clawdotnet/openclaw.net \
   --pattern 'openclaw-gateway-standard-aot-linux-x64.zip' \
   --dir ./openclaw-gateway-aot
 
-gh release download <tag> \
+gh release download \
   --repo clawdotnet/openclaw.net \
   --pattern 'openclaw-cli-aot-linux-x64.zip' \
   --dir ./openclaw-cli-aot

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,6 +1,6 @@
 # Release Downloads
 
-OpenClaw.NET's low-friction desktop path is the **desktop bundle** published on GitHub Releases. It bundles:
+OpenClaw.NET's low-friction desktop path is the **desktop bundle** published on [GitHub Releases](https://github.com/clawdotnet/openclaw.net/releases/latest). It bundles:
 
 - Companion
 - the standard NativeAOT gateway
@@ -10,9 +10,9 @@ Users should start with the desktop bundle for their platform instead of GitHub 
 
 | Asset | Audience |
 | --- | --- |
-| `openclaw-desktop-win-x64.zip` | Windows desktop users |
-| `openclaw-desktop-osx-arm64.zip` | Apple Silicon macOS desktop users |
-| `openclaw-desktop-linux-x64.zip` | Linux desktop users |
+| [`openclaw-desktop-win-x64.zip`](https://github.com/clawdotnet/openclaw.net/releases/latest/download/openclaw-desktop-win-x64.zip) | Windows desktop users |
+| [`openclaw-desktop-osx-arm64.zip`](https://github.com/clawdotnet/openclaw.net/releases/latest/download/openclaw-desktop-osx-arm64.zip) | Apple Silicon macOS desktop users |
+| [`openclaw-desktop-linux-x64.zip`](https://github.com/clawdotnet/openclaw.net/releases/latest/download/openclaw-desktop-linux-x64.zip) | Linux desktop users |
 | `openclaw-gateway-standard-aot-*.zip` | Operators who only want the native gateway |
 | `openclaw-gateway-maf-enabled-aot-*.zip` | Operators who need optional `Runtime.Orchestrator=maf` |
 | `openclaw-cli-aot-*.zip` | CLI-only installs and scripting |
@@ -21,7 +21,7 @@ Each archive has a matching `.sha256` checksum file.
 
 ## User First Run
 
-1. Download the desktop bundle from the latest GitHub Release.
+1. Download the desktop bundle from the [latest GitHub Release](https://github.com/clawdotnet/openclaw.net/releases/latest).
 2. Extract the archive.
 3. Launch Companion from the `companion` folder.
 4. Use the **Setup** tab to enter a provider, model, workspace, and provider key.
@@ -66,7 +66,7 @@ The workflow currently builds:
 
 - `linux-x64` on `ubuntu-latest`
 - `win-x64` on `windows-latest`
-- `osx-arm64` on `macos-latest`
+- `osx-arm64` on `macos-14`
 
 The macOS runner label is intentionally ARM-native for the `osx-arm64` artifact. Add an Intel macOS row only if you want to support older Intel Macs and have a runner that can NativeAOT publish that RID reliably.
 

--- a/src/OpenClaw.Companion/App.axaml.cs
+++ b/src/OpenClaw.Companion/App.axaml.cs
@@ -40,7 +40,12 @@ public partial class App : Application
             };
 
             viewModel.StartApprovalsPolling();
-            _ = viewModel.InitializeLocalGatewayAsync();
+            var initializeLocalGatewayTask = viewModel.InitializeLocalGatewayAsync();
+            _ = initializeLocalGatewayTask.ContinueWith(
+                task => viewModel.ReportLocalGatewayInitializationFailure(task.Exception),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
 
             desktop.Exit += async (_, _) =>
             {

--- a/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
+++ b/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
@@ -166,14 +166,17 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
                 await process.WaitForExitAsync(ct);
             }
         }
-        catch (ObjectDisposedException)
+        catch (ObjectDisposedException ex)
         {
+            TraceIgnoredProcessException("stop", ex);
         }
-        catch (System.ComponentModel.Win32Exception)
+        catch (System.ComponentModel.Win32Exception ex)
         {
+            TraceIgnoredProcessException("stop", ex);
         }
-        catch (InvalidOperationException)
+        catch (InvalidOperationException ex)
         {
+            TraceIgnoredProcessException("stop", ex);
         }
         finally
         {
@@ -197,11 +200,7 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
         {
             return false;
         }
-        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
-        {
-            return false;
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
             return false;
         }
@@ -306,10 +305,15 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
             await process.WaitForExitAsync(timeoutCts.Token);
             return new ProcessRunResult(process.ExitCode, await stdout, await stderr);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
             TryKill(process);
             return new ProcessRunResult(124, "", "Command timed out.");
+        }
+        catch (OperationCanceledException)
+        {
+            TryKill(process);
+            throw;
         }
         catch (ObjectDisposedException ex)
         {
@@ -373,20 +377,24 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
                 string.IsNullOrWhiteSpace(bind) ? "127.0.0.1" : bind,
                 port);
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
+            Trace.TraceWarning("Managed gateway config read ignored JSON error for '{0}': {1}", ConfigPath, ex.Message);
             return null;
         }
-        catch (IOException)
+        catch (IOException ex)
         {
+            Trace.TraceWarning("Managed gateway config read ignored IO error for '{0}': {1}", ConfigPath, ex.Message);
             return null;
         }
-        catch (UnauthorizedAccessException)
+        catch (UnauthorizedAccessException ex)
         {
+            Trace.TraceWarning("Managed gateway config read ignored access error for '{0}': {1}", ConfigPath, ex.Message);
             return null;
         }
-        catch (InvalidOperationException)
+        catch (InvalidOperationException ex)
         {
+            Trace.TraceWarning("Managed gateway config read ignored invalid state for '{0}': {1}", ConfigPath, ex.Message);
             return null;
         }
     }
@@ -405,14 +413,19 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
             _ => "ws"
         };
 
-        var path = uri.AbsolutePath;
-        if (string.IsNullOrWhiteSpace(path) || path == "/")
+        var normalizedPath = uri.AbsolutePath.TrimEnd('/');
+        string path;
+        if (string.IsNullOrWhiteSpace(normalizedPath))
         {
             path = "/ws";
         }
-        else if (!path.EndsWith("/ws", StringComparison.OrdinalIgnoreCase))
+        else if (normalizedPath.EndsWith("/ws", StringComparison.OrdinalIgnoreCase))
         {
-            path = path.TrimEnd('/') + "/ws";
+            path = normalizedPath;
+        }
+        else
+        {
+            path = normalizedPath + "/ws";
         }
 
         var builder = new UriBuilder(uri)
@@ -482,14 +495,17 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
             if (!process.HasExited)
                 process.Kill(entireProcessTree: true);
         }
-        catch (ObjectDisposedException)
+        catch (ObjectDisposedException ex)
         {
+            TraceIgnoredProcessException("kill", ex);
         }
-        catch (System.ComponentModel.Win32Exception)
+        catch (System.ComponentModel.Win32Exception ex)
         {
+            TraceIgnoredProcessException("kill", ex);
         }
-        catch (InvalidOperationException)
+        catch (InvalidOperationException ex)
         {
+            TraceIgnoredProcessException("kill", ex);
         }
     }
 
@@ -504,11 +520,13 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
             if (!process.HasExited)
                 return;
         }
-        catch (ObjectDisposedException)
+        catch (ObjectDisposedException ex)
         {
+            TraceIgnoredProcessException("dispose exited process state check", ex);
         }
-        catch (InvalidOperationException)
+        catch (InvalidOperationException ex)
         {
+            TraceIgnoredProcessException("dispose exited process state check", ex);
         }
 
         if (ReferenceEquals(_gatewayProcess, process))
@@ -530,27 +548,38 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
         if (process is null)
             return;
 
-        try
+        using (process)
         {
-            if (!process.HasExited)
+            try
             {
-                process.Kill(entireProcessTree: true);
-                process.WaitForExit(5000);
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                    process.WaitForExit(5000);
+                }
+            }
+            catch (ObjectDisposedException ex)
+            {
+                TraceIgnoredProcessException("dispose stop", ex);
+            }
+            catch (System.ComponentModel.Win32Exception ex)
+            {
+                TraceIgnoredProcessException("dispose stop", ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                TraceIgnoredProcessException("dispose stop", ex);
             }
         }
-        catch (ObjectDisposedException)
-        {
-        }
-        catch (System.ComponentModel.Win32Exception)
-        {
-        }
-        catch (InvalidOperationException)
-        {
-        }
-        finally
-        {
-            process.Dispose();
-        }
+    }
+
+    private static void TraceIgnoredProcessException(string operation, Exception ex)
+    {
+        Trace.TraceWarning(
+            "Managed gateway process cleanup ignored {0} during {1}: {2}",
+            ex.GetType().Name,
+            operation,
+            ex.Message);
     }
 
     private sealed record ProcessRunResult(int ExitCode, string Output, string Error);

--- a/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
+++ b/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
@@ -1,13 +1,17 @@
 using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using OpenClaw.Core.Setup;
 
 namespace OpenClaw.Companion.Services;
 
 public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
 {
+    private const string ProviderApiKeyEnvironmentVariable = "OPENCLAW_MODEL_PROVIDER_KEY";
     private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
     private Process? _gatewayProcess;
+    private string? _providerApiKey;
 
     public ManagedGatewayService(
         string? baseDirectory = null,
@@ -17,6 +21,7 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
     {
         BaseDirectory = Path.GetFullPath(baseDirectory ?? AppContext.BaseDirectory);
         _httpClient = httpClient ?? new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
+        _ownsHttpClient = httpClient is null;
         ConfigPath = configPath ?? Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             ".openclaw",
@@ -44,14 +49,12 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
 
     public string WebSocketUrl
     {
-        get
-        {
-            var builder = new UriBuilder(BaseUrl.TrimEnd('/') + "/ws")
-            {
-                Scheme = BaseUrl.StartsWith("https:", StringComparison.OrdinalIgnoreCase) ? "wss" : "ws"
-            };
-            return builder.Uri.ToString();
-        }
+        get => BuildWebSocketUrl(BaseUrl);
+    }
+
+    public void SetProviderApiKey(string? apiKey)
+    {
+        _providerApiKey = string.IsNullOrWhiteSpace(apiKey) ? null : apiKey.Trim();
     }
 
     public async Task<ManagedGatewaySetupResult> RunSetupAsync(ManagedGatewaySetupRequest request, CancellationToken ct)
@@ -88,13 +91,22 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
         if (!string.IsNullOrWhiteSpace(apiKey))
         {
             args.Add("--api-key");
-            args.Add(apiKey);
+            args.Add($"env:{ProviderApiKeyEnvironmentVariable}");
         }
 
-        var result = await RunProcessToCompletionAsync(CliExecutable, args, TimeSpan.FromMinutes(2), ct);
-        return result.ExitCode == 0
-            ? ManagedGatewaySetupResult.Success(result.Output)
-            : ManagedGatewaySetupResult.Fail(string.IsNullOrWhiteSpace(result.Error) ? result.Output : result.Error);
+        var environment = string.IsNullOrWhiteSpace(apiKey)
+            ? null
+            : new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [ProviderApiKeyEnvironmentVariable] = apiKey
+            };
+
+        var result = await RunProcessToCompletionAsync(CliExecutable, args, environment, TimeSpan.FromMinutes(2), ct);
+        if (result.ExitCode != 0)
+            return ManagedGatewaySetupResult.Fail(string.IsNullOrWhiteSpace(result.Error) ? result.Output : result.Error);
+
+        SetProviderApiKey(apiKey);
+        return ManagedGatewaySetupResult.Success(result.Output);
     }
 
     public async Task<ManagedGatewayStartResult> StartAsync(string? authToken, CancellationToken ct)
@@ -108,26 +120,32 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
 
         if (_gatewayProcess is { HasExited: false })
             return await WaitForReadyAsync(authToken, "Gateway is starting.", ct);
+        DisposeExitedGatewayProcess();
 
         var startInfo = CreateStartInfo(GatewayExecutable, ["--config", ConfigPath]);
         startInfo.RedirectStandardOutput = false;
         startInfo.RedirectStandardError = false;
+        ApplyProviderApiKeyEnvironment(startInfo);
 
-        _gatewayProcess = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+        var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+        _gatewayProcess = process;
         try
         {
-            _gatewayProcess.Start();
+            process.Start();
         }
         catch (ObjectDisposedException ex)
         {
+            ClearFailedStartProcess(process);
             return ManagedGatewayStartResult.Fail($"Gateway launch failed: {ex.Message}");
         }
         catch (System.ComponentModel.Win32Exception ex)
         {
+            ClearFailedStartProcess(process);
             return ManagedGatewayStartResult.Fail($"Gateway launch failed: {ex.Message}");
         }
         catch (InvalidOperationException ex)
         {
+            ClearFailedStartProcess(process);
             return ManagedGatewayStartResult.Fail($"Gateway launch failed: {ex.Message}");
         }
 
@@ -175,7 +193,19 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
             using var response = await _httpClient.SendAsync(request, ct);
             return response.IsSuccessStatusCode;
         }
-        catch
+        catch (HttpRequestException)
+        {
+            return false;
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return false;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            return false;
+        }
+        catch (UriFormatException)
         {
             return false;
         }
@@ -191,14 +221,16 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
 
     public async ValueTask DisposeAsync()
     {
-        await StopAsync(CancellationToken.None);
-        _httpClient.Dispose();
+        await StopAsync(CancellationToken.None).ConfigureAwait(false);
+        if (_ownsHttpClient)
+            _httpClient.Dispose();
     }
 
     public void Dispose()
     {
-        StopAsync(CancellationToken.None).GetAwaiter().GetResult();
-        _httpClient.Dispose();
+        StopForDispose();
+        if (_ownsHttpClient)
+            _httpClient.Dispose();
     }
 
     internal static ManagedExecutable? ResolveGatewayExecutable(string baseDirectory)
@@ -246,6 +278,7 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
     private async Task<ProcessRunResult> RunProcessToCompletionAsync(
         ManagedExecutable executable,
         IReadOnlyList<string> args,
+        IReadOnlyDictionary<string, string>? environment,
         TimeSpan timeout,
         CancellationToken ct)
     {
@@ -259,6 +292,11 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
         };
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.RedirectStandardError = true;
+        if (environment is not null)
+        {
+            foreach (var (key, value) in environment)
+                process.StartInfo.Environment[key] = value;
+        }
 
         try
         {
@@ -273,7 +311,19 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
             TryKill(process);
             return new ProcessRunResult(124, "", "Command timed out.");
         }
-        catch (Exception ex)
+        catch (ObjectDisposedException ex)
+        {
+            return new ProcessRunResult(1, "", ex.Message);
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            return new ProcessRunResult(1, "", ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return new ProcessRunResult(1, "", ex.Message);
+        }
+        catch (IOException ex)
         {
             return new ProcessRunResult(1, "", ex.Message);
         }
@@ -296,6 +346,12 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
         return startInfo;
     }
 
+    private void ApplyProviderApiKeyEnvironment(ProcessStartInfo startInfo)
+    {
+        if (!string.IsNullOrWhiteSpace(_providerApiKey))
+            startInfo.Environment[ProviderApiKeyEnvironmentVariable] = _providerApiKey;
+    }
+
     private string? ReadBaseUrlFromConfig()
     {
         if (!File.Exists(ConfigPath))
@@ -313,15 +369,58 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
             var port = openClaw.TryGetProperty("Port", out var portProperty) && portProperty.TryGetInt32(out var parsedPort)
                 ? parsedPort
                 : 18789;
-            var host = string.IsNullOrWhiteSpace(bind) || bind is "0.0.0.0" or "::"
-                ? "127.0.0.1"
-                : bind;
-            return $"http://{host}:{port}";
+            return GatewaySetupArtifacts.BuildReachableBaseUrl(
+                string.IsNullOrWhiteSpace(bind) ? "127.0.0.1" : bind,
+                port);
         }
-        catch
+        catch (JsonException)
         {
             return null;
         }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    internal static string BuildWebSocketUrl(string baseUrl)
+    {
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri))
+            return baseUrl;
+
+        var scheme = uri.Scheme.ToLowerInvariant() switch
+        {
+            "https" => "wss",
+            "http" => "ws",
+            "wss" => "wss",
+            "ws" => "ws",
+            _ => "ws"
+        };
+
+        var path = uri.AbsolutePath;
+        if (string.IsNullOrWhiteSpace(path) || path == "/")
+        {
+            path = "/ws";
+        }
+        else if (!path.EndsWith("/ws", StringComparison.OrdinalIgnoreCase))
+        {
+            path = path.TrimEnd('/') + "/ws";
+        }
+
+        var builder = new UriBuilder(uri)
+        {
+            Scheme = scheme,
+            Path = path
+        };
+        return builder.Uri.ToString();
     }
 
     private static ManagedExecutable? ResolveExecutable(
@@ -383,8 +482,74 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
             if (!process.HasExited)
                 process.Kill(entireProcessTree: true);
         }
-        catch
+        catch (ObjectDisposedException)
         {
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+
+    private void DisposeExitedGatewayProcess()
+    {
+        var process = _gatewayProcess;
+        if (process is null)
+            return;
+
+        try
+        {
+            if (!process.HasExited)
+                return;
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        if (ReferenceEquals(_gatewayProcess, process))
+            _gatewayProcess = null;
+        process.Dispose();
+    }
+
+    private void ClearFailedStartProcess(Process process)
+    {
+        if (ReferenceEquals(_gatewayProcess, process))
+            _gatewayProcess = null;
+        process.Dispose();
+    }
+
+    private void StopForDispose()
+    {
+        var process = _gatewayProcess;
+        _gatewayProcess = null;
+        if (process is null)
+            return;
+
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit(5000);
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        finally
+        {
+            process.Dispose();
         }
     }
 

--- a/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
+++ b/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
@@ -200,7 +200,11 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
         {
             return false;
         }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
         {
             return false;
         }

--- a/src/OpenClaw.Companion/Services/SettingsStore.cs
+++ b/src/OpenClaw.Companion/Services/SettingsStore.cs
@@ -22,16 +22,16 @@ public sealed class SettingsStore
         ProtectedTokenStore? tokenStore = null,
         ProtectedTokenStore? providerKeyStore = null)
     {
-        var dir = baseDir ?? Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "OpenClaw",
+        var defaultDir = Path.Join(
+            Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "OpenClaw"),
             "Companion");
-        SettingsPath = Path.Combine(dir, "settings.json");
+        var dir = baseDir ?? defaultDir;
+        SettingsPath = Path.Join(dir, "settings.json");
         _tokenStore = tokenStore ?? new ProtectedTokenStore(dir);
-        var providerKeyDir = Path.Combine(dir, "provider-key");
+        var providerKeyDir = Path.Join(dir, "provider-key");
         _providerKeyStore = providerKeyStore ?? new ProtectedTokenStore(providerKeyDir);
         var providerKeyMarkerDirectory = Path.GetDirectoryName(_providerKeyStore.FallbackPath) ?? providerKeyDir;
-        _providerKeyMarkerPath = Path.Combine(providerKeyMarkerDirectory, "stored.marker");
+        _providerKeyMarkerPath = Path.Join(providerKeyMarkerDirectory, "stored.marker");
     }
 
     public CompanionSettings Load()

--- a/src/OpenClaw.Companion/Services/SettingsStore.cs
+++ b/src/OpenClaw.Companion/Services/SettingsStore.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using OpenClaw.Companion.Models;
 
@@ -29,7 +30,8 @@ public sealed class SettingsStore
         _tokenStore = tokenStore ?? new ProtectedTokenStore(dir);
         var providerKeyDir = Path.Combine(dir, "provider-key");
         _providerKeyStore = providerKeyStore ?? new ProtectedTokenStore(providerKeyDir);
-        _providerKeyMarkerPath = Path.Combine(providerKeyDir, "stored.marker");
+        var providerKeyMarkerDirectory = Path.GetDirectoryName(_providerKeyStore.FallbackPath) ?? providerKeyDir;
+        _providerKeyMarkerPath = Path.Combine(providerKeyMarkerDirectory, "stored.marker");
     }
 
     public CompanionSettings Load()
@@ -47,8 +49,29 @@ public sealed class SettingsStore
             LastWarning = _tokenStore.LastWarning;
             return settings;
         }
-        catch
+        catch (JsonException ex)
         {
+            TraceSettingsLoadFailure(ex);
+            return new CompanionSettings();
+        }
+        catch (IOException ex)
+        {
+            TraceSettingsLoadFailure(ex);
+            return new CompanionSettings();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            TraceSettingsLoadFailure(ex);
+            return new CompanionSettings();
+        }
+        catch (InvalidOperationException ex)
+        {
+            TraceSettingsLoadFailure(ex);
+            return new CompanionSettings();
+        }
+        catch (NotSupportedException ex)
+        {
+            TraceSettingsLoadFailure(ex);
             return new CompanionSettings();
         }
     }
@@ -106,10 +129,19 @@ public sealed class SettingsStore
     public bool SaveProviderApiKey(string providerApiKey, bool allowPlaintextFallback)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(_providerKeyMarkerPath)!);
-        File.WriteAllText(_providerKeyMarkerPath, "stored");
-        var saved = _providerKeyStore.SaveToken(providerApiKey, allowPlaintextFallback, out var warning);
+        _ = _providerKeyStore.SaveToken(providerApiKey, allowPlaintextFallback, out var warning);
         LastWarning = warning;
-        return saved;
+
+        var loadedProviderApiKey = _providerKeyStore.LoadToken(allowPlaintextFallback);
+        LastWarning ??= _providerKeyStore.LastWarning;
+        if (!string.Equals(loadedProviderApiKey, providerApiKey, StringComparison.Ordinal))
+        {
+            TryDelete(_providerKeyMarkerPath);
+            return false;
+        }
+
+        File.WriteAllText(_providerKeyMarkerPath, "stored");
+        return true;
     }
 
     public void ClearProviderApiKey()
@@ -132,11 +164,24 @@ public sealed class SettingsStore
             if (root.TryGetProperty("authToken", out authToken) && authToken.ValueKind == JsonValueKind.String)
                 return authToken.GetString();
         }
-        catch
+        catch (JsonException ex)
         {
+            Trace.TraceWarning("Settings store ignored legacy token JSON error: {0}", ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            Trace.TraceWarning("Settings store ignored legacy token invalid state: {0}", ex.Message);
         }
 
         return null;
+    }
+
+    private static void TraceSettingsLoadFailure(Exception ex)
+    {
+        Trace.TraceWarning(
+            "Settings store ignored settings load {0}: {1}",
+            ex.GetType().Name,
+            ex.Message);
     }
 
     private static void TryDelete(string path)
@@ -145,11 +190,13 @@ public sealed class SettingsStore
         {
             File.Delete(path);
         }
-        catch (IOException)
+        catch (IOException ex)
         {
+            Trace.TraceWarning("Settings store ignored delete IO error for '{0}': {1}", path, ex.Message);
         }
-        catch (UnauthorizedAccessException)
+        catch (UnauthorizedAccessException ex)
         {
+            Trace.TraceWarning("Settings store ignored delete access error for '{0}': {1}", path, ex.Message);
         }
     }
 }

--- a/src/OpenClaw.Companion/Services/SettingsStore.cs
+++ b/src/OpenClaw.Companion/Services/SettingsStore.cs
@@ -10,11 +10,16 @@ public sealed class SettingsStore
         WriteIndented = true
     };
     private readonly ProtectedTokenStore _tokenStore;
+    private readonly ProtectedTokenStore _providerKeyStore;
+    private readonly string _providerKeyMarkerPath;
 
     public string SettingsPath { get; }
     public string? LastWarning { get; private set; }
 
-    public SettingsStore(string? baseDir = null, ProtectedTokenStore? tokenStore = null)
+    public SettingsStore(
+        string? baseDir = null,
+        ProtectedTokenStore? tokenStore = null,
+        ProtectedTokenStore? providerKeyStore = null)
     {
         var dir = baseDir ?? Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
@@ -22,6 +27,9 @@ public sealed class SettingsStore
             "Companion");
         SettingsPath = Path.Combine(dir, "settings.json");
         _tokenStore = tokenStore ?? new ProtectedTokenStore(dir);
+        var providerKeyDir = Path.Combine(dir, "provider-key");
+        _providerKeyStore = providerKeyStore ?? new ProtectedTokenStore(providerKeyDir);
+        _providerKeyMarkerPath = Path.Combine(providerKeyDir, "stored.marker");
     }
 
     public CompanionSettings Load()
@@ -85,6 +93,31 @@ public sealed class SettingsStore
         LastWarning = warning;
     }
 
+    public string? LoadProviderApiKey(bool allowPlaintextFallback)
+    {
+        if (!File.Exists(_providerKeyMarkerPath))
+            return null;
+
+        var providerApiKey = _providerKeyStore.LoadToken(allowPlaintextFallback);
+        LastWarning = _providerKeyStore.LastWarning;
+        return providerApiKey;
+    }
+
+    public bool SaveProviderApiKey(string providerApiKey, bool allowPlaintextFallback)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_providerKeyMarkerPath)!);
+        File.WriteAllText(_providerKeyMarkerPath, "stored");
+        var saved = _providerKeyStore.SaveToken(providerApiKey, allowPlaintextFallback, out var warning);
+        LastWarning = warning;
+        return saved;
+    }
+
+    public void ClearProviderApiKey()
+    {
+        _providerKeyStore.ClearToken();
+        TryDelete(_providerKeyMarkerPath);
+    }
+
     private static string? TryReadLegacyAuthToken(string json, bool rememberToken)
     {
         if (!rememberToken)
@@ -104,5 +137,19 @@ public sealed class SettingsStore
         }
 
         return null;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
     }
 }

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.ManagedGateway.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.ManagedGateway.cs
@@ -22,12 +22,14 @@ public sealed partial class MainWindowViewModel
     private bool _localGatewayCanStart;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanRunLocalGatewaySetup))]
     private bool _localGatewayCanRunSetup;
 
     [ObservableProperty]
     private bool _localGatewayIsHealthy;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanRunLocalGatewaySetup))]
     private bool _isManagedGatewayBusy;
 
     [ObservableProperty]
@@ -47,6 +49,8 @@ public sealed partial class MainWindowViewModel
 
     [ObservableProperty]
     private string _setupApiKey = "";
+
+    public bool CanRunLocalGatewaySetup => LocalGatewayCanRunSetup && !IsManagedGatewayBusy;
 
     public async Task InitializeLocalGatewayAsync()
     {
@@ -77,11 +81,12 @@ public sealed partial class MainWindowViewModel
         try
         {
             SaveSettings();
+            var setupApiKey = string.IsNullOrWhiteSpace(SetupApiKey) ? null : SetupApiKey;
             LocalGatewayStatus = "Writing local setup...";
             var result = await _managedGateway.RunSetupAsync(new ManagedGatewaySetupRequest(
                 SetupProvider,
                 SetupModel,
-                string.IsNullOrWhiteSpace(SetupApiKey) ? null : SetupApiKey,
+                setupApiKey,
                 string.IsNullOrWhiteSpace(SetupModelPreset) ? null : SetupModelPreset,
                 string.IsNullOrWhiteSpace(SetupWorkspacePath) ? _managedGateway.WorkspacePath : SetupWorkspacePath,
                 _managedGateway.ConfigPath), CancellationToken.None);
@@ -94,7 +99,12 @@ public sealed partial class MainWindowViewModel
             }
 
             SetupApiKey = "";
+            if (setupApiKey is null)
+                _settingsStore.ClearProviderApiKey();
+            else
+                _settingsStore.SaveProviderApiKey(setupApiKey, AllowPlaintextTokenFallback);
             RefreshManagedGatewayStateCore();
+            ShowSettingsWarningIfNeeded();
             AddSystemMessageCore("Local setup completed.");
             await StartLocalGatewayCoreAsync(connectAfterStart: true);
         }

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.cs
@@ -131,6 +131,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase
             SetupWorkspacePath = string.IsNullOrWhiteSpace(settings.SetupWorkspacePath)
                 ? _managedGateway.WorkspacePath
                 : settings.SetupWorkspacePath;
+            _managedGateway.SetProviderApiKey(_settingsStore.LoadProviderApiKey(settings.AllowPlaintextTokenFallback));
             ApplyEnvironmentSettings();
         }
         finally
@@ -175,15 +176,16 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     }
 
     private static string ConvertBaseUrlToWebSocketUrl(string baseUrl)
-    {
-        if (!Uri.TryCreate(baseUrl.TrimEnd('/') + "/ws", UriKind.Absolute, out var uri))
-            return baseUrl;
+        => ManagedGatewayService.BuildWebSocketUrl(baseUrl);
 
-        var builder = new UriBuilder(uri)
+    public void ReportLocalGatewayInitializationFailure(Exception? exception)
+    {
+        var detail = exception?.GetBaseException().Message ?? "Unknown error.";
+        Dispatcher.UIThread.Post(() =>
         {
-            Scheme = uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ? "wss" : "ws"
-        };
-        return builder.Uri.ToString();
+            LocalGatewayStatus = $"Local gateway initialization failed: {detail}";
+            AddSystemMessageCore($"Local gateway initialization failed: {detail}");
+        });
     }
 
     private void HandleInboundText(string payload)

--- a/src/OpenClaw.Companion/Views/MainWindow.axaml
+++ b/src/OpenClaw.Companion/Views/MainWindow.axaml
@@ -97,7 +97,7 @@
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <Button Content="Set Up and Start"
                                             Command="{Binding SetupAndStartLocalGatewayCommand}"
-                                            IsEnabled="{Binding IsManagedGatewayBusy, Converter={StaticResource InverseBool}}" />
+                                            IsEnabled="{Binding CanRunLocalGatewaySetup}" />
                                 </StackPanel>
                             </StackPanel>
                         </Border>

--- a/src/OpenClaw.Tests/CompanionSettingsStoreTests.cs
+++ b/src/OpenClaw.Tests/CompanionSettingsStoreTests.cs
@@ -98,10 +98,11 @@ public sealed class CompanionSettingsStoreTests
         var baseDir = CreateTempDir();
         try
         {
+            var providerStoreDir = Path.Combine(baseDir, "provider-secret-store");
             var store = new SettingsStore(
                 baseDir,
                 new ProtectedTokenStore(baseDir, new InMemorySecretStore()),
-                new ProtectedTokenStore(Path.Combine(baseDir, "provider-secret-store"), new InMemorySecretStore()));
+                new ProtectedTokenStore(providerStoreDir, new InMemorySecretStore()));
             store.Save(new CompanionSettings
             {
                 ServerUrl = "ws://127.0.0.1:18789/ws"
@@ -113,10 +114,61 @@ public sealed class CompanionSettingsStoreTests
             Assert.True(saved);
             Assert.DoesNotContain("provider-secret", json, StringComparison.Ordinal);
             Assert.Equal("provider-secret", store.LoadProviderApiKey(allowPlaintextFallback: false));
+            Assert.True(File.Exists(Path.Combine(providerStoreDir, "stored.marker")));
+            Assert.False(File.Exists(Path.Combine(baseDir, "provider-key", "stored.marker")));
 
             store.ClearProviderApiKey();
 
             Assert.Null(store.LoadProviderApiKey(allowPlaintextFallback: false));
+        }
+        finally
+        {
+            Directory.Delete(baseDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ProviderApiKey_DoesNotLeaveMarkerWhenSecretCannotBeStored()
+    {
+        var baseDir = CreateTempDir();
+        try
+        {
+            var providerStoreDir = Path.Combine(baseDir, "provider-secret-store");
+            var store = new SettingsStore(
+                baseDir,
+                new ProtectedTokenStore(baseDir, new InMemorySecretStore()),
+                new ProtectedTokenStore(providerStoreDir, new UnavailableTestSecretStore()));
+
+            var saved = store.SaveProviderApiKey("provider-secret", allowPlaintextFallback: false);
+
+            Assert.False(saved);
+            Assert.False(File.Exists(Path.Combine(providerStoreDir, "stored.marker")));
+            Assert.Null(store.LoadProviderApiKey(allowPlaintextFallback: false));
+        }
+        finally
+        {
+            Directory.Delete(baseDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ProviderApiKey_TreatsPlaintextFallbackAsStoredWhenExplicitlyAllowed()
+    {
+        var baseDir = CreateTempDir();
+        try
+        {
+            var providerStoreDir = Path.Combine(baseDir, "provider-secret-store");
+            var store = new SettingsStore(
+                baseDir,
+                new ProtectedTokenStore(baseDir, new InMemorySecretStore()),
+                new ProtectedTokenStore(providerStoreDir, new UnavailableTestSecretStore()));
+
+            var saved = store.SaveProviderApiKey("provider-secret", allowPlaintextFallback: true);
+
+            Assert.True(saved);
+            Assert.True(File.Exists(Path.Combine(providerStoreDir, "stored.marker")));
+            Assert.Equal("provider-secret", store.LoadProviderApiKey(allowPlaintextFallback: true));
+            Assert.Equal("provider-secret", File.ReadAllText(Path.Combine(providerStoreDir, "token.txt")));
         }
         finally
         {

--- a/src/OpenClaw.Tests/CompanionSettingsStoreTests.cs
+++ b/src/OpenClaw.Tests/CompanionSettingsStoreTests.cs
@@ -92,6 +92,38 @@ public sealed class CompanionSettingsStoreTests
         }
     }
 
+    [Fact]
+    public void ProviderApiKey_UsesProtectedStoreAndDoesNotPersistInSettingsJson()
+    {
+        var baseDir = CreateTempDir();
+        try
+        {
+            var store = new SettingsStore(
+                baseDir,
+                new ProtectedTokenStore(baseDir, new InMemorySecretStore()),
+                new ProtectedTokenStore(Path.Combine(baseDir, "provider-secret-store"), new InMemorySecretStore()));
+            store.Save(new CompanionSettings
+            {
+                ServerUrl = "ws://127.0.0.1:18789/ws"
+            });
+
+            var saved = store.SaveProviderApiKey("provider-secret", allowPlaintextFallback: false);
+            var json = File.ReadAllText(store.SettingsPath);
+
+            Assert.True(saved);
+            Assert.DoesNotContain("provider-secret", json, StringComparison.Ordinal);
+            Assert.Equal("provider-secret", store.LoadProviderApiKey(allowPlaintextFallback: false));
+
+            store.ClearProviderApiKey();
+
+            Assert.Null(store.LoadProviderApiKey(allowPlaintextFallback: false));
+        }
+        finally
+        {
+            Directory.Delete(baseDir, recursive: true);
+        }
+    }
+
     private static string CreateTempDir()
     {
         var path = Path.Combine(Path.GetTempPath(), "openclaw-companion-tests", Guid.NewGuid().ToString("N"));

--- a/src/OpenClaw.Tests/CompanionSettingsStoreTests.cs
+++ b/src/OpenClaw.Tests/CompanionSettingsStoreTests.cs
@@ -49,7 +49,7 @@ public sealed class CompanionSettingsStoreTests
                 AuthToken = "top-secret"
             });
 
-            Assert.False(File.Exists(Path.Combine(baseDir, "token.txt")));
+            Assert.False(File.Exists(Path.Join(baseDir, "token.txt")));
             Assert.Contains("not saved", store.LastWarning, StringComparison.OrdinalIgnoreCase);
 
             var loaded = store.Load();
@@ -80,7 +80,7 @@ public sealed class CompanionSettingsStoreTests
             var json = File.ReadAllText(store.SettingsPath);
             Assert.DoesNotContain("fallback-secret", json, StringComparison.Ordinal);
             Assert.Contains("\"allowPlaintextTokenFallback\": true", json, StringComparison.OrdinalIgnoreCase);
-            Assert.Equal("fallback-secret", File.ReadAllText(Path.Combine(baseDir, "token.txt")));
+            Assert.Equal("fallback-secret", File.ReadAllText(Path.Join(baseDir, "token.txt")));
 
             var loaded = store.Load();
             Assert.True(loaded.AllowPlaintextTokenFallback);
@@ -98,7 +98,8 @@ public sealed class CompanionSettingsStoreTests
         var baseDir = CreateTempDir();
         try
         {
-            var providerStoreDir = Path.Combine(baseDir, "provider-secret-store");
+            var providerStoreDir = Path.Join(baseDir, "provider-secret-store");
+            var defaultProviderKeyDir = Path.Join(baseDir, "provider-key");
             var store = new SettingsStore(
                 baseDir,
                 new ProtectedTokenStore(baseDir, new InMemorySecretStore()),
@@ -114,8 +115,8 @@ public sealed class CompanionSettingsStoreTests
             Assert.True(saved);
             Assert.DoesNotContain("provider-secret", json, StringComparison.Ordinal);
             Assert.Equal("provider-secret", store.LoadProviderApiKey(allowPlaintextFallback: false));
-            Assert.True(File.Exists(Path.Combine(providerStoreDir, "stored.marker")));
-            Assert.False(File.Exists(Path.Combine(baseDir, "provider-key", "stored.marker")));
+            Assert.True(File.Exists(Path.Join(providerStoreDir, "stored.marker")));
+            Assert.False(File.Exists(Path.Join(defaultProviderKeyDir, "stored.marker")));
 
             store.ClearProviderApiKey();
 
@@ -133,7 +134,7 @@ public sealed class CompanionSettingsStoreTests
         var baseDir = CreateTempDir();
         try
         {
-            var providerStoreDir = Path.Combine(baseDir, "provider-secret-store");
+            var providerStoreDir = Path.Join(baseDir, "provider-secret-store");
             var store = new SettingsStore(
                 baseDir,
                 new ProtectedTokenStore(baseDir, new InMemorySecretStore()),
@@ -142,7 +143,7 @@ public sealed class CompanionSettingsStoreTests
             var saved = store.SaveProviderApiKey("provider-secret", allowPlaintextFallback: false);
 
             Assert.False(saved);
-            Assert.False(File.Exists(Path.Combine(providerStoreDir, "stored.marker")));
+            Assert.False(File.Exists(Path.Join(providerStoreDir, "stored.marker")));
             Assert.Null(store.LoadProviderApiKey(allowPlaintextFallback: false));
         }
         finally
@@ -157,7 +158,7 @@ public sealed class CompanionSettingsStoreTests
         var baseDir = CreateTempDir();
         try
         {
-            var providerStoreDir = Path.Combine(baseDir, "provider-secret-store");
+            var providerStoreDir = Path.Join(baseDir, "provider-secret-store");
             var store = new SettingsStore(
                 baseDir,
                 new ProtectedTokenStore(baseDir, new InMemorySecretStore()),
@@ -166,9 +167,9 @@ public sealed class CompanionSettingsStoreTests
             var saved = store.SaveProviderApiKey("provider-secret", allowPlaintextFallback: true);
 
             Assert.True(saved);
-            Assert.True(File.Exists(Path.Combine(providerStoreDir, "stored.marker")));
+            Assert.True(File.Exists(Path.Join(providerStoreDir, "stored.marker")));
             Assert.Equal("provider-secret", store.LoadProviderApiKey(allowPlaintextFallback: true));
-            Assert.Equal("provider-secret", File.ReadAllText(Path.Combine(providerStoreDir, "token.txt")));
+            Assert.Equal("provider-secret", File.ReadAllText(Path.Join(providerStoreDir, "token.txt")));
         }
         finally
         {
@@ -178,7 +179,7 @@ public sealed class CompanionSettingsStoreTests
 
     private static string CreateTempDir()
     {
-        var path = Path.Combine(Path.GetTempPath(), "openclaw-companion-tests", Guid.NewGuid().ToString("N"));
+        var path = Path.Join(Path.GetTempPath(), "openclaw-companion-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(path);
         return path;
     }

--- a/src/OpenClaw.Tests/ManagedGatewayServiceTests.cs
+++ b/src/OpenClaw.Tests/ManagedGatewayServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using OpenClaw.Companion.Services;
 using Xunit;
 
@@ -54,6 +55,48 @@ public sealed class ManagedGatewayServiceTests : IDisposable
     }
 
     [Fact]
+    public void WebSocketUrl_BracketsIpv6BindAddress()
+    {
+        var configPath = Path.Combine(_tempDir, "openclaw.settings.json");
+        File.WriteAllText(configPath, """
+        {
+          "OpenClaw": {
+            "BindAddress": "::1",
+            "Port": 19002
+          }
+        }
+        """);
+
+        using var service = new ManagedGatewayService(_tempDir, configPath: configPath);
+
+        Assert.Equal("http://[::1]:19002", service.BaseUrl);
+        Assert.Equal("ws://[::1]:19002/ws", service.WebSocketUrl.TrimEnd('/'));
+    }
+
+    [Theory]
+    [InlineData("https://example.test", "wss://example.test/ws")]
+    [InlineData("http://example.test/root", "ws://example.test/root/ws")]
+    [InlineData("wss://example.test/ws", "wss://example.test/ws")]
+    [InlineData("ws://example.test/root/ws", "ws://example.test/root/ws")]
+    public void BuildWebSocketUrl_PreservesWsSchemeAndAvoidsDuplicatePath(string baseUrl, string expected)
+    {
+        Assert.Equal(expected, ManagedGatewayService.BuildWebSocketUrl(baseUrl).TrimEnd('/'));
+    }
+
+    [Fact]
+    public async Task Dispose_DoesNotDisposeInjectedHttpClient()
+    {
+        using var httpClient = new HttpClient(new StaticHttpMessageHandler(HttpStatusCode.OK));
+        using (new ManagedGatewayService(_tempDir, httpClient))
+        {
+        }
+
+        using var response = await httpClient.GetAsync("http://example.test/health");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
     public async Task RunSetupAsync_RequiresApiKeyForRemoteProviders()
     {
         var cliDir = Path.Combine(_tempDir, "cli");
@@ -73,6 +116,114 @@ public sealed class ManagedGatewayServiceTests : IDisposable
         Assert.Contains("API key", result.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task RunSetupAsync_PassesApiKeyAsChildEnvironmentReference()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var cliDir = Path.Combine(_tempDir, "cli");
+        Directory.CreateDirectory(cliDir);
+        var cliPath = Path.Combine(cliDir, BinaryName("openclaw"));
+        File.WriteAllText(cliPath, """
+        #!/usr/bin/env sh
+        printf '%s\n' "$@" > "$OPENCLAW_ARG_CAPTURE_PATH"
+        printf '%s' "$OPENCLAW_MODEL_PROVIDER_KEY" > "$OPENCLAW_ENV_CAPTURE_PATH"
+        exit 0
+        """);
+        File.SetUnixFileMode(
+            cliPath,
+            UnixFileMode.UserRead |
+            UnixFileMode.UserWrite |
+            UnixFileMode.UserExecute);
+
+        var argCapturePath = Path.Combine(_tempDir, "args.txt");
+        var envCapturePath = Path.Combine(_tempDir, "env.txt");
+        var previousProviderKey = Environment.GetEnvironmentVariable("OPENCLAW_MODEL_PROVIDER_KEY");
+        var previousArgCapturePath = Environment.GetEnvironmentVariable("OPENCLAW_ARG_CAPTURE_PATH");
+        var previousEnvCapturePath = Environment.GetEnvironmentVariable("OPENCLAW_ENV_CAPTURE_PATH");
+        Environment.SetEnvironmentVariable("OPENCLAW_MODEL_PROVIDER_KEY", "parent-value");
+        Environment.SetEnvironmentVariable("OPENCLAW_ARG_CAPTURE_PATH", argCapturePath);
+        Environment.SetEnvironmentVariable("OPENCLAW_ENV_CAPTURE_PATH", envCapturePath);
+        try
+        {
+            using var service = new ManagedGatewayService(_tempDir);
+
+            var result = await service.RunSetupAsync(new ManagedGatewaySetupRequest(
+                "openai",
+                "gpt-4o",
+                ApiKey: "super-secret",
+                ModelPresetId: null,
+                WorkspacePath: Path.Combine(_tempDir, "workspace"),
+                ConfigPath: Path.Combine(_tempDir, "config.json")), CancellationToken.None);
+
+            var args = File.ReadAllText(argCapturePath);
+            var childProviderKey = File.ReadAllText(envCapturePath);
+
+            Assert.True(result.IsSuccess, result.Message);
+            Assert.Contains("env:OPENCLAW_MODEL_PROVIDER_KEY", args);
+            Assert.DoesNotContain("super-secret", args);
+            Assert.Equal("super-secret", childProviderKey);
+            Assert.Equal("parent-value", Environment.GetEnvironmentVariable("OPENCLAW_MODEL_PROVIDER_KEY"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OPENCLAW_MODEL_PROVIDER_KEY", previousProviderKey);
+            Environment.SetEnvironmentVariable("OPENCLAW_ARG_CAPTURE_PATH", previousArgCapturePath);
+            Environment.SetEnvironmentVariable("OPENCLAW_ENV_CAPTURE_PATH", previousEnvCapturePath);
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_InjectsStoredProviderApiKeyIntoGatewayProcess()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var gatewayDir = Path.Combine(_tempDir, "gateway");
+        Directory.CreateDirectory(gatewayDir);
+        var gatewayPath = Path.Combine(gatewayDir, BinaryName("OpenClaw.Gateway"));
+        File.WriteAllText(gatewayPath, """
+        #!/usr/bin/env sh
+        printf '%s' "$OPENCLAW_MODEL_PROVIDER_KEY" > "$OPENCLAW_GATEWAY_ENV_CAPTURE_PATH"
+        exit 0
+        """);
+        File.SetUnixFileMode(
+            gatewayPath,
+            UnixFileMode.UserRead |
+            UnixFileMode.UserWrite |
+            UnixFileMode.UserExecute);
+
+        var configPath = Path.Combine(_tempDir, "openclaw.settings.json");
+        File.WriteAllText(configPath, """
+        {
+          "OpenClaw": {
+            "BindAddress": "127.0.0.1",
+            "Port": 19003
+          }
+        }
+        """);
+
+        var envCapturePath = Path.Combine(_tempDir, "gateway-env.txt");
+        var previousEnvCapturePath = Environment.GetEnvironmentVariable("OPENCLAW_GATEWAY_ENV_CAPTURE_PATH");
+        Environment.SetEnvironmentVariable("OPENCLAW_GATEWAY_ENV_CAPTURE_PATH", envCapturePath);
+        try
+        {
+            using var httpClient = new HttpClient(new StaticHttpMessageHandler(HttpStatusCode.ServiceUnavailable));
+            using var service = new ManagedGatewayService(_tempDir, httpClient, configPath: configPath);
+            service.SetProviderApiKey("super-secret");
+
+            var result = await service.StartAsync(authToken: null, CancellationToken.None);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal("super-secret", File.ReadAllText(envCapturePath));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OPENCLAW_GATEWAY_ENV_CAPTURE_PATH", previousEnvCapturePath);
+        }
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDir))
@@ -81,4 +232,10 @@ public sealed class ManagedGatewayServiceTests : IDisposable
 
     private static string BinaryName(string name)
         => OperatingSystem.IsWindows() ? name + ".exe" : name;
+
+    private sealed class StaticHttpMessageHandler(HttpStatusCode statusCode) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(statusCode));
+    }
 }

--- a/src/OpenClaw.Tests/ManagedGatewayServiceTests.cs
+++ b/src/OpenClaw.Tests/ManagedGatewayServiceTests.cs
@@ -77,10 +77,23 @@ public sealed class ManagedGatewayServiceTests : IDisposable
     [InlineData("https://example.test", "wss://example.test/ws")]
     [InlineData("http://example.test/root", "ws://example.test/root/ws")]
     [InlineData("wss://example.test/ws", "wss://example.test/ws")]
+    [InlineData("wss://example.test/ws/", "wss://example.test/ws")]
     [InlineData("ws://example.test/root/ws", "ws://example.test/root/ws")]
+    [InlineData("ws://example.test/root/ws/", "ws://example.test/root/ws")]
     public void BuildWebSocketUrl_PreservesWsSchemeAndAvoidsDuplicatePath(string baseUrl, string expected)
     {
         Assert.Equal(expected, ManagedGatewayService.BuildWebSocketUrl(baseUrl).TrimEnd('/'));
+    }
+
+    [Fact]
+    public async Task IsHealthyAsync_PropagatesCallerCancellation()
+    {
+        using var httpClient = new HttpClient(new CancellationHttpMessageHandler());
+        using var service = new ManagedGatewayService(_tempDir, httpClient);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => service.IsHealthyAsync(null, cts.Token));
     }
 
     [Fact]
@@ -175,6 +188,38 @@ public sealed class ManagedGatewayServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task RunSetupAsync_PropagatesCallerCancellation()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var cliDir = Path.Combine(_tempDir, "cli");
+        Directory.CreateDirectory(cliDir);
+        var cliPath = Path.Combine(cliDir, BinaryName("openclaw"));
+        File.WriteAllText(cliPath, """
+        #!/usr/bin/env sh
+        sleep 5
+        exit 0
+        """);
+        File.SetUnixFileMode(
+            cliPath,
+            UnixFileMode.UserRead |
+            UnixFileMode.UserWrite |
+            UnixFileMode.UserExecute);
+
+        using var service = new ManagedGatewayService(_tempDir);
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => service.RunSetupAsync(new ManagedGatewaySetupRequest(
+            "openai",
+            "gpt-4o",
+            ApiKey: "super-secret",
+            ModelPresetId: null,
+            WorkspacePath: Path.Combine(_tempDir, "workspace"),
+            ConfigPath: Path.Combine(_tempDir, "config.json")), cts.Token));
+    }
+
+    [Fact]
     public async Task StartAsync_InjectsStoredProviderApiKeyIntoGatewayProcess()
     {
         if (OperatingSystem.IsWindows())
@@ -236,6 +281,15 @@ public sealed class ManagedGatewayServiceTests : IDisposable
     private sealed class StaticHttpMessageHandler(HttpStatusCode statusCode) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            => Task.FromResult(new HttpResponseMessage(statusCode));
+        {
+            var response = new HttpResponseMessage(statusCode);
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class CancellationHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromCanceled<HttpResponseMessage>(cancellationToken);
     }
 }

--- a/src/OpenClaw.Tests/ManagedGatewayServiceTests.cs
+++ b/src/OpenClaw.Tests/ManagedGatewayServiceTests.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using OpenClaw.Companion.Services;
 using Xunit;
 
@@ -10,21 +9,21 @@ public sealed class ManagedGatewayServiceTests : IDisposable
 
     public ManagedGatewayServiceTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), "openclaw-managed-gateway-tests", Guid.NewGuid().ToString("N"));
+        _tempDir = Path.Join(Path.GetTempPath(), "openclaw-managed-gateway-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_tempDir);
     }
 
     [Fact]
     public void ResolveExecutables_FindsReleaseSiblingLayout()
     {
-        var companionDir = Path.Combine(_tempDir, "companion");
-        var gatewayDir = Path.Combine(_tempDir, "gateway");
-        var cliDir = Path.Combine(_tempDir, "cli");
+        var companionDir = Path.Join(_tempDir, "companion");
+        var gatewayDir = Path.Join(_tempDir, "gateway");
+        var cliDir = Path.Join(_tempDir, "cli");
         Directory.CreateDirectory(companionDir);
         Directory.CreateDirectory(gatewayDir);
         Directory.CreateDirectory(cliDir);
-        File.WriteAllText(Path.Combine(gatewayDir, BinaryName("OpenClaw.Gateway")), "");
-        File.WriteAllText(Path.Combine(cliDir, BinaryName("openclaw")), "");
+        File.WriteAllText(Path.Join(gatewayDir, BinaryName("OpenClaw.Gateway")), "");
+        File.WriteAllText(Path.Join(cliDir, BinaryName("openclaw")), "");
 
         var gateway = ManagedGatewayService.ResolveGatewayExecutable(companionDir);
         var cli = ManagedGatewayService.ResolveCliExecutable(companionDir);
@@ -38,7 +37,7 @@ public sealed class ManagedGatewayServiceTests : IDisposable
     [Fact]
     public void WebSocketUrl_UsesConfiguredPort()
     {
-        var configPath = Path.Combine(_tempDir, "openclaw.settings.json");
+        var configPath = Path.Join(_tempDir, "openclaw.settings.json");
         File.WriteAllText(configPath, """
         {
           "OpenClaw": {
@@ -57,7 +56,7 @@ public sealed class ManagedGatewayServiceTests : IDisposable
     [Fact]
     public void WebSocketUrl_BracketsIpv6BindAddress()
     {
-        var configPath = Path.Combine(_tempDir, "openclaw.settings.json");
+        var configPath = Path.Join(_tempDir, "openclaw.settings.json");
         File.WriteAllText(configPath, """
         {
           "OpenClaw": {
@@ -97,24 +96,22 @@ public sealed class ManagedGatewayServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Dispose_DoesNotDisposeInjectedHttpClient()
+    public void Dispose_DoesNotDisposeInjectedHttpClient()
     {
-        using var httpClient = new HttpClient(new StaticHttpMessageHandler(HttpStatusCode.OK));
+        using var httpClient = new TrackingHttpClient();
         using (new ManagedGatewayService(_tempDir, httpClient))
         {
         }
 
-        using var response = await httpClient.GetAsync("http://example.test/health");
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.False(httpClient.WasDisposed);
     }
 
     [Fact]
     public async Task RunSetupAsync_RequiresApiKeyForRemoteProviders()
     {
-        var cliDir = Path.Combine(_tempDir, "cli");
+        var cliDir = Path.Join(_tempDir, "cli");
         Directory.CreateDirectory(cliDir);
-        File.WriteAllText(Path.Combine(cliDir, BinaryName("openclaw")), "");
+        File.WriteAllText(Path.Join(cliDir, BinaryName("openclaw")), "");
         using var service = new ManagedGatewayService(_tempDir);
 
         var result = await service.RunSetupAsync(new ManagedGatewaySetupRequest(
@@ -122,8 +119,8 @@ public sealed class ManagedGatewayServiceTests : IDisposable
             "gpt-4o",
             ApiKey: null,
             ModelPresetId: null,
-            WorkspacePath: Path.Combine(_tempDir, "workspace"),
-            ConfigPath: Path.Combine(_tempDir, "config.json")), CancellationToken.None);
+            WorkspacePath: Path.Join(_tempDir, "workspace"),
+            ConfigPath: Path.Join(_tempDir, "config.json")), CancellationToken.None);
 
         Assert.False(result.IsSuccess);
         Assert.Contains("API key", result.Message, StringComparison.OrdinalIgnoreCase);
@@ -135,9 +132,9 @@ public sealed class ManagedGatewayServiceTests : IDisposable
         if (OperatingSystem.IsWindows())
             return;
 
-        var cliDir = Path.Combine(_tempDir, "cli");
+        var cliDir = Path.Join(_tempDir, "cli");
         Directory.CreateDirectory(cliDir);
-        var cliPath = Path.Combine(cliDir, BinaryName("openclaw"));
+        var cliPath = Path.Join(cliDir, BinaryName("openclaw"));
         File.WriteAllText(cliPath, """
         #!/usr/bin/env sh
         printf '%s\n' "$@" > "$OPENCLAW_ARG_CAPTURE_PATH"
@@ -150,8 +147,8 @@ public sealed class ManagedGatewayServiceTests : IDisposable
             UnixFileMode.UserWrite |
             UnixFileMode.UserExecute);
 
-        var argCapturePath = Path.Combine(_tempDir, "args.txt");
-        var envCapturePath = Path.Combine(_tempDir, "env.txt");
+        var argCapturePath = Path.Join(_tempDir, "args.txt");
+        var envCapturePath = Path.Join(_tempDir, "env.txt");
         var previousProviderKey = Environment.GetEnvironmentVariable("OPENCLAW_MODEL_PROVIDER_KEY");
         var previousArgCapturePath = Environment.GetEnvironmentVariable("OPENCLAW_ARG_CAPTURE_PATH");
         var previousEnvCapturePath = Environment.GetEnvironmentVariable("OPENCLAW_ENV_CAPTURE_PATH");
@@ -167,8 +164,8 @@ public sealed class ManagedGatewayServiceTests : IDisposable
                 "gpt-4o",
                 ApiKey: "super-secret",
                 ModelPresetId: null,
-                WorkspacePath: Path.Combine(_tempDir, "workspace"),
-                ConfigPath: Path.Combine(_tempDir, "config.json")), CancellationToken.None);
+                WorkspacePath: Path.Join(_tempDir, "workspace"),
+                ConfigPath: Path.Join(_tempDir, "config.json")), CancellationToken.None);
 
             var args = File.ReadAllText(argCapturePath);
             var childProviderKey = File.ReadAllText(envCapturePath);
@@ -193,9 +190,9 @@ public sealed class ManagedGatewayServiceTests : IDisposable
         if (OperatingSystem.IsWindows())
             return;
 
-        var cliDir = Path.Combine(_tempDir, "cli");
+        var cliDir = Path.Join(_tempDir, "cli");
         Directory.CreateDirectory(cliDir);
-        var cliPath = Path.Combine(cliDir, BinaryName("openclaw"));
+        var cliPath = Path.Join(cliDir, BinaryName("openclaw"));
         File.WriteAllText(cliPath, """
         #!/usr/bin/env sh
         sleep 5
@@ -215,8 +212,8 @@ public sealed class ManagedGatewayServiceTests : IDisposable
             "gpt-4o",
             ApiKey: "super-secret",
             ModelPresetId: null,
-            WorkspacePath: Path.Combine(_tempDir, "workspace"),
-            ConfigPath: Path.Combine(_tempDir, "config.json")), cts.Token));
+            WorkspacePath: Path.Join(_tempDir, "workspace"),
+            ConfigPath: Path.Join(_tempDir, "config.json")), cts.Token));
     }
 
     [Fact]
@@ -225,9 +222,9 @@ public sealed class ManagedGatewayServiceTests : IDisposable
         if (OperatingSystem.IsWindows())
             return;
 
-        var gatewayDir = Path.Combine(_tempDir, "gateway");
+        var gatewayDir = Path.Join(_tempDir, "gateway");
         Directory.CreateDirectory(gatewayDir);
-        var gatewayPath = Path.Combine(gatewayDir, BinaryName("OpenClaw.Gateway"));
+        var gatewayPath = Path.Join(gatewayDir, BinaryName("OpenClaw.Gateway"));
         File.WriteAllText(gatewayPath, """
         #!/usr/bin/env sh
         printf '%s' "$OPENCLAW_MODEL_PROVIDER_KEY" > "$OPENCLAW_GATEWAY_ENV_CAPTURE_PATH"
@@ -239,7 +236,7 @@ public sealed class ManagedGatewayServiceTests : IDisposable
             UnixFileMode.UserWrite |
             UnixFileMode.UserExecute);
 
-        var configPath = Path.Combine(_tempDir, "openclaw.settings.json");
+        var configPath = Path.Join(_tempDir, "openclaw.settings.json");
         File.WriteAllText(configPath, """
         {
           "OpenClaw": {
@@ -249,12 +246,12 @@ public sealed class ManagedGatewayServiceTests : IDisposable
         }
         """);
 
-        var envCapturePath = Path.Combine(_tempDir, "gateway-env.txt");
+        var envCapturePath = Path.Join(_tempDir, "gateway-env.txt");
         var previousEnvCapturePath = Environment.GetEnvironmentVariable("OPENCLAW_GATEWAY_ENV_CAPTURE_PATH");
         Environment.SetEnvironmentVariable("OPENCLAW_GATEWAY_ENV_CAPTURE_PATH", envCapturePath);
         try
         {
-            using var httpClient = new HttpClient(new StaticHttpMessageHandler(HttpStatusCode.ServiceUnavailable));
+            using var httpClient = new HttpClient(new FailingHttpMessageHandler());
             using var service = new ManagedGatewayService(_tempDir, httpClient, configPath: configPath);
             service.SetProviderApiKey("super-secret");
 
@@ -278,12 +275,14 @@ public sealed class ManagedGatewayServiceTests : IDisposable
     private static string BinaryName(string name)
         => OperatingSystem.IsWindows() ? name + ".exe" : name;
 
-    private sealed class StaticHttpMessageHandler(HttpStatusCode statusCode) : HttpMessageHandler
+    private sealed class TrackingHttpClient : HttpClient
     {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        public bool WasDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
         {
-            var response = new HttpResponseMessage(statusCode);
-            return Task.FromResult(response);
+            WasDisposed = true;
+            base.Dispose(disposing);
         }
     }
 
@@ -291,5 +290,11 @@ public sealed class ManagedGatewayServiceTests : IDisposable
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             => Task.FromCanceled<HttpResponseMessage>(cancellationToken);
+    }
+
+    private sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromException<HttpResponseMessage>(new HttpRequestException("unhealthy"));
     }
 }


### PR DESCRIPTION
## Summary
- Address post-merge Copilot/code-quality comments from the desktop release onboarding PR
- Harden managed gateway startup/disposal, URL handling, and setup secret flow
- Gate setup UI by bundled CLI availability and pin the macOS ARM release runner

## Validation
- dotnet build src/OpenClaw.Companion/OpenClaw.Companion.csproj -c Release
- dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj -c Release --filter "ManagedGatewayServiceTests|CompanionSettingsStoreTests"
- dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj -c Release
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release workflow yaml ok'"
- git diff --check