### PR TITLE
[codex] Harden release candidate flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,43 +30,29 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Restore standard targets
-        run: |
-          dotnet restore src/OpenClaw.Gateway && dotnet restore src/OpenClaw.Tests
-          dotnet restore src/OpenClaw.SemanticKernelAdapter
-          dotnet restore samples/OpenClaw.SemanticKernelInteropHost
+      - name: Restore solution
+        run: dotnet restore OpenClaw.Net.slnx
 
-      - name: Build standard targets
-        run: |
-          dotnet build --no-restore -c Release src/OpenClaw.Gateway && dotnet build --no-restore -c Release src/OpenClaw.Tests
-          dotnet build --no-restore -c Release src/OpenClaw.SemanticKernelAdapter
-          dotnet build --no-restore -c Release samples/OpenClaw.SemanticKernelInteropHost
+      - name: Build solution
+        run: dotnet build OpenClaw.Net.slnx --no-restore -c Release
 
       - name: Test standard targets
         run: dotnet test --no-build -c Release --verbosity normal --logger "trx;LogFileName=results.trx" src/OpenClaw.Tests
 
-      - name: Restore sandbox-enabled targets
-        run: |
-          dotnet restore src/OpenClaw.Gateway -p:OpenClawEnableOpenSandbox=true
-          dotnet restore src/OpenClaw.Tests -p:OpenClawEnableOpenSandbox=true
+      - name: Restore sandbox-enabled solution
+        run: dotnet restore OpenClaw.Net.slnx -p:OpenClawEnableOpenSandbox=true
 
-      - name: Build sandbox-enabled targets
-        run: |
-          dotnet build --no-restore -c Release -p:OpenClawEnableOpenSandbox=true src/OpenClaw.Gateway
-          dotnet build --no-restore -c Release -p:OpenClawEnableOpenSandbox=true src/OpenClaw.Tests
+      - name: Build sandbox-enabled solution
+        run: dotnet build OpenClaw.Net.slnx --no-restore -c Release -p:OpenClawEnableOpenSandbox=true
 
       - name: Test sandbox-enabled targets
         run: dotnet test --no-build -c Release -p:OpenClawEnableOpenSandbox=true --verbosity normal --logger "trx;LogFileName=results-sandbox.trx" src/OpenClaw.Tests
 
-      - name: Restore MAF-enabled targets
-        run: |
-          dotnet restore src/OpenClaw.Gateway -p:OpenClawEnableMafExperiment=true
-          dotnet restore src/OpenClaw.Tests -p:OpenClawEnableMafExperiment=true
+      - name: Restore MAF-enabled solution
+        run: dotnet restore OpenClaw.Net.slnx -p:OpenClawEnableMafExperiment=true
 
-      - name: Build MAF-enabled targets
-        run: |
-          dotnet build --no-restore -c Release -p:OpenClawEnableMafExperiment=true src/OpenClaw.Gateway
-          dotnet build --no-restore -c Release -p:OpenClawEnableMafExperiment=true src/OpenClaw.Tests
+      - name: Build MAF-enabled solution
+        run: dotnet build OpenClaw.Net.slnx --no-restore -c Release -p:OpenClawEnableMafExperiment=true
 
       - name: Test MAF-enabled targets
         run: dotnet test --no-build -c Release -p:OpenClawEnableMafExperiment=true --verbosity normal --logger "trx;LogFileName=results-maf.trx" src/OpenClaw.Tests
@@ -81,7 +67,7 @@ jobs:
   publish-aot:
     needs: build-and-test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
 
@@ -93,30 +79,104 @@ jobs:
       - name: Install AOT prerequisites
         run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
 
-      - name: Publish and smoke-test NativeAOT binaries
+      - name: Publish and smoke-test standard NativeAOT binaries
         run: |
           chmod +x ./eng/verify-aot-smoke.sh
-          chmod +x ./eng/verify-aot-maf-smoke.sh
           ./eng/verify-aot-smoke.sh
+
+      - name: Publish and smoke-test MAF NativeAOT gateway
+        if: github.event_name != 'pull_request'
+        run: |
+          chmod +x ./eng/verify-aot-maf-smoke.sh
           ./eng/verify-aot-maf-smoke.sh
 
       - name: Upload standard gateway artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: gateway-standard-aot-linux-x64
           path: ./artifacts/aot/gateway/
 
       - name: Upload MAF-enabled gateway artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: gateway-maf-enabled-aot-linux-x64
           path: ./artifacts/aot-maf/gateway/
 
       - name: Upload CLI artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: openclaw-cli-aot-linux-x64
           path: ./artifacts/aot/cli/
+
+  macos-gateway-linker-probe:
+    needs: build-and-test
+    runs-on: macos-15
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure macOS Swift library path
+        shell: bash
+        run: |
+          set -euo pipefail
+          developer_dir="$(xcode-select -p)"
+          sdk_path="$(xcrun --sdk macosx --show-sdk-path)"
+          library_paths=()
+          for candidate in \
+            "/usr/lib/swift" \
+            "$developer_dir/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx" \
+            "$sdk_path/usr/lib/swift"; do
+            if [[ -d "$candidate" ]]; then
+              library_paths+=("$candidate")
+            fi
+          done
+          if [[ -n "${LIBRARY_PATH:-}" ]]; then
+            library_paths+=("$LIBRARY_PATH")
+          fi
+          joined="$(IFS=:; echo "${library_paths[*]}")"
+          echo "LIBRARY_PATH=$joined" >> "$GITHUB_ENV"
+          echo "Using macOS Swift library paths: $joined"
+
+      - name: Probe gateway NativeAOT without classic linker
+        id: probe
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/linker-probe
+          dotnet publish src/OpenClaw.Gateway/OpenClaw.Gateway.csproj \
+            -c Release \
+            -r osx-arm64 \
+            --self-contained true \
+            -p:PublishAot=true \
+            -p:OpenClawUseClassicMacLd=false \
+            -o artifacts/linker-probe/gateway \
+            2>&1 | tee artifacts/linker-probe/publish.log
+
+      - name: Report linker probe outcome
+        shell: bash
+        run: |
+          if [[ "${{ steps.probe.outcome }}" == "success" ]]; then
+            echo "::notice title=Gateway linked without classic linker::Remove the gateway OpenClawUseClassicMacLd default after validating release smoke coverage."
+          else
+            echo "::warning title=Gateway still needs classic linker::The no-classic-linker probe failed on macos-15; keep the scoped gateway fallback."
+          fi
+
+      - name: Upload linker probe log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-gateway-linker-probe
+          path: artifacts/linker-probe/
 
   publish-jit:
     needs: build-and-test

--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,0 +1,118 @@
+# OpenClaw.NET Hardening Audit
+
+Date: 2026-05-02
+
+## Executive Summary
+
+OpenClaw.NET is in a generally healthy state for the standard runtime path: restore, Release build, full test suite, CLI NativeAOT publish, and gateway NativeAOT publish all completed successfully on macOS arm64 with .NET SDK 10.0.100. The main product risk found in the initial pass was not the default path; it was the optional compatibility and filesystem-hardening edge cases around plugin loading and MAF-enabled builds. Those highest-value issues were fixed in this pass, and the follow-up limitation pass tightened the remaining developer-confidence issues where the repository controls them.
+
+No Critical issue was found in the standard runtime, gateway, CLI, companion, or test path. The highest-value fixes selected for this pass are:
+
+- High: fixed the MAF-enabled solution build by giving the test project direct conditional references to the MAF/A2A packages used by MAF tests.
+- High: hardened plugin entry path containment so symlinked entry files or symlinked parent directories cannot escape the plugin root.
+- Medium: hardened tool and contract-scope path canonicalization for existing files under symlinked parent directories.
+- Medium: normalized Companion managed-gateway websocket URLs by stripping query and fragment data.
+- Medium: made streaming clients receive `tool_start` before long-running non-streaming tools block the stream.
+- Medium: made browser-tool tests use a local page and Playwright's normal browser cache instead of a per-run browser install path and external `example.com`.
+- Low: scoped the macOS `-ld_classic` fallback to the gateway AOT project instead of every osx-arm64 AOT publish.
+- Low: made top-level CLI help list the existing `plugins` command.
+
+## Build And Test Status
+
+- `dotnet restore OpenClaw.Net.slnx`: Passed.
+- `dotnet build OpenClaw.Net.slnx --configuration Release --no-restore`: Passed with 0 warnings and 0 errors.
+- Initial `dotnet test OpenClaw.Net.slnx --configuration Release --no-build`: Passed, 1039/1039 tests.
+- Initial post-fix focused regression tests: Passed, 46/46 tests.
+- Post-fix `dotnet test OpenClaw.Net.slnx --configuration Release --no-build`: Passed, 1044/1044 tests.
+- Limitation-pass focused tests for streaming and browser coverage: Passed, 34/34 tests.
+- Limitation-pass `dotnet test OpenClaw.Net.slnx --configuration Release --no-restore`: Passed, 1045/1045 tests.
+- `dotnet publish src/OpenClaw.Cli/OpenClaw.Cli.csproj --configuration Release --runtime osx-arm64 --self-contained true`: Passed and the resulting `openclaw --help` ran successfully. After scoping `-ld_classic`, the CLI publish no longer emits the deprecated linker warning.
+- `dotnet publish src/OpenClaw.Gateway/OpenClaw.Gateway.csproj --configuration Release --runtime osx-arm64 --self-contained true`: Passed. Gateway still emits the deprecated `-ld_classic` warning plus package/toolchain module-cache debug-info warnings. A probe without the classic linker failed with an Apple `ld::Fixup` assertion, so the gateway fallback remains intentionally scoped.
+- Post-fix `dotnet build OpenClaw.Net.slnx --configuration Release -p:OpenClawEnableOpenSandbox=true`: Passed with 0 warnings and 0 errors.
+- Post-fix `dotnet build OpenClaw.Net.slnx --configuration Release -p:OpenClawEnableMafExperiment=true`: Passed with 0 warnings and 0 errors.
+- CI follow-up: `.github/workflows/ci.yml` now restores/builds `OpenClaw.Net.slnx` for the standard, OpenSandbox-enabled, and MAF-enabled variants; PR CI now runs the standard Linux NativeAOT gateway/CLI smoke, and scheduled/manual CI probes macOS gateway publish with `-p:OpenClawUseClassicMacLd=false`.
+
+## Critical Bugs Found
+
+None in the standard build, test, CLI, gateway, or companion paths audited so far.
+
+## High Severity
+
+- High: MAF-enabled solution build fails.
+  - Evidence: enabling `OpenClawEnableMafExperiment=true` produced missing namespace/type errors for `A2A`, `Microsoft.Agents.AI`, `ChatClientAgent`, and `AgentSession` in `OpenClaw.Tests`.
+  - Impact: the documented optional MAF/AOT-JIT compatibility lane cannot be validated by a full solution build.
+  - Fix: added direct conditional test package references for the MAF/A2A packages used by those test files.
+  - Status: fixed; post-fix MAF-enabled solution build passes with 0 warnings.
+
+- High: plugin entry containment can be bypassed through symlinked entry paths.
+  - Evidence: `PluginDiscovery.FindEntryFile` returns common entry files such as `index.js` without a real-path containment check after resolving symlinks. Existing containment checks also only resolved the final path component, not symlinked parent directories.
+  - Impact: a plugin directory could point its entry file or parent directory outside the plugin root while still appearing to be under the root path.
+  - Fix: canonicalized paths segment-by-segment, resolved symlinked ancestors, and re-checked containment for manifest-discovered entry files.
+  - Status: fixed with regression tests for manifest entry symlinks and package entries under symlinked parent directories.
+
+## Medium Severity
+
+- Medium: tool path policy canonicalization does not resolve symlinked parent directories for existing read targets.
+  - Impact: allowed-root checks are stronger for non-existent write targets than for existing files reachable through symlinked directories.
+  - Fix: uses segment-by-segment symlink resolution for all tool path checks and aligns contract-scope allowed roots with the same canonicalization.
+  - Status: fixed with regression tests.
+
+- Medium: Companion managed-gateway websocket URLs preserve query strings/fragments from the configured base URL.
+  - Impact: a configured base URL containing query or fragment data can produce a confusing `/ws?...` URL.
+  - Fix: clears query and fragment when constructing the websocket endpoint.
+  - Status: fixed with regression coverage.
+
+- Medium: the full test suite has a cold-machine network dependency.
+  - Evidence: `BrowserToolTests.BrowserTool_CanNavigateAndGetText` downloaded Playwright Chromium, FFmpeg, and headless shell during `dotnet test`.
+  - Impact: first-time contributors can see slow or network-sensitive test runs even when all product code is correct.
+  - Fix: the test now serves a local loopback page, disables private-network URL blocking only for that local fixture, and uses Playwright's normal browser cache by default instead of a fresh per-run temp browser path. The first run can still download Playwright assets if none are installed.
+  - Status: fixed as far as practical without removing browser coverage.
+
+- Medium: streaming non-streaming tool progress is delayed until tool completion.
+  - Impact: websocket clients see no `tool_start` for a long-running non-streaming tool or parallel non-streaming batch until the runtime has already finished the batch.
+  - Fix: streaming now emits `tool_start` before executing non-streaming tools and preserves completion status/failure metadata in `tool_result`.
+  - Status: fixed with regression coverage.
+
+## Low Severity
+
+- Low: CLI top-level usage omitted the existing `openclaw plugins <install|remove|list|search>` command even though plugin help/examples appeared lower in the same output. Fixed in this pass.
+- Low: macOS gateway NativeAOT publish emits native linker/debug-info warnings. The CLI no longer uses `-ld_classic` by default; the gateway keeps it because the current toolchain failed to link the gateway without it. Release documentation now calls this out.
+
+## Business Logic Mismatches
+
+- The standard product identity and positioning are consistent: the code separates NativeAOT-friendly core/gateway/CLI paths from optional non-AOT adapters, and the README keeps the OpenClaw.NET identity.
+- The MAF optional lane is documented as an experiment/optional compatibility surface; the flagged solution build now passes after adding direct test package references.
+- The CLI exposes plugin management and top-level help now advertises the command in the usage block.
+
+## Security And Safety Concerns
+
+- Public-bind hardening and endpoint auth are covered by tests and implementation patterns; `/health/live` and `/health/ready` intentionally expose only minimal unauthenticated probe data.
+- Plugin entry path containment needed symlink hardening.
+- Tool read/write path policy needed equivalent ancestor-symlink hardening for existing files and non-existent targets.
+- No evidence was found in this pass of provider API keys being passed on the command line by Companion setup; it passes them through a child-process environment reference.
+
+## Performance And Resource Usage
+
+- Standard build/test performance is acceptable for a large integration-heavy suite.
+- The browser-tool test still may trigger a first-time Playwright asset install, but it no longer forces a fresh browser download path per run and no longer depends on `example.com`.
+- Runtime tool execution has bounded timeouts, cancellation propagation, and bounded streaming collection. Streaming now emits `tool_start` before non-streaming tools execute, including parallel batches, so clients see progress earlier.
+
+## NativeAOT And Trimming Concerns
+
+- Standard CLI and gateway NativeAOT publish succeeded on osx-arm64.
+- Gateway suppresses known package-level Playwright trim/AOT warnings while still surfacing project-owned diagnostics.
+- Optional adapters are marked as non-AOT or conditional where appropriate.
+- The MAF-enabled validation build failure was the main NativeAOT/JIT boundary confidence issue found; the flagged build now passes.
+- The CLI osx-arm64 NativeAOT publish no longer carries the gateway's classic-linker fallback. The gateway still carries it intentionally because removing it reproduced an Apple linker assertion on this toolchain.
+
+## Documentation Mismatches
+
+- CLI help needed to list `openclaw plugins`; fixed in this pass.
+- Contributor/onboarding docs needed to mention that the full test suite may install Playwright browser assets on a cold machine; `docs/QUICKSTART.md` now notes the one-time cache behavior and the isolation override.
+- Release docs now note the gateway-specific macOS NativeAOT classic-linker fallback and when to revisit it.
+
+## Recommended Follow-Up Work
+
+- Monitor the first GitHub Actions run after these workflow changes, especially the PR-time Linux NativeAOT smoke and scheduled macOS linker probe.
+- Remove the gateway `OpenClawUseClassicMacLd` default once the scheduled macOS probe links the gateway reliably without it.
+- Consider an explicit browser-dependent test category only if CI or contributor environments need a fully offline default test command.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to OpenClaw.NET
 
-Thank you for your interest in contributing! This guide covers the contributor workflow. For the project shape, repository map, and how the runtime fits together, start with [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md). For a first local run, follow [docs/QUICKSTART.md](docs/QUICKSTART.md).
+Thank you for your interest in contributing! This guide covers the contributor workflow. For the project shape, repository map, and how the runtime fits together, start with [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md). If you are evaluating the project for the first time, read [docs/START_HERE.md](docs/START_HERE.md). For a first local run, follow [docs/QUICKSTART.md](docs/QUICKSTART.md).
 
 ## Prerequisites
 
@@ -14,13 +14,14 @@ Thank you for your interest in contributing! This guide covers the contributor w
 git clone https://github.com/clawdotnet/openclaw.net
 cd openclaw.net
 
-dotnet build
+dotnet restore OpenClaw.Net.slnx
+dotnet build OpenClaw.Net.slnx --configuration Release --no-restore
 
 # All tests
-dotnet test
+dotnet test OpenClaw.Net.slnx --configuration Release --no-build
 
-# A specific test project
-dotnet test src/OpenClaw.Tests
+# First deterministic runtime smoke
+dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build
 ```
 
 ## Code Style
@@ -39,12 +40,20 @@ dotnet test src/OpenClaw.Tests
 4. **Verify before submitting:**
 
    ```bash
-   dotnet test
-   dotnet build -warnaserror
-   # Optional: dotnet publish src/OpenClaw.Gateway -c Release
+   dotnet build OpenClaw.Net.slnx --configuration Release --no-restore
+   dotnet test OpenClaw.Net.slnx --configuration Release --no-build
+   dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build
    ```
 
 5. **Open a PR.** Fill out the template, reference related issues (`Fixes #123`), and keep PRs focused — one feature or fix per PR. Rebase on `main` if your branch is behind.
+
+## Good First Contribution Areas
+
+- Documentation gaps where a setup or diagnostic step is unclear.
+- Focused regression tests for existing runtime, gateway, CLI, setup, or plugin behavior.
+- Small CLI/help-text improvements that make failures more actionable.
+- Compatibility catalog additions that exercise a real upstream package or intentionally unsupported case.
+- Sample improvements that demonstrate existing behavior without adding new runtime architecture.
 
 ## Pull Request Review
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
-  <ItemGroup Condition="'$(PublishAot)' == 'true' and '$(RuntimeIdentifier)' == 'osx-arm64'">
+  <ItemGroup Condition="'$(PublishAot)' == 'true' and '$(RuntimeIdentifier)' == 'osx-arm64' and '$(OpenClawUseClassicMacLd)' == 'true'">
     <LinkerArg Include="-ld_classic" />
   </ItemGroup>
 </Project>

--- a/OpenClaw.Net.slnx
+++ b/OpenClaw.Net.slnx
@@ -5,6 +5,7 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/samples/">
+    <Project Path="samples/OpenClaw.HelloAgent/OpenClaw.HelloAgent.csproj" />
     <Project Path="samples/OpenClaw.SemanticKernelInteropHost/OpenClaw.SemanticKernelInteropHost.csproj" />
   </Folder>
   <Folder Name="/src/">

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 ![NativeAOT-friendly](https://img.shields.io/badge/NativeAOT-friendly-blue)
-![Plugin compatibility](https://img.shields.io/badge/plugin%20compatibility-practical-green)
+![Plugin compatibility](https://img.shields.io/badge/plugin%20compatibility-evolving-green)
 ![Tools](https://img.shields.io/badge/native%20tools-48-green)
 ![Channels](https://img.shields.io/badge/channels-9-green)
 
@@ -41,7 +41,7 @@ Each desktop bundle includes Companion, the standard NativeAOT gateway, and the 
 4. Choose a provider/model and enter the provider key, or choose Ollama for a local model.
 5. Click **Set Up and Start**.
 
-Companion writes a local config, starts the bundled gateway on `127.0.0.1`, and connects to it. Windows and macOS archives are currently unsigned unless repository signing secrets are configured, so first-run OS warnings are expected. See [docs/RELEASES.md](docs/RELEASES.md) for checksums, standalone CLI/gateway archives, signing status, and maintainer release flow.
+Companion writes a local config, starts the bundled gateway on `127.0.0.1`, and connects to it. Windows and macOS archives are currently unsigned so first-run OS warnings are expected. See [docs/RELEASES.md](docs/RELEASES.md) for checksums, standalone CLI/gateway archives, signing status, and maintainer release flow.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -13,18 +13,46 @@
 
 > **Disclaimer**: This project is not affiliated with, endorsed by, or associated with [OpenClaw](https://github.com/openclaw/openclaw). It is an independent .NET implementation inspired by their work.
 
-Self-hosted **AI agent runtime and gateway for .NET** with 48 native tools, 9 channel adapters, multi-agent routing, review-first self-evolving features, built-in OpenAI/Claude/Gemini provider support, NativeAOT support, and practical OpenClaw ecosystem compatibility.
+OpenClaw.NET is a NativeAOT-friendly AI agent runtime and gateway for .NET with practical OpenClaw ecosystem compatibility.
 
-## Highlights
+It is for .NET developers and operators who want a local or self-hosted agent gateway with explicit diagnostics, first-party .NET tools, OpenAI-compatible HTTP surfaces, and a path from source checkout to NativeAOT release artifacts.
+
+## What Works Now
 
 - **NativeAOT-friendly** runtime and gateway for .NET agent workloads
+- **Agent runtime** with tool execution, streaming, cancellation, retry, memory, and session support
+- **Gateway** with chat UI, admin UI, OpenAI-compatible endpoints, MCP, websocket, health, and diagnostics
+- **CLI and Companion** setup flows for source checkouts and desktop bundles
 - **48 native tools** covering file ops, sessions, memory, web, messaging, home automation, databases, email, and more
 - **9 channel adapters** (Telegram, SMS, WhatsApp, Teams, Slack, Discord, Signal, email, webhooks) with DM policy, allowlists, and signature validation
 - **Native LLM providers** for OpenAI, Claude, Gemini, Azure OpenAI, Ollama, and OpenAI-compatible endpoints
 - **Practical reuse** of existing OpenClaw TS/JS plugins and `SKILL.md` packages
-- **Review-first self-evolving** workflows — the runtime proposes profile updates, automation drafts, and skill drafts from observed sessions; operators approve or reject
 
-## Download And Run
+Start with [docs/START_HERE.md](docs/START_HERE.md) for the evaluator overview, [docs/QUICKSTART.md](docs/QUICKSTART.md) for the supported local setup path, or [docs/RELEASES.md](docs/RELEASES.md) for desktop downloads.
+
+## Fastest Source Proof
+
+This deterministic sample proves the runtime loop and tool path without provider keys, Ollama, Docker, or a browser:
+
+```bash
+git clone https://github.com/clawdotnet/openclaw.net
+cd openclaw.net
+
+dotnet restore OpenClaw.Net.slnx
+dotnet build OpenClaw.Net.slnx --configuration Release --no-restore
+dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build
+```
+
+Expected output:
+
+```text
+OpenClaw.HelloAgent
+User: hello
+Agent: hello from OpenClaw.NET
+Tool: echo(hello): ok
+```
+
+## Download And Run Desktop
 
 For the lowest-friction desktop start, download the latest desktop bundle for your platform:
 
@@ -46,10 +74,9 @@ Companion writes a local config, starts the bundled gateway on `127.0.0.1`, and 
 
 ## Quickstart
 
-```bash
-git clone https://github.com/clawdotnet/openclaw.net
-cd openclaw.net
+For a real local gateway from source:
 
+```bash
 export MODEL_PROVIDER_KEY="sk-..."
 dotnet run --project src/OpenClaw.Cli -c Release -- start
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ![Plugin compatibility](https://img.shields.io/badge/plugin%20compatibility-evolving-green)
 ![Tools](https://img.shields.io/badge/native%20tools-48-green)
 ![Channels](https://img.shields.io/badge/channels-9-green)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/clawdotnet/openclaw.net)
 
 > **Disclaimer**: This project is not affiliated with, endorsed by, or associated with [OpenClaw](https://github.com/openclaw/openclaw). It is an independent .NET implementation inspired by their work.
 
@@ -41,7 +42,7 @@ Each desktop bundle includes Companion, the standard NativeAOT gateway, and the 
 4. Choose a provider/model and enter the provider key, or choose Ollama for a local model.
 5. Click **Set Up and Start**.
 
-Companion writes a local config, starts the bundled gateway on `127.0.0.1`, and connects to it. See [docs/RELEASES.md](docs/RELEASES.md) for checksums, standalone CLI/gateway archives, signing status, and maintainer release flow.
+Companion writes a local config, starts the bundled gateway on `127.0.0.1`, and connects to it. The current Windows and macOS release archives are unsigned, so first-run OS warnings are expected. See [docs/RELEASES.md](docs/RELEASES.md) for checksums, standalone CLI/gateway archives, signing status, and maintainer release flow.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Each desktop bundle includes Companion, the standard NativeAOT gateway, and the 
 4. Choose a provider/model and enter the provider key, or choose Ollama for a local model.
 5. Click **Set Up and Start**.
 
-Companion writes a local config, starts the bundled gateway on `127.0.0.1`, and connects to it. Windows and macOS archives are currently unsigned so first-run OS warnings are expected. See [docs/RELEASES.md](docs/RELEASES.md) for checksums, standalone CLI/gateway archives, signing status, and maintainer release flow.
+Companion writes a local config, starts the bundled gateway on `127.0.0.1`, and connects to it. See [docs/RELEASES.md](docs/RELEASES.md) for checksums, standalone CLI/gateway archives, signing status, and maintainer release flow.
 
 ## Quickstart
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,7 +2,31 @@
 
 This guide gets OpenClaw.NET to a first working agent with the supported setup path.
 
-If you want the broader overview first, start with [GETTING_STARTED.md](GETTING_STARTED.md). That guide explains what each project is, how the runtime layers fit together, and which parts most contributors actually need.
+If you want the broader evaluator overview first, start with [START_HERE.md](START_HERE.md). If you want the repository map and contributor-oriented project shape, read [GETTING_STARTED.md](GETTING_STARTED.md).
+
+## Clone-To-Success Smoke
+
+Run this before configuring providers. It proves the runtime loop and tool invocation path without external services:
+
+```bash
+git clone https://github.com/clawdotnet/openclaw.net
+cd openclaw.net
+
+dotnet restore OpenClaw.Net.slnx
+dotnet build OpenClaw.Net.slnx --configuration Release --no-restore
+dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build
+```
+
+Expected output:
+
+```text
+OpenClaw.HelloAgent
+User: hello
+Agent: hello from OpenClaw.NET
+Tool: echo(hello): ok
+```
+
+After that succeeds, continue with the local gateway flow below.
 
 ## First 10 Minutes
 
@@ -53,7 +77,7 @@ Download the matching asset:
 
 Extract the archive and launch Companion from the `companion` folder. Open the **Setup** tab, enter the provider/model/key or choose Ollama, then click **Set Up and Start**. Companion writes the local config, starts the bundled gateway on `127.0.0.1`, and connects to it.
 
-Current Windows and macOS archives are unsigned until signing/notarization secrets are configured in the release workflow. Windows users may see SmartScreen warnings; macOS users may need to right-click Open or remove quarantine for local testing. See [RELEASES.md](RELEASES.md) for the signing path.
+Current Windows and macOS archives are unsigned. Windows users may see SmartScreen warnings; macOS users may need to right-click Open or remove quarantine for local testing. See [RELEASES.md](RELEASES.md) for checksums and release assets.
 
 Operators can still download standalone AOT archives from the same release:
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -107,6 +107,8 @@ You explicitly do **not** need any of these to get started:
 - .NET 10 SDK
 - Optional: Node.js 20+ if you want upstream-style TS/JS plugin support
 
+The first full `dotnet test` run may download Playwright browser assets for browser-tool coverage. The test suite uses Playwright's normal browser cache after that first install; set `OPENCLAW_TEST_ISOLATE_PLAYWRIGHT_BROWSERS=true` only when you intentionally want an isolated test browser install.
+
 Examples below use `openclaw ...`. From a source checkout, replace that with `dotnet run --project src/OpenClaw.Cli -c Release -- ...`.
 
 For a first run from source, prefer the generated external config from `openclaw setup`. Do not start by relying on the checked-in `src/OpenClaw.Gateway/appsettings.json` unless you intentionally want to debug raw repo defaults.
@@ -182,7 +184,7 @@ openclaw models presets
 openclaw models doctor
 ```
 
-The doctor now warns when an Ollama profile still points at `/v1` or when a local agentic profile is missing a deterministic fallback.
+Plain `openclaw run "hello"` requests work as prompt-only chat with non-tool Ollama profiles when no explicit tool preset is requested. Tool-heavy routes and explicit presets still need a tool-capable model profile or configured fallback. The doctor now warns when an Ollama profile still points at `/v1` or when a local agentic profile is missing a deterministic fallback.
 
 After the first successful run, use the maintenance surface to keep the install healthy without touching user-authored prompt files:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Use this page as the map. If you are unsure where to go next, the groups below a
 
 | Doc | When to read |
 | --- | --- |
+| [START_HERE.md](START_HERE.md) | You are evaluating the repo and want the shortest orientation: what works, what is experimental, how to prove the runtime, and where the compatibility boundaries are. |
 | [GETTING_STARTED.md](GETTING_STARTED.md) | You cloned the repo and want the project shape, repository map, and first-run debugging flow before running commands. |
 | [QUICKSTART.md](QUICKSTART.md) | You want the shortest supported path to a running local instance. |
 | [GLOSSARY.md](GLOSSARY.md) | A term in another doc is unfamiliar — *gateway*, *runtime*, *skill*, *plugin*, *profile*, *posture*, `aot` / `jit` / `auto`, etc. |

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -70,6 +70,22 @@ The workflow currently builds:
 
 The macOS runner label is intentionally ARM-native for the `osx-arm64` artifact. Add an Intel macOS row only if you want to support older Intel Macs and have a runner that can NativeAOT publish that RID reliably.
 
+### Companion Release Smoke
+
+Before publishing a public desktop release, run this manual smoke on at least one desktop bundle:
+
+1. Extract the desktop archive into a clean directory.
+2. Launch Companion from the `companion` folder.
+3. Use **Setup** with a temporary workspace and either a local Ollama model or a throwaway provider key.
+4. Confirm Companion writes config, starts the bundled gateway on `127.0.0.1`, and shows a connected state.
+5. Stop the managed gateway, start it again, and confirm Companion reconnects.
+6. Delete or corrupt the temporary config and confirm setup surfaces a clear recoverable error.
+7. Close Companion and confirm the managed gateway process exits.
+
+### macOS NativeAOT Linker Note
+
+The gateway project currently opts into Apple's classic linker for `osx-arm64` NativeAOT publishes because the new macOS arm64 linker can fail with an `ld::Fixup` assertion on the gateway binary. This may print a `-ld_classic is deprecated` warning during gateway publish. The CLI does not use this fallback by default. Scheduled/manual CI probes the gateway with `-p:OpenClawUseClassicMacLd=false`; remove the gateway opt-in when the Apple/.NET toolchain links the gateway reliably without it.
+
 ## CI Artifacts vs Releases
 
 Actions artifacts are useful for validating a commit, but they are not a user-friendly distribution channel. They can expire, may require GitHub access, and are harder for users to find. GitHub Releases are the supported download surface for normal users.

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -1,0 +1,121 @@
+# Start Here
+
+OpenClaw.NET is a NativeAOT-friendly AI agent runtime and gateway for .NET with practical OpenClaw ecosystem compatibility.
+
+Read this page first if you are cloning the repository to decide whether the project is useful, buildable, and worth evaluating.
+
+## What It Is
+
+OpenClaw.NET is a self-hosted .NET agent stack. It includes:
+
+| Part | Responsibility |
+| --- | --- |
+| Runtime | Runs the agent loop, model calls, tool calls, streaming, memory, sessions, cancellation, retries, and runtime hooks. |
+| Gateway | Hosts the local HTTP, OpenAI-compatible, MCP, websocket, admin, health, and diagnostic surfaces. |
+| CLI | Handles setup, launch, model/profile diagnostics, maintenance, plugin/skill commands, and scripted prompt runs. |
+| Companion | Desktop setup and managed-gateway flow for users who prefer a local app over terminal commands. |
+
+The project is aimed at .NET developers and operators who want a local or self-hosted agent gateway with explicit failure modes, NativeAOT-friendly defaults, and compatibility with practical parts of the OpenClaw ecosystem.
+
+## What Works Today
+
+| Surface | Status | Notes |
+| --- | --- | --- |
+| Agent runtime | Stable core | Agent loop, tool execution, streaming events, cancellation, retry, session history, and memory are covered by tests. |
+| Gateway | Stable local path | Local loopback startup, health/status, OpenAI-compatible endpoints, admin diagnostics, MCP, and websocket paths build and test. |
+| CLI | Stable local path | `start`, `setup`, `run`, `chat`, `models`, `maintenance`, `upgrade`, plugin, skill, and diagnostic commands are available. |
+| Companion | Supported with caveats | Builds with the solution and includes managed-gateway tests. Desktop release managers should still run the manual smoke checklist in [RELEASES.md](RELEASES.md). |
+| Native tools | Supported | Core native tools are first-party .NET tools with explicit path, network, and approval guardrails. |
+| Model providers | Supported with provider setup | OpenAI, Claude, Gemini, Azure OpenAI, Ollama, and OpenAI-compatible endpoints are represented in the provider/config surface. |
+| NativeAOT | Supported/friendly | Runtime and gateway are designed for the AOT lane. Dynamic/plugin surfaces are explicitly separated where needed. |
+| OpenClaw compatibility | Practical compatibility | `SKILL.md`, ClawHub-style skill install, mainstream tool/service plugin APIs, and package discovery are supported. Full upstream API parity is not claimed. |
+
+## Experimental Or Partial
+
+- JIT-only plugin surfaces such as dynamic channels, commands, hooks, provider registration, and native dynamic .NET plugins.
+- Microsoft Agent Framework adapter experiments.
+- Browser tool local execution when dynamic code or a non-local execution backend is not configured.
+- Companion UI behavior beyond the managed-gateway unit coverage; use the release smoke checklist before public desktop releases.
+- Full production signing/notarization polish for desktop archives.
+
+## First Successful Source Run
+
+Use the deterministic hello-agent sample first. It proves the runtime can build, call a tool, complete the agent loop, and print a known result without requiring provider keys, Ollama, Docker, or a browser.
+
+```bash
+git clone https://github.com/clawdotnet/openclaw.net
+cd openclaw.net
+
+dotnet restore OpenClaw.Net.slnx
+dotnet build OpenClaw.Net.slnx --configuration Release --no-restore
+dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build
+```
+
+Expected output:
+
+```text
+OpenClaw.HelloAgent
+User: hello
+Agent: hello from OpenClaw.NET
+Tool: echo(hello): ok
+```
+
+After that works, choose one of these:
+
+```bash
+# Guided local gateway setup and launch
+dotnet run --project src/OpenClaw.Cli -c Release -- start
+
+# Direct interactive gateway fallback
+dotnet run --project src/OpenClaw.Gateway -c Release -- --quickstart
+
+# Full test suite
+dotnet test OpenClaw.Net.slnx --configuration Release --no-build
+```
+
+For the full local setup path, continue with [QUICKSTART.md](QUICKSTART.md).
+
+## Support Matrix
+
+| Area | Windows | Linux | macOS | Notes |
+| --- | --- | --- | --- | --- |
+| Source build/test | Supported | Supported | Supported | Requires .NET 10 SDK. |
+| Runtime | Supported | Supported | Supported | NativeAOT-friendly core; dynamic plugin surfaces are mode-gated. |
+| Gateway | Supported | Supported | Supported | Loopback local path is the primary developer evaluation path. |
+| CLI | Supported | Supported | Supported | Also published as NativeAOT release archives. |
+| Companion | Supported | Supported | Supported | Desktop bundles include Companion, gateway, and CLI. |
+| Desktop release archives | Windows x64 | Linux x64 | Apple Silicon macOS | Windows/macOS archives are currently unsigned, so OS warnings are expected. |
+| Plugin compatibility | Supported with caveats | Supported with caveats | Supported with caveats | See [COMPATIBILITY.md](COMPATIBILITY.md) for the exact AOT/JIT boundary. |
+| NativeAOT publish | Supported | Supported | Supported with linker caveat | The gateway has a scoped macOS classic-linker fallback until the Apple/.NET linker path is reliable. |
+
+## Compatibility Boundaries
+
+OpenClaw.NET supports practical OpenClaw ecosystem reuse:
+
+- standalone `SKILL.md` packages
+- plugin-packaged skills
+- ClawHub-style skill install flow
+- mainstream `api.registerTool()` and `api.registerService()` plugin surfaces
+- explicit diagnostics for unsupported plugin APIs
+
+OpenClaw.NET is not a full upstream OpenClaw clone. Unsupported or JIT-only surfaces fail fast instead of loading partially. See [COMPATIBILITY.md](COMPATIBILITY.md) for the canonical matrix.
+
+## Known Limitations
+
+- Tool-heavy local Ollama routes need a tool-capable model profile or configured fallback. Plain chat works as prompt-only when no explicit tool preset is requested.
+- Public-bind startup intentionally refuses unsafe configurations until auth, secrets, tool roots, and channel signature settings are hardened.
+- TypeScript plugin loading requires `jiti`; OpenClaw.NET does not bundle a TypeScript runtime automatically.
+- Browser tool setup defaults are conservative. Local/public generated profiles leave it disabled unless a compatible execution backend is selected.
+- Windows and macOS release archives are unsigned today, so first-run operating-system warnings are expected.
+- Some advanced plugin/provider surfaces are JIT-only by design.
+
+## Where To Go Next
+
+| Goal | Read |
+| --- | --- |
+| Run a real local gateway | [QUICKSTART.md](QUICKSTART.md) |
+| Understand repository shape | [GETTING_STARTED.md](GETTING_STARTED.md) |
+| Check compatibility | [COMPATIBILITY.md](COMPATIBILITY.md) |
+| Use tools and skills | [USER_GUIDE.md](USER_GUIDE.md) and [TOOLS_GUIDE.md](TOOLS_GUIDE.md) |
+| Download desktop bundles | [RELEASES.md](RELEASES.md) |
+| Contribute | [../CONTRIBUTING.md](../CONTRIBUTING.md) |

--- a/docs/TOOLS_GUIDE.md
+++ b/docs/TOOLS_GUIDE.md
@@ -56,6 +56,7 @@ Allows basic file operations.
 Allows the agent to navigate and interact with websites using Playwright.
 - **Config**: `OpenClaw:Tooling:EnableBrowserTool` (bool)
 - **Options**: `BrowserHeadless` (default: true), `BrowserTimeoutSeconds` (default: 30).
+- **Runtime note**: source/setup-generated local profiles disable this tool by default because the NativeAOT-friendly gateway does not run local Playwright execution unless dynamic code or a configured non-local execution backend is available. Enable it only after configuring an execution backend or sandbox for browser automation.
 
 ### 4. Memory Note Tool (`memory`)
 Stores and retrieves lightweight notes in the configured memory store.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -236,11 +236,13 @@ You can lock down the agent via the `Tooling` config block:
       "AllowedWriteRoots": ["/Users/telli/safe-dir"],
       "RequireToolApproval": true,
       "ApprovalRequiredTools": ["shell", "write_file"],
-      "EnableBrowserTool": true
+      "EnableBrowserTool": false
     }
   }
 }
 ```
+
+Setup-generated local profiles keep the browser tool disabled unless you explicitly configure a non-local execution backend or sandbox. Turn `EnableBrowserTool` on only after that backend is available.
 
 If you expose OpenClaw to the internet (a non-loopback bind address like `0.0.0.0`), the Gateway will **refuse to start** unless you explicitly harden these settings or opt-out of the safety checks.
 

--- a/samples/OpenClaw.HelloAgent/OpenClaw.HelloAgent.csproj
+++ b/samples/OpenClaw.HelloAgent/OpenClaw.HelloAgent.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>OpenClaw.HelloAgent</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenClaw.Core\OpenClaw.Core.csproj" />
+    <ProjectReference Include="..\..\src\OpenClaw.Agent\OpenClaw.Agent.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/OpenClaw.HelloAgent/Program.cs
+++ b/samples/OpenClaw.HelloAgent/Program.cs
@@ -6,7 +6,7 @@ using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Memory;
 using OpenClaw.Core.Models;
 
-var memoryPath = Path.Combine(Path.GetTempPath(), "openclaw-hello-agent", Guid.NewGuid().ToString("N"));
+var memoryPath = Path.Join(Path.GetTempPath(), "openclaw-hello-agent", Guid.NewGuid().ToString("N"));
 await using var memoryStore = new FileMemoryStore(memoryPath);
 
 var agent = new AgentRuntime(

--- a/samples/OpenClaw.HelloAgent/Program.cs
+++ b/samples/OpenClaw.HelloAgent/Program.cs
@@ -1,0 +1,103 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using OpenClaw.Agent;
+using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Memory;
+using OpenClaw.Core.Models;
+
+var memoryPath = Path.Combine(Path.GetTempPath(), "openclaw-hello-agent", Guid.NewGuid().ToString("N"));
+await using var memoryStore = new FileMemoryStore(memoryPath);
+
+var agent = new AgentRuntime(
+    new HelloChatClient(),
+    [new EchoTool()],
+    memoryStore,
+    new LlmProviderConfig
+    {
+        Provider = "deterministic",
+        Model = "hello-agent",
+        TimeoutSeconds = 0,
+        RetryCount = 0
+    },
+    maxHistoryTurns: 8,
+    parallelToolExecution: false);
+
+var session = new Session
+{
+    Id = $"hello:{Guid.NewGuid():N}",
+    ChannelId = "sample",
+    SenderId = "developer"
+};
+
+var prompt = args.Length > 0 ? string.Join(' ', args) : "hello";
+var response = await agent.RunAsync(session, prompt, CancellationToken.None);
+
+Console.WriteLine("OpenClaw.HelloAgent");
+Console.WriteLine($"User: {prompt}");
+Console.WriteLine(response);
+
+file sealed class EchoTool : ITool
+{
+    public string Name => "hello_echo";
+    public string Description => "Echoes the supplied text for the hello-agent sample.";
+    public string ParameterSchema => """{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}""";
+
+    public ValueTask<string> ExecuteAsync(string argumentsJson, CancellationToken ct)
+    {
+        using var doc = JsonDocument.Parse(argumentsJson);
+        var text = doc.RootElement.TryGetProperty("text", out var value)
+            ? value.GetString() ?? ""
+            : "";
+        return ValueTask.FromResult($"Tool: echo({text}): ok");
+    }
+}
+
+file sealed class HelloChatClient : IChatClient
+{
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var toolResult = messages
+            .SelectMany(static message => message.Contents)
+            .OfType<FunctionResultContent>()
+            .LastOrDefault();
+
+        if (toolResult is not null)
+        {
+            var result = toolResult.Result?.ToString() ?? "";
+            return Task.FromResult(new ChatResponse(new ChatMessage(
+                ChatRole.Assistant,
+                $"Agent: hello from OpenClaw.NET{Environment.NewLine}{result}")));
+        }
+
+        var userText = messages.LastOrDefault(static message => message.Role == ChatRole.User)?.Text ?? "hello";
+        var call = new FunctionCallContent(
+            callId: "call_hello_echo",
+            name: "hello_echo",
+            arguments: new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["text"] = userText
+            });
+
+        return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, [call])));
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var response = await GetResponseAsync(messages, options, cancellationToken);
+        foreach (var message in response.Messages)
+            yield return new ChatResponseUpdate(message.Role, message.Contents);
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/OpenClaw.Agent/AgentRuntime.cs
+++ b/src/OpenClaw.Agent/AgentRuntime.cs
@@ -664,13 +664,41 @@ public sealed class AgentRuntime : IAgentRuntime
             }
             else
             {
-                (invocations, toolResults) = await ExecuteToolCallsAsync(
-                    toolCalls, session, turnCtx, isStreaming: true, approvalCallback, ct);
-
-                foreach (var inv in invocations)
+                if (_parallelToolExecution && toolCalls.Count > 1)
                 {
-                    yield return AgentStreamEvent.ToolStarted(inv.ToolName, inv.Arguments);
-                    yield return AgentStreamEvent.ToolCompleted(inv.ToolName, inv.Result ?? "");
+                    foreach (var call in toolCalls)
+                    {
+                        var argsJson = call.Arguments is not null
+                            ? JsonSerializer.Serialize(call.Arguments, CoreJsonContext.Default.IDictionaryStringObject)
+                            : "{}";
+                        yield return AgentStreamEvent.ToolStarted(call.Name, argsJson);
+                    }
+
+                    (invocations, toolResults) = await ExecuteToolCallsAsync(
+                        toolCalls, session, turnCtx, isStreaming: true, approvalCallback, ct);
+
+                    foreach (var inv in invocations)
+                        yield return CreateToolCompletedEvent(inv);
+                }
+                else
+                {
+                    invocations = new List<ToolInvocation>(toolCalls.Count);
+                    toolResults = new List<FunctionResultContent>(toolCalls.Count);
+
+                    foreach (var call in toolCalls)
+                    {
+                        var argsJson = call.Arguments is not null
+                            ? JsonSerializer.Serialize(call.Arguments, CoreJsonContext.Default.IDictionaryStringObject)
+                            : "{}";
+                        yield return AgentStreamEvent.ToolStarted(call.Name, argsJson);
+
+                        var (invocation, result) = await ExecuteSingleToolCallAsync(
+                            call, session, turnCtx, isStreaming: true, approvalCallback, ct, onDelta: null);
+                        invocations.Add(invocation);
+                        toolResults.Add(result);
+
+                        yield return CreateToolCompletedEvent(invocation);
+                    }
                 }
             }
 
@@ -697,6 +725,17 @@ public sealed class AgentRuntime : IAgentRuntime
         AppendContractSnapshot(session, "active");
         LogTurnComplete(turnCtx);
     }
+
+    private static AgentStreamEvent CreateToolCompletedEvent(ToolInvocation invocation) =>
+        AgentStreamEvent.ToolCompleted(
+            invocation.ToolName,
+            invocation.Result ?? "",
+            resultStatus: string.IsNullOrWhiteSpace(invocation.ResultStatus)
+                ? ToolResultStatuses.Completed
+                : invocation.ResultStatus!,
+            failureCode: invocation.FailureCode,
+            failureMessage: invocation.FailureMessage,
+            nextStep: invocation.NextStep);
 
     private async ValueTask TryInjectRecallAsync(List<ChatMessage> messages, string userMessage, CancellationToken ct)
     {

--- a/src/OpenClaw.Agent/AgentRuntime.cs
+++ b/src/OpenClaw.Agent/AgentRuntime.cs
@@ -612,9 +612,7 @@ public sealed class AgentRuntime : IAgentRuntime
 
                 foreach (var call in toolCalls)
                 {
-                    var argsJson = call.Arguments is not null
-                        ? JsonSerializer.Serialize(call.Arguments, CoreJsonContext.Default.IDictionaryStringObject)
-                        : "{}";
+                    var argsJson = SerializeToolArgumentsForEvent(call.Arguments);
                     yield return AgentStreamEvent.ToolStarted(call.Name, argsJson);
 
                     var channel = Channel.CreateBounded<string>(new BoundedChannelOptions(256)
@@ -668,9 +666,7 @@ public sealed class AgentRuntime : IAgentRuntime
                 {
                     foreach (var call in toolCalls)
                     {
-                        var argsJson = call.Arguments is not null
-                            ? JsonSerializer.Serialize(call.Arguments, CoreJsonContext.Default.IDictionaryStringObject)
-                            : "{}";
+                        var argsJson = SerializeToolArgumentsForEvent(call.Arguments);
                         yield return AgentStreamEvent.ToolStarted(call.Name, argsJson);
                     }
 
@@ -687,9 +683,7 @@ public sealed class AgentRuntime : IAgentRuntime
 
                     foreach (var call in toolCalls)
                     {
-                        var argsJson = call.Arguments is not null
-                            ? JsonSerializer.Serialize(call.Arguments, CoreJsonContext.Default.IDictionaryStringObject)
-                            : "{}";
+                        var argsJson = SerializeToolArgumentsForEvent(call.Arguments);
                         yield return AgentStreamEvent.ToolStarted(call.Name, argsJson);
 
                         var (invocation, result) = await ExecuteSingleToolCallAsync(
@@ -1677,6 +1671,21 @@ public sealed class AgentRuntime : IAgentRuntime
             {
                 ["_raw"] = arguments
             };
+        }
+    }
+
+    private static string SerializeToolArgumentsForEvent(IDictionary<string, object?>? arguments)
+    {
+        if (arguments is null || arguments.Count == 0)
+            return "{}";
+
+        try
+        {
+            return JsonSerializer.Serialize(arguments, CoreJsonContext.Default.IDictionaryStringObject);
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
+        {
+            return "{}";
         }
     }
 

--- a/src/OpenClaw.Agent/ContractScopeHook.cs
+++ b/src/OpenClaw.Agent/ContractScopeHook.cs
@@ -143,7 +143,7 @@ public sealed class ContractScopeHook : IToolHookWithContext
         foreach (var allowed in allowedPaths)
         {
             var allowedExpanded = ExpandTilde(allowed.Trim());
-            var allowedFull = Path.GetFullPath(allowedExpanded);
+            var allowedFull = ToolPathPolicy.ResolveRealPath(allowedExpanded);
 
             if (string.Equals(full, allowedFull, comparison))
                 return true;

--- a/src/OpenClaw.Agent/Tools/ToolPathPolicy.cs
+++ b/src/OpenClaw.Agent/Tools/ToolPathPolicy.cs
@@ -4,6 +4,8 @@ namespace OpenClaw.Agent.Tools;
 
 internal static class ToolPathPolicy
 {
+    private const int MaxSymlinkResolutionDepth = 64;
+
     public static bool IsReadAllowed(ToolingConfig config, string path) =>
         IsPathAllowed(config.AllowedReadRoots, path);
 
@@ -38,8 +40,14 @@ internal static class ToolPathPolicy
     /// remaining segments are appended.
     /// </summary>
     internal static string ResolveRealPath(string path)
+        => ResolveRealPath(path, new HashSet<string>(GetPathComparer()), depth: 0);
+
+    private static string ResolveRealPath(string path, HashSet<string> visited, int depth)
     {
         var full = Path.GetFullPath(path);
+        if (depth >= MaxSymlinkResolutionDepth || !visited.Add(full))
+            return full;
+
         var root = Path.GetPathRoot(full);
         if (string.IsNullOrEmpty(root))
             return full;
@@ -52,10 +60,13 @@ internal static class ToolPathPolicy
 
         foreach (var segment in segments)
         {
-            current = Path.Combine(current, segment);
+            if (Path.IsPathRooted(segment))
+                return Path.GetFullPath(current);
+
+            current = Path.Join(current, segment);
             var resolved = TryResolveLinkTarget(current);
             if (resolved is not null)
-                current = ResolveRealPath(resolved);
+                current = ResolveRealPath(resolved, visited, depth + 1);
         }
 
         return Path.GetFullPath(current);
@@ -72,19 +83,36 @@ internal static class ToolPathPolicy
             var target = File.ResolveLinkTarget(path, returnFinalTarget: true);
             if (target is not null) return target.FullName;
         }
-        catch (IOException) { }
-        catch (UnauthorizedAccessException) { }
+        catch (IOException)
+        {
+            // Expected when probing inaccessible or broken filesystem entries.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Expected when probing roots the current process cannot inspect.
+        }
 
         try
         {
             var target = Directory.ResolveLinkTarget(path, returnFinalTarget: true);
             if (target is not null) return target.FullName;
         }
-        catch (IOException) { }
-        catch (UnauthorizedAccessException) { }
+        catch (IOException)
+        {
+            // Expected when probing inaccessible or broken filesystem entries.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Expected when probing roots the current process cannot inspect.
+        }
 
         return null;
     }
+
+    private static StringComparer GetPathComparer()
+        => OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
 
     private static bool IsUnderRoot(string fullPath, string fullRoot)
     {

--- a/src/OpenClaw.Agent/Tools/ToolPathPolicy.cs
+++ b/src/OpenClaw.Agent/Tools/ToolPathPolicy.cs
@@ -33,46 +33,32 @@ internal static class ToolPathPolicy
     }
 
     /// <summary>
-    /// Resolves the real filesystem path, following symlinks.
-    /// For paths that don't exist yet (e.g. write targets), resolves the deepest
-    /// existing ancestor and appends the remaining segments.
+    /// Resolves the real filesystem path, following symlinked ancestors and final targets.
+    /// For paths that do not exist yet, existing ancestors are still resolved and the
+    /// remaining segments are appended.
     /// </summary>
     internal static string ResolveRealPath(string path)
     {
         var full = Path.GetFullPath(path);
-
-        // Try resolving as a symlink first, without checking existence.
-        // This eliminates the TOCTOU window between File.Exists and ResolveLinkTarget.
-        var resolved = TryResolveLinkTarget(full);
-        if (resolved is not null)
-            return resolved;
-
-        // Not a symlink — if the path exists as-is, return it directly
-        if (File.Exists(full) || Directory.Exists(full))
+        var root = Path.GetPathRoot(full);
+        if (string.IsNullOrEmpty(root))
             return full;
 
-        // Path doesn't exist yet — resolve the deepest existing ancestor
-        // and append the remaining tail. This prevents writing through a
-        // symlinked parent directory.
-        var dir = Path.GetDirectoryName(full);
-        var tail = Path.GetFileName(full);
+        var current = root;
+        var remaining = full[root.Length..];
+        var segments = remaining.Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
 
-        while (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        foreach (var segment in segments)
         {
-            tail = Path.Combine(Path.GetFileName(dir), tail);
-            dir = Path.GetDirectoryName(dir);
+            current = Path.Combine(current, segment);
+            var resolved = TryResolveLinkTarget(current);
+            if (resolved is not null)
+                current = ResolveRealPath(resolved);
         }
 
-        if (!string.IsNullOrEmpty(dir))
-        {
-            if (IsPathRoot(dir))
-                return Path.Combine(dir, tail);
-
-            var realDir = TryResolveLinkTarget(dir) ?? dir;
-            return Path.Combine(realDir, tail);
-        }
-
-        return full;
+        return Path.GetFullPath(current);
     }
 
     /// <summary>
@@ -98,22 +84,6 @@ internal static class ToolPathPolicy
         catch (UnauthorizedAccessException) { }
 
         return null;
-    }
-
-    private static bool IsPathRoot(string path)
-    {
-        var root = Path.GetPathRoot(path);
-        if (string.IsNullOrEmpty(root))
-            return false;
-
-        var comparison = OperatingSystem.IsWindows()
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
-
-        return string.Equals(
-            Path.TrimEndingDirectorySeparator(path),
-            Path.TrimEndingDirectorySeparator(root),
-            comparison);
     }
 
     private static bool IsUnderRoot(string fullPath, string fullRoot)

--- a/src/OpenClaw.Cli/Program.cs
+++ b/src/OpenClaw.Cli/Program.cs
@@ -101,6 +101,7 @@ internal static class Program
               openclaw backends <list|probe|run|session send> [options]
               openclaw admin <posture|incident export|trajectory export|approvals simulate> [options]
               openclaw compatibility <catalog> [options]
+              openclaw plugins <install|remove|list|search> [options]
               openclaw skills <inspect|install|list> [options]
               openclaw clawhub [wrapper options] [--] <clawhub args...>
 

--- a/src/OpenClaw.Cli/SetupCommand.cs
+++ b/src/OpenClaw.Cli/SetupCommand.cs
@@ -304,6 +304,7 @@ internal static class SetupCommand
                 if (!Uri.TryCreate(answers.OpenSandboxEndpoint, UriKind.Absolute, out _))
                     throw new ArgumentException($"Invalid OpenSandbox endpoint: {answers.OpenSandboxEndpoint}");
 
+                config.Tooling.EnableBrowserTool = true;
                 config.Sandbox.Provider = SandboxProviderNames.OpenSandbox;
                 config.Sandbox.Endpoint = answers.OpenSandboxEndpoint;
                 config.Execution.Profiles["opensandbox"] = new ExecutionBackendProfileConfig

--- a/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
+++ b/src/OpenClaw.Companion/Services/ManagedGatewayService.cs
@@ -435,7 +435,9 @@ public sealed class ManagedGatewayService : IAsyncDisposable, IDisposable
         var builder = new UriBuilder(uri)
         {
             Scheme = scheme,
-            Path = path
+            Path = path,
+            Query = string.Empty,
+            Fragment = string.Empty
         };
         return builder.Uri.ToString();
     }

--- a/src/OpenClaw.Core/Plugins/PluginDiscovery.cs
+++ b/src/OpenClaw.Core/Plugins/PluginDiscovery.cs
@@ -10,6 +10,8 @@ namespace OpenClaw.Core.Plugins;
 /// </summary>
 public static class PluginDiscovery
 {
+    private const int MaxSymlinkResolutionDepth = 64;
+
     private const string ManifestFileName = "openclaw.plugin.json";
     private const string PackageJsonFileName = "package.json";
 
@@ -500,7 +502,20 @@ public static class PluginDiscovery
 
     public static bool TryResolveContainedPath(string rootPath, string relativePath, out string resolvedPath)
     {
-        resolvedPath = Path.GetFullPath(Path.Combine(rootPath, relativePath));
+        if (Path.IsPathRooted(relativePath))
+        {
+            resolvedPath = string.Empty;
+            return false;
+        }
+
+        var candidatePath = Path.GetFullPath(Path.Join(rootPath, relativePath));
+        if (IsUnresolvedLink(candidatePath))
+        {
+            resolvedPath = string.Empty;
+            return false;
+        }
+
+        resolvedPath = candidatePath;
         var fullRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(rootPath));
 
         // Resolve symlinks for both paths to prevent symlink-based escape from the root.
@@ -522,8 +537,14 @@ public static class PluginDiscovery
     /// Falls back to the normalized segment path when a segment does not exist.
     /// </summary>
     private static string ResolveRealPath(string path)
+        => ResolveRealPath(path, new HashSet<string>(GetPathComparer()), depth: 0);
+
+    private static string ResolveRealPath(string path, HashSet<string> visited, int depth)
     {
         var full = Path.GetFullPath(path);
+        if (depth >= MaxSymlinkResolutionDepth || !visited.Add(full))
+            return full;
+
         var root = Path.GetPathRoot(full);
         if (string.IsNullOrEmpty(root))
             return full;
@@ -536,10 +557,13 @@ public static class PluginDiscovery
 
         foreach (var segment in segments)
         {
-            current = Path.Combine(current, segment);
+            if (Path.IsPathRooted(segment))
+                return Path.GetFullPath(current);
+
+            current = Path.Join(current, segment);
             var resolved = TryResolveLinkTarget(current);
             if (resolved is not null)
-                current = ResolveRealPath(resolved);
+                current = ResolveRealPath(resolved, visited, depth + 1);
         }
 
         return Path.GetFullPath(current);
@@ -555,9 +579,11 @@ public static class PluginDiscovery
         }
         catch (IOException)
         {
+            // Expected when discovery probes inaccessible or broken filesystem entries.
         }
         catch (UnauthorizedAccessException)
         {
+            // Expected when discovery probes roots the current process cannot inspect.
         }
 
         try
@@ -568,11 +594,38 @@ public static class PluginDiscovery
         }
         catch (IOException)
         {
+            // Expected when discovery probes inaccessible or broken filesystem entries.
         }
         catch (UnauthorizedAccessException)
         {
+            // Expected when discovery probes roots the current process cannot inspect.
         }
 
         return null;
     }
+
+    private static bool IsUnresolvedLink(string path)
+    {
+        try
+        {
+            FileSystemInfo info = File.Exists(path)
+                ? new FileInfo(path)
+                : new DirectoryInfo(path);
+
+            return !string.IsNullOrEmpty(info.LinkTarget) && TryResolveLinkTarget(path) is null;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static StringComparer GetPathComparer()
+        => OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
 }

--- a/src/OpenClaw.Core/Plugins/PluginDiscovery.cs
+++ b/src/OpenClaw.Core/Plugins/PluginDiscovery.cs
@@ -254,11 +254,32 @@ public static class PluginDiscovery
             return;
         }
 
+        if (!TryResolveContainedPath(pluginRoot, Path.GetRelativePath(pluginRoot, entryPath), out var containedEntryPath))
+        {
+            result.Reports.Add(new PluginLoadReport
+            {
+                PluginId = manifest.Id,
+                SourcePath = Path.GetFullPath(pluginRoot),
+                EntryPath = Path.GetFullPath(entryPath),
+                Loaded = false,
+                Diagnostics =
+                [
+                    new PluginCompatibilityDiagnostic
+                    {
+                        Code = "entry_outside_root",
+                        Message = $"Plugin entry file for '{manifest.Id}' resolves outside the plugin root.",
+                        Path = Path.GetFullPath(entryPath)
+                    }
+                ]
+            });
+            return;
+        }
+
         result.Plugins.Add(new DiscoveredPlugin
         {
             Manifest = manifest,
             RootPath = Path.GetFullPath(pluginRoot),
-            EntryPath = Path.GetFullPath(entryPath)
+            EntryPath = containedEntryPath
         });
     }
 
@@ -497,30 +518,61 @@ public static class PluginDiscovery
     }
 
     /// <summary>
-    /// Resolves the real filesystem path, following symlinks.
-    /// Falls back to the normalized path when the target does not exist.
+    /// Resolves the real filesystem path, following symlinked ancestors and final targets.
+    /// Falls back to the normalized segment path when a segment does not exist.
     /// </summary>
     private static string ResolveRealPath(string path)
     {
+        var full = Path.GetFullPath(path);
+        var root = Path.GetPathRoot(full);
+        if (string.IsNullOrEmpty(root))
+            return full;
+
+        var current = root;
+        var remaining = full[root.Length..];
+        var segments = remaining.Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var segment in segments)
+        {
+            current = Path.Combine(current, segment);
+            var resolved = TryResolveLinkTarget(current);
+            if (resolved is not null)
+                current = ResolveRealPath(resolved);
+        }
+
+        return Path.GetFullPath(current);
+    }
+
+    private static string? TryResolveLinkTarget(string path)
+    {
         try
         {
-            if (File.Exists(path))
-            {
-                var resolved = File.ResolveLinkTarget(path, returnFinalTarget: true);
-                return resolved?.FullName ?? path;
-            }
-
-            if (Directory.Exists(path))
-            {
-                var resolved = Directory.ResolveLinkTarget(path, returnFinalTarget: true);
-                return resolved?.FullName ?? path;
-            }
+            var target = File.ResolveLinkTarget(path, returnFinalTarget: true);
+            if (target is not null)
+                return target.FullName;
         }
-        catch
+        catch (IOException)
         {
-            // Symlink resolution failed — fall through to the unresolved path.
+        }
+        catch (UnauthorizedAccessException)
+        {
         }
 
-        return path;
+        try
+        {
+            var target = Directory.ResolveLinkTarget(path, returnFinalTarget: true);
+            if (target is not null)
+                return target.FullName;
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+
+        return null;
     }
 }

--- a/src/OpenClaw.Core/Setup/GatewaySetupProfileFactory.cs
+++ b/src/OpenClaw.Core/Setup/GatewaySetupProfileFactory.cs
@@ -45,6 +45,7 @@ public static class GatewaySetupProfileFactory
                 WorkspaceRoot = workspacePath,
                 WorkspaceOnly = true,
                 AllowShell = normalizedProfile == "local",
+                EnableBrowserTool = false,
                 AllowedReadRoots = [workspacePath],
                 AllowedWriteRoots = [workspacePath],
                 RequireToolApproval = normalizedProfile == "public"

--- a/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.ChatCompletions.cs
+++ b/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.ChatCompletions.cs
@@ -132,6 +132,7 @@ internal static partial class OpenAiEndpoints
                         ActivePresetId = presetHeader.Trim()
                     });
                 }
+                ApplyImplicitToolPolicy(session, runtime, presetHeader);
                 approvalCallback = ToolApprovalCallbackFactory.Create(
                     startup.Config,
                     runtime,

--- a/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.Responses.cs
+++ b/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.Responses.cs
@@ -121,6 +121,7 @@ internal static partial class OpenAiEndpoints
                         ActivePresetId = responsesPresetHeader.Trim()
                     });
                 }
+                ApplyImplicitToolPolicy(session, runtime, responsesPresetHeader);
                 approvalCallback = ToolApprovalCallbackFactory.Create(
                     startup.Config,
                     runtime,

--- a/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.cs
+++ b/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.cs
@@ -23,7 +23,7 @@ internal static partial class OpenAiEndpoints
     {
         ClearImplicitToolSuppression(session);
 
-        if (!string.IsNullOrWhiteSpace(presetId))
+        if (HasExplicitPreset(session, runtime, presetId))
             return;
 
         if (!TryResolveSelectedProfile(session, runtime, out var profile) ||
@@ -57,6 +57,12 @@ internal static partial class OpenAiEndpoints
             return true;
         }
 
+        if (!string.IsNullOrWhiteSpace(session.ModelOverride))
+        {
+            profile = null!;
+            return false;
+        }
+
         var defaultProfileId = runtime.Operations.ModelProfiles.DefaultProfileId;
         if (!string.IsNullOrWhiteSpace(defaultProfileId) &&
             runtime.Operations.ModelProfiles.TryGet(defaultProfileId, out var defaultProfile) &&
@@ -68,5 +74,14 @@ internal static partial class OpenAiEndpoints
 
         profile = null!;
         return false;
+    }
+
+    private static bool HasExplicitPreset(Session session, GatewayAppRuntime runtime, string? presetId)
+    {
+        if (!string.IsNullOrWhiteSpace(presetId) || !string.IsNullOrWhiteSpace(session.RoutePresetId))
+            return true;
+
+        var metadata = runtime.Operations.SessionMetadata.Get(session.Id);
+        return !string.IsNullOrWhiteSpace(metadata.ActivePresetId);
     }
 }

--- a/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.cs
+++ b/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.cs
@@ -1,5 +1,6 @@
 using OpenClaw.Gateway.Bootstrap;
 using OpenClaw.Gateway.Composition;
+using OpenClaw.Core.Models;
 
 namespace OpenClaw.Gateway.Endpoints;
 
@@ -7,6 +8,7 @@ internal static partial class OpenAiEndpoints
 {
     private const int MaxChatCompletionRequestBytes = 1024 * 1024;
     private const string StableSessionHeader = "X-OpenClaw-Session-Id";
+    private const string NoImplicitToolsAllowed = "__openclaw_openai_no_implicit_tools__";
 
     public static void MapOpenClawOpenAiEndpoints(
         this WebApplication app,
@@ -15,5 +17,56 @@ internal static partial class OpenAiEndpoints
     {
         MapChatCompletionsEndpoint(app, startup, runtime);
         MapResponsesEndpoint(app, startup, runtime);
+    }
+
+    private static void ApplyImplicitToolPolicy(Session session, GatewayAppRuntime runtime, string? presetId)
+    {
+        ClearImplicitToolSuppression(session);
+
+        if (!string.IsNullOrWhiteSpace(presetId))
+            return;
+
+        if (!TryResolveSelectedProfile(session, runtime, out var profile) ||
+            profile.Capabilities.SupportsTools)
+        {
+            return;
+        }
+
+        session.RouteAllowedTools = [NoImplicitToolsAllowed];
+    }
+
+    private static void ClearImplicitToolSuppression(Session session)
+    {
+        if (session.RouteAllowedTools.Length == 1 &&
+            string.Equals(session.RouteAllowedTools[0], NoImplicitToolsAllowed, StringComparison.Ordinal))
+        {
+            session.RouteAllowedTools = [];
+        }
+    }
+
+    private static bool TryResolveSelectedProfile(
+        Session session,
+        GatewayAppRuntime runtime,
+        out ModelProfile profile)
+    {
+        if (!string.IsNullOrWhiteSpace(session.ModelProfileId) &&
+            runtime.Operations.ModelProfiles.TryGet(session.ModelProfileId, out var explicitProfile) &&
+            explicitProfile is not null)
+        {
+            profile = explicitProfile;
+            return true;
+        }
+
+        var defaultProfileId = runtime.Operations.ModelProfiles.DefaultProfileId;
+        if (!string.IsNullOrWhiteSpace(defaultProfileId) &&
+            runtime.Operations.ModelProfiles.TryGet(defaultProfileId, out var defaultProfile) &&
+            defaultProfile is not null)
+        {
+            profile = defaultProfile;
+            return true;
+        }
+
+        profile = null!;
+        return false;
     }
 }

--- a/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
+++ b/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
@@ -7,6 +7,8 @@
     <PublishAot>true</PublishAot>
     <StripSymbols>true</StripSymbols>
     <OptimizationPreference>Size</OptimizationPreference>
+    <!-- The gateway AOT link currently trips Apple's new macOS arm64 linker; keep the classic linker scoped to this project. -->
+    <OpenClawUseClassicMacLd Condition="'$(OpenClawUseClassicMacLd)' == ''">true</OpenClawUseClassicMacLd>
     <!-- Aggressive AOT trimming for minimal binary -->
     <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
     <IlcOptimizationPreference>Size</IlcOptimizationPreference>

--- a/src/OpenClaw.Tests/BrowserToolTests.cs
+++ b/src/OpenClaw.Tests/BrowserToolTests.cs
@@ -34,7 +34,7 @@ public class BrowserToolTests
             StringComparison.OrdinalIgnoreCase);
         if (isolateBrowserInstall)
         {
-            var browsersPath = Path.Combine(Path.GetTempPath(), "openclaw-playwright-tests", "browsers");
+            var browsersPath = Path.Join(Path.GetTempPath(), "openclaw-playwright-tests", "browsers");
             Directory.CreateDirectory(browsersPath);
             Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", browsersPath);
         }
@@ -96,6 +96,7 @@ public class BrowserToolTests
             }
             catch (OperationCanceledException)
             {
+                // Cancellation is expected when the local fixture server is stopped during disposal.
             }
 
             _cts.Dispose();

--- a/src/OpenClaw.Tests/BrowserToolTests.cs
+++ b/src/OpenClaw.Tests/BrowserToolTests.cs
@@ -1,5 +1,8 @@
 using System;
 using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -18,27 +21,37 @@ public class BrowserToolTests
         { 
             EnableBrowserTool = true, 
             BrowserHeadless = true,
-            BrowserTimeoutSeconds = 30
+            BrowserTimeoutSeconds = 30,
+            UrlSafety = new UrlSafetyConfig
+            {
+                BlockPrivateNetworkTargets = false
+            }
         };
         var previousBrowsersPath = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
-        var browsersPath = Path.Combine(Path.GetTempPath(), "openclaw-playwright-tests", Guid.NewGuid().ToString("N"));
-        Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", browsersPath);
+        var isolateBrowserInstall = string.Equals(
+            Environment.GetEnvironmentVariable("OPENCLAW_TEST_ISOLATE_PLAYWRIGHT_BROWSERS"),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+        if (isolateBrowserInstall)
+        {
+            var browsersPath = Path.Combine(Path.GetTempPath(), "openclaw-playwright-tests", "browsers");
+            Directory.CreateDirectory(browsersPath);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", browsersPath);
+        }
 
         try
         {
+            await using var pageServer = LocalPageServer.Start();
             await using var browser = new BrowserTool(config);
 
-            // goto example.com
-            var gotoArgs = "{\"action\": \"goto\", \"url\": \"https://example.com\"}";
+            var gotoArgs = $$"""{"action": "goto", "url": "{{pageServer.Url}}"}""";
             var gotoRes = await browser.ExecuteAsync(gotoArgs, CancellationToken.None);
             Assert.Contains("Navigated to", gotoRes);
 
-            // get_text
             var getTextArgs = "{\"action\": \"get_text\", \"selector\": \"h1\"}";
             var textRes = await browser.ExecuteAsync(getTextArgs, CancellationToken.None);
-            Assert.Contains("Example Domain", textRes);
+            Assert.Contains("OpenClaw Browser Tool Test", textRes);
 
-            // evaluate JS
             var evalArgs = "{\"action\": \"evaluate\", \"script\": \"Math.max(1, 5)\"}";
             var evalRes = await browser.ExecuteAsync(evalArgs, CancellationToken.None);
             Assert.Equal("5", evalRes);
@@ -46,6 +59,98 @@ public class BrowserToolTests
         finally
         {
             Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", previousBrowsersPath);
+        }
+    }
+
+    private sealed class LocalPageServer : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _serveTask;
+
+        private LocalPageServer(TcpListener listener)
+        {
+            _listener = listener;
+            var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            Url = new Uri($"http://127.0.0.1:{port}/");
+            _serveTask = ServeAsync();
+        }
+
+        public Uri Url { get; }
+
+        public static LocalPageServer Start()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, port: 0);
+            listener.Start();
+            return new LocalPageServer(listener);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+
+            try
+            {
+                await _serveTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+
+            _cts.Dispose();
+        }
+
+        private async Task ServeAsync()
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                TcpClient client;
+                try
+                {
+                    client = await _listener.AcceptTcpClientAsync(_cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+
+                try
+                {
+                    await HandleAsync(client, _cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+
+        private static async Task HandleAsync(TcpClient client, CancellationToken ct)
+        {
+            using (client)
+            {
+                var stream = client.GetStream();
+                var buffer = new byte[1024];
+                _ = await stream.ReadAsync(buffer, ct).ConfigureAwait(false);
+
+                const string Body =
+                    "<!doctype html><html><head><title>OpenClaw Browser Tool Test</title></head>" +
+                    "<body><h1>OpenClaw Browser Tool Test</h1></body></html>";
+                var bodyBytes = Encoding.UTF8.GetBytes(Body);
+                var header = Encoding.ASCII.GetBytes(
+                    "HTTP/1.1 200 OK\r\n" +
+                    "Content-Type: text/html; charset=utf-8\r\n" +
+                    $"Content-Length: {bodyBytes.Length}\r\n" +
+                    "Connection: close\r\n\r\n");
+
+                await stream.WriteAsync(header, ct).ConfigureAwait(false);
+                await stream.WriteAsync(bodyBytes, ct).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/OpenClaw.Tests/CliProgramTests.cs
+++ b/src/OpenClaw.Tests/CliProgramTests.cs
@@ -8,6 +8,26 @@ namespace OpenClaw.Tests;
 public sealed class CliProgramTests
 {
     [Fact]
+    public async Task Main_Help_ListsPluginsCommand()
+    {
+        var previousOut = Console.Out;
+        using var output = new StringWriter();
+        try
+        {
+            Console.SetOut(output);
+
+            var exitCode = await OpenClaw.Cli.Program.Main(["--help"]);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("openclaw plugins <install|remove|list|search> [options]", output.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+        }
+    }
+
+    [Fact]
     public void ResolveAuthToken_CliToken_WarnsAndTakesPrecedence()
     {
         var previous = Environment.GetEnvironmentVariable("OPENCLAW_AUTH_TOKEN");

--- a/src/OpenClaw.Tests/FeatureParityTests.cs
+++ b/src/OpenClaw.Tests/FeatureParityTests.cs
@@ -128,6 +128,75 @@ public class FeatureParityTests
     }
 
     [Fact]
+    public async Task RunStreamingAsync_NonStreamingTool_YieldsToolStartedBeforeToolCompletes()
+    {
+        var chatClient = Substitute.For<IChatClient>();
+        var memory = Substitute.For<IMemoryStore>();
+
+        var toolCallUpdates = new[]
+        {
+            new ChatResponseUpdate(ChatRole.Assistant, new List<AIContent>
+            {
+                new FunctionCallContent("call1", "slow_tool", new Dictionary<string, object?> { ["id"] = "1" })
+            })
+        };
+        var finalUpdates = new[]
+        {
+            new ChatResponseUpdate(ChatRole.Assistant, "done")
+        };
+
+        var streamCallCount = 0;
+        chatClient.GetStreamingResponseAsync(
+            Arg.Any<IList<ChatMessage>>(),
+            Arg.Any<ChatOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var call = Interlocked.Increment(ref streamCallCount);
+                return (call == 1 ? toolCallUpdates : finalUpdates).ToAsyncEnumerable();
+            });
+
+        var executeCalled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseTool = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var slowTool = Substitute.For<ITool>();
+        slowTool.Name.Returns("slow_tool");
+        slowTool.Description.Returns("A slow tool");
+        slowTool.ParameterSchema.Returns("""{"type":"object","properties":{"id":{"type":"string"}}}""");
+        slowTool.ExecuteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<string>(CompleteToolAfterReleaseAsync(executeCalled, releaseTool.Task)));
+
+        var agent = new AgentRuntime(chatClient, [slowTool], memory, DefaultConfig,
+            maxHistoryTurns: 10,
+            parallelToolExecution: false);
+        var session = CreateSession();
+
+        await using var enumerator = agent.RunStreamingAsync(session, "Run a slow tool", CancellationToken.None)
+            .GetAsyncEnumerator();
+
+        var firstMove = enumerator.MoveNextAsync().AsTask();
+        var completed = await Task.WhenAny(firstMove, Task.Delay(TimeSpan.FromSeconds(2)));
+
+        Assert.Same(firstMove, completed);
+        Assert.True(await firstMove);
+        Assert.Equal(AgentStreamEventType.ToolStart, enumerator.Current.Type);
+        Assert.Equal("slow_tool", enumerator.Current.ToolName);
+        Assert.False(executeCalled.Task.IsCompleted);
+
+        releaseTool.SetResult(true);
+
+        var remaining = new List<AgentStreamEvent>();
+        while (await enumerator.MoveNextAsync())
+            remaining.Add(enumerator.Current);
+
+        Assert.True(await executeCalled.Task);
+        Assert.Contains(remaining, evt =>
+            evt.Type == AgentStreamEventType.ToolResult
+            && evt.ToolName == "slow_tool"
+            && evt.Content == "tool result");
+        Assert.Contains(remaining, evt => evt.Type == AgentStreamEventType.Done);
+    }
+
+    [Fact]
     public async Task RunAsync_EstimatedTokenAdmissionControl_RejectsBeforeCallingLlm()
     {
         var chatClient = Substitute.For<IChatClient>();
@@ -970,6 +1039,13 @@ public class FeatureParityTests
 #pragma warning disable CS0162 // Unreachable code detected
         yield break;
 #pragma warning restore CS0162
+    }
+
+    private static async Task<string> CompleteToolAfterReleaseAsync(TaskCompletionSource<bool> executeCalled, Task releaseTool)
+    {
+        executeCalled.SetResult(true);
+        await releaseTool;
+        return "tool result";
     }
 }
 

--- a/src/OpenClaw.Tests/FeatureParityTests.cs
+++ b/src/OpenClaw.Tests/FeatureParityTests.cs
@@ -197,6 +197,40 @@ public class FeatureParityTests
     }
 
     [Fact]
+    public async Task RunStreamingAsync_ToolStartIgnoresUnserializableArguments()
+    {
+        var chatClient = Substitute.For<IChatClient>();
+        var memory = Substitute.For<IMemoryStore>();
+        var cyclicArguments = new Dictionary<string, object?>(StringComparer.Ordinal);
+        cyclicArguments["self"] = cyclicArguments;
+
+        var toolCallUpdates = new[]
+        {
+            new ChatResponseUpdate(ChatRole.Assistant, new List<AIContent>
+            {
+                new FunctionCallContent("call1", "cyclic_tool", cyclicArguments)
+            })
+        };
+
+        chatClient.GetStreamingResponseAsync(
+            Arg.Any<IList<ChatMessage>>(),
+            Arg.Any<ChatOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(toolCallUpdates.ToAsyncEnumerable());
+
+        var agent = new AgentRuntime(chatClient, [], memory, DefaultConfig, maxHistoryTurns: 10);
+        var session = CreateSession();
+
+        await using var enumerator = agent.RunStreamingAsync(session, "Run tool", CancellationToken.None)
+            .GetAsyncEnumerator();
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal(AgentStreamEventType.ToolStart, enumerator.Current.Type);
+        Assert.Equal("cyclic_tool", enumerator.Current.ToolName);
+        Assert.Equal("{}", enumerator.Current.ToolArguments);
+    }
+
+    [Fact]
     public async Task RunAsync_EstimatedTokenAdmissionControl_RejectsBeforeCallingLlm()
     {
         var chatClient = Substitute.For<IChatClient>();

--- a/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
+++ b/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
@@ -1890,6 +1890,84 @@ public sealed class GatewayAdminEndpointTests
     }
 
     [Fact]
+    public async Task ChatCompletions_DefaultProfileWithoutTools_DoesNotSuppressToolsForLiteralModelOverride()
+    {
+        await using var harness = await CreateHarnessAsync(nonLoopbackBind: true, ConfigureNoToolDefaultProfile);
+        Session? capturedSession = null;
+        harness.Runtime.AgentRuntime.RunAsync(
+                Arg.Any<Session>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<ToolApprovalCallback?>(),
+                Arg.Any<JsonElement?>())
+            .Returns(callInfo =>
+            {
+                capturedSession = callInfo.Arg<Session>();
+                return Task.FromResult("override chat ok");
+            });
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/chat/completions")
+        {
+            Content = JsonContent("""{"model":"llama3.2:latest","messages":[{"role":"user","content":"hello"}]}""")
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+
+        var response = await harness.Client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(capturedSession);
+        Assert.Equal("llama3.2:latest", capturedSession!.ModelOverride);
+        Assert.Empty(capturedSession.RouteAllowedTools);
+    }
+
+    [Fact]
+    public async Task ChatCompletions_DefaultProfileWithoutTools_KeepsPersistedPresetRequestsExplicit()
+    {
+        await using var harness = await CreateHarnessAsync(nonLoopbackBind: true, ConfigureNoToolDefaultProfile);
+        var capturedSessions = new List<Session>();
+        harness.Runtime.AgentRuntime.RunAsync(
+                Arg.Any<Session>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<ToolApprovalCallback?>(),
+                Arg.Any<JsonElement?>())
+            .Returns(callInfo =>
+            {
+                capturedSessions.Add(callInfo.Arg<Session>());
+                return Task.FromResult("stable preset chat ok");
+            });
+
+        const string stableSessionId = "stable-preset-session";
+        using var firstRequest = new HttpRequestMessage(HttpMethod.Post, "/v1/chat/completions")
+        {
+            Content = JsonContent("""{"messages":[{"role":"user","content":"set preset"}]}""")
+        };
+        firstRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+        firstRequest.Headers.Add("X-OpenClaw-Session-Id", stableSessionId);
+        firstRequest.Headers.Add("X-OpenClaw-Preset", "web");
+
+        using var firstResponse = await harness.Client.SendAsync(firstRequest);
+        Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
+
+        using var secondRequest = new HttpRequestMessage(HttpMethod.Post, "/v1/chat/completions")
+        {
+            Content = JsonContent("""{"messages":[{"role":"user","content":"follow up"}]}""")
+        };
+        secondRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+        secondRequest.Headers.Add("X-OpenClaw-Session-Id", stableSessionId);
+
+        using var secondResponse = await harness.Client.SendAsync(secondRequest);
+
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+        Assert.Equal(2, capturedSessions.Count);
+        Assert.Empty(capturedSessions[1].RouteAllowedTools);
+
+        var activeSession = await FindStableSessionAsync(harness, stableSessionId);
+        Assert.NotNull(activeSession);
+        Assert.True(harness.Runtime.SessionManager.RemoveActive(activeSession!.Id));
+    }
+
+    [Fact]
     public async Task ChatCompletions_StableSession_DoesNotDuplicatePersistedHistory()
     {
         await using var harness = await CreateHarnessAsync(nonLoopbackBind: true);

--- a/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
+++ b/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
@@ -39,6 +39,7 @@ using OpenClaw.Gateway.Composition;
 using OpenClaw.Gateway.Endpoints;
 using OpenClaw.Gateway.Extensions;
 using OpenClaw.Gateway.Mcp;
+using OpenClaw.Gateway.Models;
 using Xunit;
 
 namespace OpenClaw.Tests;
@@ -1824,6 +1825,68 @@ public sealed class GatewayAdminEndpointTests
 
         Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
         Assert.Equal("Request too large.", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task ChatCompletions_DefaultProfileWithoutTools_RunsPromptOnlyWhenNoPresetRequested()
+    {
+        await using var harness = await CreateHarnessAsync(nonLoopbackBind: true, ConfigureNoToolDefaultProfile);
+        Session? capturedSession = null;
+        harness.Runtime.AgentRuntime.RunAsync(
+                Arg.Any<Session>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<ToolApprovalCallback?>(),
+                Arg.Any<JsonElement?>())
+            .Returns(callInfo =>
+            {
+                capturedSession = callInfo.Arg<Session>();
+                return Task.FromResult("plain chat ok");
+            });
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/chat/completions")
+        {
+            Content = JsonContent("""{"messages":[{"role":"user","content":"hello"}]}""")
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+
+        var response = await harness.Client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(capturedSession);
+        Assert.Single(capturedSession!.RouteAllowedTools);
+        Assert.Contains("no_implicit_tools", capturedSession.RouteAllowedTools[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ChatCompletions_DefaultProfileWithoutTools_KeepsPresetRequestsExplicit()
+    {
+        await using var harness = await CreateHarnessAsync(nonLoopbackBind: true, ConfigureNoToolDefaultProfile);
+        Session? capturedSession = null;
+        harness.Runtime.AgentRuntime.RunAsync(
+                Arg.Any<Session>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<ToolApprovalCallback?>(),
+                Arg.Any<JsonElement?>())
+            .Returns(callInfo =>
+            {
+                capturedSession = callInfo.Arg<Session>();
+                return Task.FromResult("preset chat ok");
+            });
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/chat/completions")
+        {
+            Content = JsonContent("""{"messages":[{"role":"user","content":"use the configured preset"}]}""")
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+        request.Headers.Add("X-OpenClaw-Preset", "web");
+
+        var response = await harness.Client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(capturedSession);
+        Assert.Empty(capturedSession!.RouteAllowedTools);
     }
 
     [Fact]
@@ -4601,6 +4664,29 @@ public sealed class GatewayAdminEndpointTests
     private static StringContent JsonContent(string json)
         => new(json, Encoding.UTF8, "application/json");
 
+    private static void ConfigureNoToolDefaultProfile(GatewayConfig config)
+    {
+        config.Models.DefaultProfile = "ollama-general";
+        config.Models.Profiles =
+        [
+            new ModelProfileConfig
+            {
+                Id = "ollama-general",
+                Provider = "ollama",
+                Model = "llama3.2",
+                BaseUrl = "http://127.0.0.1:11434",
+                Capabilities = new ModelCapabilities
+                {
+                    SupportsTools = false,
+                    SupportsStreaming = true,
+                    SupportsSystemMessages = true,
+                    MaxContextTokens = 131_072,
+                    MaxOutputTokens = 4_096
+                }
+            }
+        ];
+    }
+
     private static async Task<HttpResponseMessage> PostWebhookAsync(HttpClient client, string name, string body, string secret)
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, $"/webhooks/{name}")
@@ -5018,6 +5104,9 @@ public sealed class GatewayAdminEndpointTests
             PluginReports = Array.Empty<PluginLoadReport>(),
             Operations = new RuntimeOperationsState
             {
+                ModelProfiles = new ConfiguredModelProfileRegistry(
+                    config,
+                    NullLogger<ConfiguredModelProfileRegistry>.Instance),
                 ProviderPolicies = providerPolicies,
                 ProviderRegistry = providerRegistry,
                 LlmExecution = llmExecution,

--- a/src/OpenClaw.Tests/ManagedGatewayServiceTests.cs
+++ b/src/OpenClaw.Tests/ManagedGatewayServiceTests.cs
@@ -75,6 +75,7 @@ public sealed class ManagedGatewayServiceTests : IDisposable
     [Theory]
     [InlineData("https://example.test", "wss://example.test/ws")]
     [InlineData("http://example.test/root", "ws://example.test/root/ws")]
+    [InlineData("https://example.test/root?token=abc#frag", "wss://example.test/root/ws")]
     [InlineData("wss://example.test/ws", "wss://example.test/ws")]
     [InlineData("wss://example.test/ws/", "wss://example.test/ws")]
     [InlineData("ws://example.test/root/ws", "ws://example.test/root/ws")]

--- a/src/OpenClaw.Tests/OpenClaw.Tests.csproj
+++ b/src/OpenClaw.Tests/OpenClaw.Tests.csproj
@@ -23,6 +23,12 @@
   <ItemGroup Condition="'$(OpenClawEnableMafExperiment)' == 'true'">
     <ProjectReference Include="..\OpenClaw.MicrosoftAgentFrameworkAdapter\OpenClaw.MicrosoftAgentFrameworkAdapter.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(OpenClawEnableMafExperiment)' == 'true'">
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Agents.AI.Hosting.A2A" Version="1.0.0-preview.260330.1" />
+    <PackageReference Include="A2A" Version="1.0.0-preview" />
+    <PackageReference Include="A2A.AspNetCore" Version="1.0.0-preview" />
+  </ItemGroup>
   <ItemGroup Condition="'$(OpenClawEnableOpenSandbox)' == 'true'">
     <ProjectReference Include="..\OpenClawNet.Sandbox.OpenSandbox\OpenClawNet.Sandbox.OpenSandbox.csproj" />
   </ItemGroup>

--- a/src/OpenClaw.Tests/PluginTests.cs
+++ b/src/OpenClaw.Tests/PluginTests.cs
@@ -231,8 +231,8 @@ public class PluginDiscoveryTests : IDisposable
         if (OperatingSystem.IsWindows())
             return;
 
-        var pluginDir = Path.Combine(_tempDir, "symlink-plugin");
-        var outsideDir = Path.Combine(_tempDir, "outside");
+        var pluginDir = Path.GetFullPath("symlink-plugin", _tempDir);
+        var outsideDir = Path.GetFullPath("outside", _tempDir);
         Directory.CreateDirectory(pluginDir);
         Directory.CreateDirectory(outsideDir);
         File.WriteAllText(Path.Combine(pluginDir, "openclaw.plugin.json"), """{"id":"symlink-plugin"}""");
@@ -249,6 +249,28 @@ public class PluginDiscoveryTests : IDisposable
         Assert.Empty(result.Plugins);
         var report = Assert.Single(result.Reports);
         Assert.Contains(report.Diagnostics, diagnostic => diagnostic.Code == "entry_outside_root");
+    }
+
+    [Fact]
+    public void DiscoverWithDiagnostics_ManifestEntryCyclicSymlink_DoesNotRecurseIndefinitely()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var pluginDir = Path.GetFullPath("cyclic-symlink-plugin", _tempDir);
+        Directory.CreateDirectory(pluginDir);
+        File.WriteAllText(Path.Combine(pluginDir, "openclaw.plugin.json"), """{"id":"cyclic-symlink-plugin"}""");
+        var loop = Path.Combine(pluginDir, "index.js");
+        File.CreateSymbolicLink(loop, loop);
+
+        var config = new PluginsConfig
+        {
+            Load = new PluginLoadConfig { Paths = [pluginDir] }
+        };
+
+        var result = PluginDiscovery.DiscoverWithDiagnostics(config);
+
+        Assert.Empty(result.Plugins);
     }
 
     [Fact]

--- a/src/OpenClaw.Tests/PluginTests.cs
+++ b/src/OpenClaw.Tests/PluginTests.cs
@@ -225,6 +225,67 @@ public class PluginDiscoveryTests : IDisposable
         Assert.Contains(report.Diagnostics, diagnostic => diagnostic.Code == "entry_outside_root");
     }
 
+    [Fact]
+    public void DiscoverWithDiagnostics_ManifestEntrySymlinkOutsideRoot_IsRejected()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var pluginDir = Path.Combine(_tempDir, "symlink-plugin");
+        var outsideDir = Path.Combine(_tempDir, "outside");
+        Directory.CreateDirectory(pluginDir);
+        Directory.CreateDirectory(outsideDir);
+        File.WriteAllText(Path.Combine(pluginDir, "openclaw.plugin.json"), """{"id":"symlink-plugin"}""");
+        File.WriteAllText(Path.Combine(outsideDir, "index.js"), "export default function() {}");
+        File.CreateSymbolicLink(Path.Combine(pluginDir, "index.js"), Path.Combine(outsideDir, "index.js"));
+
+        var config = new PluginsConfig
+        {
+            Load = new PluginLoadConfig { Paths = [pluginDir] }
+        };
+
+        var result = PluginDiscovery.DiscoverWithDiagnostics(config);
+
+        Assert.Empty(result.Plugins);
+        var report = Assert.Single(result.Reports);
+        Assert.Contains(report.Diagnostics, diagnostic => diagnostic.Code == "entry_outside_root");
+    }
+
+    [Fact]
+    public void DiscoverWithDiagnostics_PackageEntryUnderSymlinkedParentOutsideRoot_IsRejected()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var pluginDir = Path.Combine(_tempDir, "packed-symlink-plugin");
+        var outsideDir = Path.Combine(_tempDir, "outside-pack");
+        Directory.CreateDirectory(pluginDir);
+        Directory.CreateDirectory(outsideDir);
+        File.WriteAllText(Path.Combine(outsideDir, "entry.js"), "export default function() {}");
+        Directory.CreateSymbolicLink(Path.Combine(pluginDir, "linked"), outsideDir);
+        File.WriteAllText(
+            Path.Combine(pluginDir, "package.json"),
+            """
+            {
+              "name": "packed-symlink-plugin",
+              "openclaw": {
+                "extensions": ["linked/entry.js"]
+              }
+            }
+            """);
+
+        var config = new PluginsConfig
+        {
+            Load = new PluginLoadConfig { Paths = [pluginDir] }
+        };
+
+        var result = PluginDiscovery.DiscoverWithDiagnostics(config);
+
+        Assert.Empty(result.Plugins);
+        var report = Assert.Single(result.Reports);
+        Assert.Contains(report.Diagnostics, diagnostic => diagnostic.Code == "entry_outside_root");
+    }
+
     private static DiscoveredPlugin MakePlugin(string id, string? kind = null)
         => new()
         {

--- a/src/OpenClaw.Tests/SetupCommandTests.cs
+++ b/src/OpenClaw.Tests/SetupCommandTests.cs
@@ -60,6 +60,7 @@ public sealed class SetupCommandTests
             var tooling = openClaw.GetProperty("tooling");
             Assert.True(tooling.GetProperty("workspaceOnly").GetBoolean());
             Assert.True(tooling.GetProperty("allowShell").GetBoolean());
+            Assert.False(tooling.GetProperty("enableBrowserTool").GetBoolean());
             Assert.Equal(workspace, tooling.GetProperty("workspaceRoot").GetString());
             Assert.Equal(workspace, tooling.GetProperty("allowedReadRoots")[0].GetString());
             Assert.Equal(workspace, tooling.GetProperty("allowedWriteRoots")[0].GetString());
@@ -119,6 +120,7 @@ public sealed class SetupCommandTests
 
             var tooling = openClaw.GetProperty("tooling");
             Assert.False(tooling.GetProperty("allowShell").GetBoolean());
+            Assert.False(tooling.GetProperty("enableBrowserTool").GetBoolean());
             Assert.True(tooling.GetProperty("requireToolApproval").GetBoolean());
 
             var security = openClaw.GetProperty("security");

--- a/src/OpenClaw.Tests/ToolPathPolicyTests.cs
+++ b/src/OpenClaw.Tests/ToolPathPolicyTests.cs
@@ -160,6 +160,21 @@ public sealed class ToolPathPolicyTests
         Assert.EndsWith("does-not-exist.txt", resolved, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ResolveRealPath_CyclicSymlink_DoesNotRecurseIndefinitely()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = CreateTempDir();
+        var loop = Path.Combine(root, "loop");
+        File.CreateSymbolicLink(loop, loop);
+
+        var resolved = ToolPathPolicy.ResolveRealPath(loop);
+
+        Assert.False(string.IsNullOrWhiteSpace(resolved));
+    }
+
     private static string CreateTempDir()
     {
         var path = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("n"));

--- a/src/OpenClaw.Tests/ToolPathPolicyTests.cs
+++ b/src/OpenClaw.Tests/ToolPathPolicyTests.cs
@@ -56,6 +56,29 @@ public sealed class ToolPathPolicyTests
     }
 
     [Fact]
+    public void IsReadAllowed_DeniesExistingFileUnderSymlinkedParentDirectory()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = CreateTempDir();
+        var outsideDir = CreateTempDir();
+        var secretFile = Path.Combine(outsideDir, "secret.txt");
+        File.WriteAllText(secretFile, "sensitive");
+
+        var symlinkDir = Path.Combine(root, "escape_dir");
+        Directory.CreateSymbolicLink(symlinkDir, outsideDir);
+        var targetPath = Path.Combine(symlinkDir, "secret.txt");
+
+        var config = new ToolingConfig
+        {
+            AllowedReadRoots = [root]
+        };
+
+        Assert.False(ToolPathPolicy.IsReadAllowed(config, targetPath));
+    }
+
+    [Fact]
     public void IsWriteAllowed_DeniesSymlinkedParentDirectory()
     {
         if (OperatingSystem.IsWindows())
@@ -118,7 +141,7 @@ public sealed class ToolPathPolicyTests
         var resolved = ToolPathPolicy.ResolveRealPath(Path.Combine(symlinkDir, "nonexistent.txt"));
 
         // The resolved path should point under the outside directory, not under root
-        Assert.StartsWith(outsideDir, resolved, StringComparison.Ordinal);
+        Assert.StartsWith(ToolPathPolicy.ResolveRealPath(outsideDir), resolved, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -133,7 +156,7 @@ public sealed class ToolPathPolicyTests
         var resolved = ToolPathPolicy.ResolveRealPath(nonExistentFile);
 
         // Should resolve under the real root directory with the correct filename
-        Assert.StartsWith(root, resolved, StringComparison.Ordinal);
+        Assert.StartsWith(ToolPathPolicy.ResolveRealPath(root), resolved, StringComparison.Ordinal);
         Assert.EndsWith("does-not-exist.txt", resolved, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
## What changed

- Hardened the agent/runtime and gateway release-candidate paths found during the audit, including clearer streaming/tool event handling, path/plugin validation, and setup defaults.
- Improved the local Ollama first-chat path by suppressing implicit gateway tools for OpenAI-compatible requests when the selected/default profile does not support tools and no explicit preset is requested.
- Disabled browser-tool setup defaults for local/public profiles unless an OpenSandbox backend is selected.
- Added focused regression coverage for path policy, plugin discovery, CLI/setup behavior, browser tool gating, feature parity, companion managed-gateway behavior, and no-tool default model profiles.
- Added `AUDIT_REPORT.md` and updated onboarding/release docs to match the hardened behavior.

## Why

A plain local Ollama prompt should not fail model-profile selection just because the gateway has an implicit tool surface. The gateway should reserve tool-capability requirements for explicit tool/preset paths while keeping first-chat onboarding predictable.

The broader audit fixes reduce developer confidence risks around setup verification, NativeAOT-friendly defaults, plugin/path safety, CI smoke coverage, and release manager handoff.

## Validation

- `dotnet build OpenClaw.Net.slnx --configuration Release --no-restore`
- `dotnet test OpenClaw.Net.slnx --configuration Release --no-build`
- Focused gateway endpoint suite: `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~GatewayAdminEndpointTests"`
- Local Ollama setup smoke with generated config: `setup verify --offline`, `setup status`, gateway `/health`, and `openclaw run --no-stream "hello"`

## Notes

`RELEASE_CANDIDATE_REPORT.md` was intentionally left untracked and is not included in this PR.
