### PR TITLE
[codex] Fix Telegram and WhatsApp channel bridges

### DIFF
--- a/docs/TOOLS_GUIDE.md
+++ b/docs/TOOLS_GUIDE.md
@@ -372,8 +372,9 @@ They also include a security posture section covering public-bind approval mode,
 ### Media Marker Protocol (Telegram + WebChat)
 The gateway/channels support portable attachment markers embedded in text (one per line):
 - `[IMAGE_URL:https://...]` (Telegram sends a real photo; WebChat renders inline)
-- `[FILE_URL:https://...]` (WebChat renders as a link)
+- `[VIDEO_URL:https://...]`, `[AUDIO_URL:https://...]`, `[DOCUMENT_URL:https://...]`, `[FILE_URL:https://...]`, `[STICKER_URL:https://...]` (Telegram sends through the matching Bot API media method where supported; WebChat renders files as links)
 - `[IMAGE:telegram:file_id=<id>]` (Telegram inbound photos are represented this way; the agent can reference it)
+- `[VIDEO:telegram:file_id=<id>]`, `[AUDIO:telegram:file_id=<id>]`, `[DOCUMENT:telegram:file_id=<id>]`, `[STICKER:telegram:file_id=<id>]` (Telegram inbound media file IDs)
 
 ## ⏰ Scheduled Tasks (Cron)
 OpenClaw.NET can run scheduled prompts via `OpenClaw:Cron`. For delivery, set a `ChannelId` and `RecipientId` on the job so the agent’s response is sent through that channel adapter.
@@ -393,7 +394,7 @@ Cron job delivery fields:
 **RecipientId quick reference**
 - `ChannelId="email"` → `RecipientId="you@example.com"`
 - `ChannelId="sms"` → `RecipientId="+15551234567"` (must be in `AllowedToNumbers`)
-- `ChannelId="telegram"` → `RecipientId="<numeric chat id>"` (see “Telegram Webhook channel” in `../README.md`)
+- `ChannelId="telegram"` → `RecipientId="<numeric chat id>"` or `RecipientId="@channelusername"` (see “Telegram Webhook channel” in `../README.md`)
 - `ChannelId="whatsapp"` → `RecipientId="<phone number>"` (Meta Cloud API “to”; format depends on your WhatsApp setup)
 - `ChannelId="websocket"` → `RecipientId="<connection id>"` (only works while that client is connected)
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -573,7 +573,7 @@ Enable them under the `Channels` block in your config.
 Scheduled jobs (Cron) and outbound delivery require a `RecipientId` that is specific to each channel:
 - **Email** (`ChannelId="email"`): the destination email address (e.g. `you@example.com`)
 - **SMS** (`ChannelId="sms"`): an E.164 number (e.g. `+15551234567`)
-- **Telegram** (`ChannelId="telegram"`): a numeric Telegram `chat.id` (not `from.id`)
+- **Telegram** (`ChannelId="telegram"`): a numeric Telegram `chat.id` (not `from.id`) or a public channel username such as `@openclaw_updates`
 
 To discover a Telegram `chat.id`:
 1. Enable the Telegram channel and temporarily set `DmPolicy="open"` (or approve the pairing).

--- a/src/OpenClaw.Agent/AgentRuntime.cs
+++ b/src/OpenClaw.Agent/AgentRuntime.cs
@@ -1717,9 +1717,9 @@ public sealed class AgentRuntime : IAgentRuntime
             var mediaType = marker.Kind switch
             {
                 MediaMarkerKind.ImageUrl or MediaMarkerKind.ImagePath or MediaMarkerKind.TelegramImageFileId => "image/*",
-                MediaMarkerKind.AudioUrl => "audio/*",
-                MediaMarkerKind.VideoUrl => "video/*",
-                MediaMarkerKind.DocumentUrl or MediaMarkerKind.FileUrl or MediaMarkerKind.FilePath => "application/octet-stream",
+                MediaMarkerKind.AudioUrl or MediaMarkerKind.TelegramAudioFileId => "audio/*",
+                MediaMarkerKind.VideoUrl or MediaMarkerKind.TelegramVideoFileId => "video/*",
+                MediaMarkerKind.DocumentUrl or MediaMarkerKind.FileUrl or MediaMarkerKind.FilePath or MediaMarkerKind.TelegramDocumentFileId => "application/octet-stream",
                 _ => "application/octet-stream"
             };
 

--- a/src/OpenClaw.Agent/Plugins/BridgedChannelAdapter.cs
+++ b/src/OpenClaw.Agent/Plugins/BridgedChannelAdapter.cs
@@ -86,19 +86,31 @@ public sealed class BridgedChannelAdapter : IBridgedChannelControl, IRestartable
     {
         var (markers, remainingText) = MediaMarkerProtocol.Extract(message.Text);
 
-        BridgeMediaAttachment[]? attachments = null;
-        if (markers.Count > 0)
+        List<BridgeMediaAttachment>? attachments = null;
+        List<string>? passthroughMarkerLines = null;
+        foreach (var marker in markers)
         {
-            attachments = new BridgeMediaAttachment[markers.Count];
-            for (var i = 0; i < markers.Count; i++)
+            if (IsBridgeAttachmentMarker(marker.Kind))
             {
-                var m = markers[i];
-                attachments[i] = new BridgeMediaAttachment
+                attachments ??= [];
+                attachments.Add(new BridgeMediaAttachment
                 {
-                    Type = MarkerKindToMediaType(m.Kind),
-                    Url = m.Value
-                };
+                    Type = MarkerKindToMediaType(marker.Kind),
+                    Url = marker.Value
+                });
             }
+            else
+            {
+                passthroughMarkerLines ??= [];
+                passthroughMarkerLines.Add(ToMarkerLine(marker));
+            }
+        }
+
+        var text = remainingText;
+        if (passthroughMarkerLines is { Count: > 0 })
+        {
+            var markerText = string.Join('\n', passthroughMarkerLines);
+            text = string.IsNullOrWhiteSpace(text) ? markerText : markerText + "\n" + text;
         }
 
         await _bridge.SendRequestAsync(
@@ -107,12 +119,12 @@ public sealed class BridgedChannelAdapter : IBridgedChannelControl, IRestartable
             {
                 ChannelId = ChannelId,
                 RecipientId = message.RecipientId,
-                Text = remainingText,
+                Text = text,
                 AccountId = message.AccountId,
                 SessionId = message.SessionId,
                 ReplyToMessageId = message.ReplyToMessageId,
                 Subject = message.Subject,
-                Attachments = attachments,
+                Attachments = attachments?.ToArray(),
             },
             CoreJsonContext.Default.BridgeChannelSendRequest,
             ct);
@@ -336,11 +348,32 @@ public sealed class BridgedChannelAdapter : IBridgedChannelControl, IRestartable
 
     private static string MarkerKindToMediaType(MediaMarkerKind kind) => kind switch
     {
-        MediaMarkerKind.ImageUrl or MediaMarkerKind.ImagePath or MediaMarkerKind.TelegramImageFileId => "image",
-        MediaMarkerKind.VideoUrl or MediaMarkerKind.TelegramVideoFileId => "video",
-        MediaMarkerKind.AudioUrl or MediaMarkerKind.TelegramAudioFileId => "audio",
-        MediaMarkerKind.DocumentUrl or MediaMarkerKind.FileUrl or MediaMarkerKind.FilePath or MediaMarkerKind.TelegramDocumentFileId => "document",
-        MediaMarkerKind.StickerUrl or MediaMarkerKind.TelegramStickerFileId => "sticker",
+        MediaMarkerKind.ImageUrl or MediaMarkerKind.ImagePath => "image",
+        MediaMarkerKind.VideoUrl => "video",
+        MediaMarkerKind.AudioUrl => "audio",
+        MediaMarkerKind.DocumentUrl or MediaMarkerKind.FileUrl or MediaMarkerKind.FilePath => "document",
+        MediaMarkerKind.StickerUrl => "sticker",
         _ => "document",
     };
+
+    private static bool IsBridgeAttachmentMarker(MediaMarkerKind kind)
+        => kind is MediaMarkerKind.ImageUrl
+            or MediaMarkerKind.ImagePath
+            or MediaMarkerKind.VideoUrl
+            or MediaMarkerKind.AudioUrl
+            or MediaMarkerKind.DocumentUrl
+            or MediaMarkerKind.FileUrl
+            or MediaMarkerKind.FilePath
+            or MediaMarkerKind.StickerUrl;
+
+    private static string ToMarkerLine(MediaMarker marker)
+        => marker.Kind switch
+        {
+            MediaMarkerKind.TelegramImageFileId => $"[IMAGE:telegram:file_id={marker.Value}]",
+            MediaMarkerKind.TelegramVideoFileId => $"[VIDEO:telegram:file_id={marker.Value}]",
+            MediaMarkerKind.TelegramAudioFileId => $"[AUDIO:telegram:file_id={marker.Value}]",
+            MediaMarkerKind.TelegramDocumentFileId => $"[DOCUMENT:telegram:file_id={marker.Value}]",
+            MediaMarkerKind.TelegramStickerFileId => $"[STICKER:telegram:file_id={marker.Value}]",
+            _ => marker.Value
+        };
 }

--- a/src/OpenClaw.Agent/Plugins/BridgedChannelAdapter.cs
+++ b/src/OpenClaw.Agent/Plugins/BridgedChannelAdapter.cs
@@ -337,10 +337,10 @@ public sealed class BridgedChannelAdapter : IBridgedChannelControl, IRestartable
     private static string MarkerKindToMediaType(MediaMarkerKind kind) => kind switch
     {
         MediaMarkerKind.ImageUrl or MediaMarkerKind.ImagePath or MediaMarkerKind.TelegramImageFileId => "image",
-        MediaMarkerKind.VideoUrl => "video",
-        MediaMarkerKind.AudioUrl => "audio",
-        MediaMarkerKind.DocumentUrl or MediaMarkerKind.FileUrl or MediaMarkerKind.FilePath => "document",
-        MediaMarkerKind.StickerUrl => "sticker",
+        MediaMarkerKind.VideoUrl or MediaMarkerKind.TelegramVideoFileId => "video",
+        MediaMarkerKind.AudioUrl or MediaMarkerKind.TelegramAudioFileId => "audio",
+        MediaMarkerKind.DocumentUrl or MediaMarkerKind.FileUrl or MediaMarkerKind.FilePath or MediaMarkerKind.TelegramDocumentFileId => "document",
+        MediaMarkerKind.StickerUrl or MediaMarkerKind.TelegramStickerFileId => "sticker",
         _ => "document",
     };
 }

--- a/src/OpenClaw.Channels/TelegramChannel.cs
+++ b/src/OpenClaw.Channels/TelegramChannel.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Http;
@@ -242,10 +243,22 @@ public sealed class TelegramMediaPayload
 [JsonConverter(typeof(TelegramChatIdJsonConverter))]
 public readonly record struct TelegramChatId(string Value)
 {
+    private static readonly Regex PublicUsernamePattern = new(
+        "^@[A-Za-z][A-Za-z0-9_]{4,31}$",
+        RegexOptions.CultureInvariant,
+        TimeSpan.FromMilliseconds(100));
+
     public static bool TryCreate(string? value, out TelegramChatId chatId)
     {
         value = value?.Trim();
         if (string.IsNullOrWhiteSpace(value))
+        {
+            chatId = default;
+            return false;
+        }
+
+        if (!long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _) &&
+            !PublicUsernamePattern.IsMatch(value))
         {
             chatId = default;
             return false;

--- a/src/OpenClaw.Channels/TelegramChannel.cs
+++ b/src/OpenClaw.Channels/TelegramChannel.cs
@@ -1,4 +1,4 @@
-using System.Net.Http;
+using System.Globalization;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -16,16 +16,26 @@ namespace OpenClaw.Channels;
 /// </summary>
 public sealed class TelegramChannel : IChannelAdapter
 {
+    private const int MaxMessageChars = 4096;
+    private const int MaxCaptionChars = 1024;
+
     private readonly TelegramChannelConfig _config;
     private readonly HttpClient _http;
     private readonly ILogger<TelegramChannel> _logger;
     private readonly string _botToken;
+    private readonly bool _ownsHttp;
 
     public TelegramChannel(TelegramChannelConfig config, ILogger<TelegramChannel> logger)
+        : this(config, logger, http: null)
+    {
+    }
+
+    public TelegramChannel(TelegramChannelConfig config, ILogger<TelegramChannel> logger, HttpClient? http)
     {
         _config = config;
         _logger = logger;
-        _http = HttpClientFactory.Create();
+        _http = http ?? HttpClientFactory.Create();
+        _ownsHttp = http is null;
         
         var tokenSource = SecretResolver.Resolve(config.BotTokenRef) ?? config.BotToken;
 
@@ -44,44 +54,66 @@ public sealed class TelegramChannel : IChannelAdapter
     {
         if (string.IsNullOrWhiteSpace(outbound.Text)) return;
 
-        // Try parsing to ensure we send back to a numeric Chat ID
-        if (!long.TryParse(outbound.RecipientId, out var chatId))
+        if (!TelegramChatId.TryCreate(outbound.RecipientId, out var chatId))
         {
-            _logger.LogWarning("Telegram SendAsync aborted: RecipientId '{RecipientId}' is not a numeric Telegram Chat ID.", outbound.RecipientId);
+            _logger.LogWarning("Telegram SendAsync aborted: RecipientId is not configured.");
             return;
         }
 
+        var replyToMessageId = TryParseReplyToMessageId(outbound.ReplyToMessageId);
         try
         {
             var (markers, remaining) = MediaMarkerProtocol.Extract(outbound.Text);
-            var images = markers.Where(m => m.Kind is MediaMarkerKind.ImageUrl or MediaMarkerKind.TelegramImageFileId).ToList();
+            var media = markers
+                .Select(static marker => TelegramMediaRequest.TryCreate(marker, out var request) ? request : null)
+                .OfType<TelegramMediaRequest>()
+                .ToList();
 
-            if (images.Count == 0)
+            if (media.Count == 0)
             {
-                await SendMessageAsync(chatId, outbound.Text, ct);
+                var text = markers.Count == 0 ? outbound.Text : remaining;
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    _logger.LogWarning("Telegram SendAsync skipped unsupported media-only message to {ChatId}.", chatId);
+                    return;
+                }
+
+                var first = true;
+                foreach (var chunk in ChunkText(text, MaxMessageChars))
+                {
+                    await SendMessageAsync(chatId, chunk, first ? replyToMessageId : null, ct);
+                    first = false;
+                }
+
                 return;
             }
 
-            const int MaxCaptionChars = 1024;
             var caption = string.IsNullOrWhiteSpace(remaining) ? null : remaining;
-            var captionForPhoto = caption is not null && caption.Length > MaxCaptionChars
-                ? caption[..MaxCaptionChars] + "…"
+            var captionForMedia = caption is not null && caption.Length > MaxCaptionChars
+                ? caption[..(MaxCaptionChars - 1)] + "…"
                 : caption;
+            var captionSentAsCaption = false;
 
-            for (var i = 0; i < images.Count; i++)
+            for (var i = 0; i < media.Count; i++)
             {
-                var marker = images[i];
-                var photo = marker.Value;
-                var cap = i == 0 ? captionForPhoto : null;
-                await SendPhotoAsync(chatId, photo, cap, ct);
+                var request = media[i];
+                var cap = i == 0 && request.SupportsCaption ? captionForMedia : null;
+                captionSentAsCaption = captionSentAsCaption || cap is not null;
+                await SendMediaAsync(chatId, request, cap, i == 0 ? replyToMessageId : null, ct);
+            }
+
+            if (caption is not null && !captionSentAsCaption)
+            {
+                foreach (var chunk in ChunkText(caption, MaxMessageChars))
+                    await SendMessageAsync(chatId, chunk, replyToMessageId: null, ct);
             }
 
             // If caption was truncated, send remainder as a follow-up message.
-            if (caption is not null && caption.Length > MaxCaptionChars)
+            if (captionSentAsCaption && caption is not null && caption.Length > MaxCaptionChars)
             {
-                var rest = caption[MaxCaptionChars..].Trim();
-                if (!string.IsNullOrWhiteSpace(rest))
-                    await SendMessageAsync(chatId, rest, ct);
+                var rest = caption[(MaxCaptionChars - 1)..].Trim();
+                foreach (var chunk in ChunkText(rest, MaxMessageChars))
+                    await SendMessageAsync(chatId, chunk, replyToMessageId: null, ct);
             }
         }
         catch (Exception ex)
@@ -90,58 +122,203 @@ public sealed class TelegramChannel : IChannelAdapter
         }
     }
 
-    private async Task SendMessageAsync(long chatId, string text, CancellationToken ct)
+    private async Task SendMessageAsync(TelegramChatId chatId, string text, int? replyToMessageId, CancellationToken ct)
     {
         var url = $"https://api.telegram.org/bot{_botToken}/sendMessage";
-        var payload = new TelegramMessagePayload { ChatId = chatId, Text = text };
+        var payload = new TelegramMessagePayload
+        {
+            ChatId = chatId,
+            Text = text,
+            ReplyToMessageId = replyToMessageId
+        };
         var response = await _http.PostAsJsonAsync(url, payload, TelegramJsonContext.Default.TelegramMessagePayload, ct);
         response.EnsureSuccessStatusCode();
         _logger.LogInformation("Sent Telegram message to {ChatId}", chatId);
     }
 
-    private async Task SendPhotoAsync(long chatId, string photo, string? caption, CancellationToken ct)
+    private async Task SendMediaAsync(
+        TelegramChatId chatId,
+        TelegramMediaRequest request,
+        string? caption,
+        int? replyToMessageId,
+        CancellationToken ct)
     {
-        var url = $"https://api.telegram.org/bot{_botToken}/sendPhoto";
-        var payload = new TelegramPhotoPayload
+        var url = $"https://api.telegram.org/bot{_botToken}/{request.MethodName}";
+        var payload = new TelegramMediaPayload
         {
             ChatId = chatId,
-            Photo = photo,
-            Caption = string.IsNullOrWhiteSpace(caption) ? null : caption
+            Caption = string.IsNullOrWhiteSpace(caption) ? null : caption,
+            ReplyToMessageId = replyToMessageId
         };
-        var response = await _http.PostAsJsonAsync(url, payload, TelegramJsonContext.Default.TelegramPhotoPayload, ct);
+
+        request.Apply(payload);
+
+        var response = await _http.PostAsJsonAsync(url, payload, TelegramJsonContext.Default.TelegramMediaPayload, ct);
         response.EnsureSuccessStatusCode();
-        _logger.LogInformation("Sent Telegram photo to {ChatId}", chatId);
+        _logger.LogInformation("Sent Telegram {MediaType} to {ChatId}", request.MediaType, chatId);
     }
 
     public ValueTask DisposeAsync()
     {
-        _http.Dispose();
+        if (_ownsHttp)
+            _http.Dispose();
         return ValueTask.CompletedTask;
+    }
+
+    private int? TryParseReplyToMessageId(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var messageId))
+            return messageId;
+
+        _logger.LogWarning("Telegram ReplyToMessageId '{ReplyToMessageId}' is not numeric and will be ignored.", value);
+        return null;
+    }
+
+    private static IEnumerable<string> ChunkText(string text, int limit)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            yield break;
+
+        for (var i = 0; i < text.Length; i += limit)
+            yield return text.Substring(i, Math.Min(limit, text.Length - i));
     }
 }
 
 public sealed class TelegramMessagePayload
 {
     [JsonPropertyName("chat_id")]
-    public required long ChatId { get; set; }
+    public required TelegramChatId ChatId { get; set; }
 
     [JsonPropertyName("text")]
     public required string Text { get; set; }
+
+    [JsonPropertyName("reply_to_message_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ReplyToMessageId { get; set; }
 }
 
 [JsonSerializable(typeof(TelegramMessagePayload))]
-[JsonSerializable(typeof(TelegramPhotoPayload))]
+[JsonSerializable(typeof(TelegramMediaPayload))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 public partial class TelegramJsonContext : JsonSerializerContext;
 
-public sealed class TelegramPhotoPayload
+public sealed class TelegramMediaPayload
 {
     [JsonPropertyName("chat_id")]
-    public required long ChatId { get; set; }
+    public required TelegramChatId ChatId { get; set; }
 
     [JsonPropertyName("photo")]
-    public required string Photo { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Photo { get; set; }
+
+    [JsonPropertyName("video")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Video { get; set; }
+
+    [JsonPropertyName("audio")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Audio { get; set; }
+
+    [JsonPropertyName("document")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Document { get; set; }
+
+    [JsonPropertyName("sticker")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Sticker { get; set; }
 
     [JsonPropertyName("caption")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Caption { get; set; }
+
+    [JsonPropertyName("reply_to_message_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ReplyToMessageId { get; set; }
+}
+
+[JsonConverter(typeof(TelegramChatIdJsonConverter))]
+public readonly record struct TelegramChatId(string Value)
+{
+    public static bool TryCreate(string? value, out TelegramChatId chatId)
+    {
+        value = value?.Trim();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            chatId = default;
+            return false;
+        }
+
+        chatId = new TelegramChatId(value);
+        return true;
+    }
+
+    public override string ToString() => Value;
+}
+
+public sealed class TelegramChatIdJsonConverter : JsonConverter<TelegramChatId>
+{
+    public override TelegramChatId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.Number => new TelegramChatId(reader.GetInt64().ToString(CultureInfo.InvariantCulture)),
+            JsonTokenType.String => new TelegramChatId(reader.GetString() ?? ""),
+            _ => throw new JsonException("Telegram chat_id must be a number or string.")
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, TelegramChatId value, JsonSerializerOptions options)
+    {
+        if (long.TryParse(value.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var numericValue))
+            writer.WriteNumberValue(numericValue);
+        else
+            writer.WriteStringValue(value.Value);
+    }
+}
+
+internal sealed record TelegramMediaRequest(
+    string MethodName,
+    string MediaType,
+    string Value,
+    bool SupportsCaption)
+{
+    public static bool TryCreate(MediaMarker marker, out TelegramMediaRequest? request)
+    {
+        request = marker.Kind switch
+        {
+            MediaMarkerKind.ImageUrl or MediaMarkerKind.TelegramImageFileId => new("sendPhoto", "photo", marker.Value, SupportsCaption: true),
+            MediaMarkerKind.VideoUrl or MediaMarkerKind.TelegramVideoFileId => new("sendVideo", "video", marker.Value, SupportsCaption: true),
+            MediaMarkerKind.AudioUrl or MediaMarkerKind.TelegramAudioFileId => new("sendAudio", "audio", marker.Value, SupportsCaption: true),
+            MediaMarkerKind.DocumentUrl or MediaMarkerKind.FileUrl or MediaMarkerKind.TelegramDocumentFileId => new("sendDocument", "document", marker.Value, SupportsCaption: true),
+            MediaMarkerKind.StickerUrl or MediaMarkerKind.TelegramStickerFileId => new("sendSticker", "sticker", marker.Value, SupportsCaption: false),
+            _ => null
+        };
+
+        return request is not null;
+    }
+
+    public void Apply(TelegramMediaPayload payload)
+    {
+        switch (MediaType)
+        {
+            case "photo":
+                payload.Photo = Value;
+                break;
+            case "video":
+                payload.Video = Value;
+                break;
+            case "audio":
+                payload.Audio = Value;
+                break;
+            case "document":
+                payload.Document = Value;
+                break;
+            case "sticker":
+                payload.Sticker = Value;
+                break;
+        }
+    }
 }

--- a/src/OpenClaw.Channels/WhatsAppBridgeChannel.cs
+++ b/src/OpenClaw.Channels/WhatsAppBridgeChannel.cs
@@ -165,13 +165,50 @@ public sealed class WhatsAppBridgeInboundPayload
     public required string From { get; set; }
 
     [JsonPropertyName("text")]
-    public required string Text { get; set; }
+    public string? Text { get; set; }
+
+    [JsonPropertyName("account_id")]
+    public string? AccountId { get; set; }
+
+    [JsonPropertyName("session_id")]
+    public string? SessionId { get; set; }
 
     [JsonPropertyName("sender_name")]
     public string? SenderName { get; set; }
 
     [JsonPropertyName("message_id")]
     public string? MessageId { get; set; }
+
+    [JsonPropertyName("reply_to_message_id")]
+    public string? ReplyToMessageId { get; set; }
+
+    [JsonPropertyName("is_group")]
+    public bool IsGroup { get; set; }
+
+    [JsonPropertyName("group_id")]
+    public string? GroupId { get; set; }
+
+    [JsonPropertyName("group_name")]
+    public string? GroupName { get; set; }
+
+    [JsonPropertyName("mentioned_ids")]
+    public string[]? MentionedIds { get; set; }
+
+    [JsonPropertyName("media_type")]
+    public string? MediaType { get; set; }
+
+    [JsonPropertyName("media_url")]
+    public string? MediaUrl { get; set; }
+
+    [JsonPropertyName("media_mime_type")]
+    public string? MediaMimeType { get; set; }
+
+    [JsonPropertyName("media_file_name")]
+    public string? MediaFileName { get; set; }
+
+    [JsonPropertyName("attachments")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public WhatsAppBridgeAttachmentPayload[]? Attachments { get; set; }
 }
 
 [JsonSerializable(typeof(WhatsAppBridgeSendPayload))]

--- a/src/OpenClaw.Core/Models/MediaMarkers.cs
+++ b/src/OpenClaw.Core/Models/MediaMarkers.cs
@@ -7,6 +7,10 @@ public enum MediaMarkerKind : byte
     FileUrl,
     FilePath,
     TelegramImageFileId,
+    TelegramVideoFileId,
+    TelegramAudioFileId,
+    TelegramDocumentFileId,
+    TelegramStickerFileId,
     VideoUrl,
     AudioUrl,
     DocumentUrl,
@@ -96,16 +100,34 @@ public static class MediaMarkerProtocol
             return true;
         }
 
-        // Telegram inbound marker: [IMAGE:telegram:file_id=<id>]
-        if (line.StartsWith("[IMAGE:telegram:file_id=", StringComparison.Ordinal) && line.EndsWith(']'))
+        if (TryParseTelegramFileId(line, "IMAGE", out var imageFileId))
         {
-            var start = "[IMAGE:telegram:file_id=".Length;
-            var value = line.Substring(start, line.Length - start - 1).Trim();
-            if (!string.IsNullOrWhiteSpace(value))
-            {
-                marker = new MediaMarker(MediaMarkerKind.TelegramImageFileId, value);
-                return true;
-            }
+            marker = new MediaMarker(MediaMarkerKind.TelegramImageFileId, imageFileId);
+            return true;
+        }
+
+        if (TryParseTelegramFileId(line, "VIDEO", out var videoFileId))
+        {
+            marker = new MediaMarker(MediaMarkerKind.TelegramVideoFileId, videoFileId);
+            return true;
+        }
+
+        if (TryParseTelegramFileId(line, "AUDIO", out var audioFileId))
+        {
+            marker = new MediaMarker(MediaMarkerKind.TelegramAudioFileId, audioFileId);
+            return true;
+        }
+
+        if (TryParseTelegramFileId(line, "DOCUMENT", out var documentFileId))
+        {
+            marker = new MediaMarker(MediaMarkerKind.TelegramDocumentFileId, documentFileId);
+            return true;
+        }
+
+        if (TryParseTelegramFileId(line, "STICKER", out var stickerFileId))
+        {
+            marker = new MediaMarker(MediaMarkerKind.TelegramStickerFileId, stickerFileId);
+            return true;
         }
 
         return false;
@@ -127,5 +149,15 @@ public static class MediaMarkerProtocol
         value = inner[prefix.Length..].Trim();
         return !string.IsNullOrWhiteSpace(value);
     }
-}
 
+    private static bool TryParseTelegramFileId(string line, string mediaType, out string value)
+    {
+        value = "";
+        var prefix = $"[{mediaType}:telegram:file_id=";
+        if (!line.StartsWith(prefix, StringComparison.Ordinal) || !line.EndsWith(']'))
+            return false;
+
+        value = line.Substring(prefix.Length, line.Length - prefix.Length - 1).Trim();
+        return !string.IsNullOrWhiteSpace(value);
+    }
+}

--- a/src/OpenClaw.Gateway/Composition/ChannelServicesExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/ChannelServicesExtensions.cs
@@ -37,6 +37,13 @@ internal static class ChannelServicesExtensions
         {
             services.AddSingleton(config.Channels.Telegram);
             services.AddSingleton<TelegramChannel>();
+            services.AddSingleton<TelegramWebhookHandler>(sp =>
+                new TelegramWebhookHandler(
+                    config.Channels.Telegram,
+                    sp.GetRequiredService<OpenClaw.Core.Security.AllowlistManager>(),
+                    sp.GetRequiredService<OpenClaw.Core.Pipeline.RecentSendersStore>(),
+                    sp.GetRequiredService<OpenClaw.Core.Security.AllowlistSemantics>(),
+                    sp.GetRequiredService<ILogger<TelegramWebhookHandler>>()));
         }
 
         if (config.Channels.Teams.Enabled)

--- a/src/OpenClaw.Gateway/Endpoints/WebhookEndpoints.cs
+++ b/src/OpenClaw.Gateway/Endpoints/WebhookEndpoints.cs
@@ -103,6 +103,7 @@ internal static class WebhookEndpoints
 
         if (startup.Config.Channels.Telegram.Enabled)
         {
+            var telegramWebhookHandler = app.Services.GetRequiredService<TelegramWebhookHandler>();
             byte[]? telegramSecretBytes = null;
             if (startup.Config.Channels.Telegram.ValidateSignature)
             {
@@ -141,11 +142,7 @@ internal static class WebhookEndpoints
                     return;
                 }
 
-                using var document = JsonDocument.Parse(bodyText, new JsonDocumentOptions { MaxDepth = 64 });
-                var root = document.RootElement;
-                var deliveryKey = root.TryGetProperty("update_id", out var updateId)
-                    ? updateId.GetRawText()
-                    : WebhookDeliveryStore.HashDeliveryKey(bodyText);
+                var deliveryKey = TelegramWebhookHandler.ResolveDeliveryKey(bodyText);
                 if (!deliveries.TryBegin("telegram", deliveryKey, TimeSpan.FromHours(6)))
                 {
                     ctx.Response.StatusCode = StatusCodes.Status200OK;
@@ -157,71 +154,21 @@ internal static class WebhookEndpoints
 
                 try
                 {
-                    if (root.TryGetProperty("message", out var message) &&
-                        message.TryGetProperty("chat", out var chat) &&
-                        chat.TryGetProperty("id", out var chatId))
+                    var response = await telegramWebhookHandler.HandleAsync(
+                        bodyText,
+                        (msg, ct) =>
+                        {
+                            replayMessage = msg;
+                            return runtime.Pipeline.InboundWriter.WriteAsync(msg, ct);
+                        },
+                        ctx.RequestAborted);
+
+                    ctx.Response.StatusCode = response.StatusCode;
+                    if (response.Body is not null)
                     {
-                        var senderIdStr = chatId.GetRawText();
-
-                        await runtime.RecentSenders.RecordAsync("telegram", senderIdStr, senderName: null, ctx.RequestAborted);
-
-                        var effective = runtime.Allowlists.GetEffective("telegram", new ChannelAllowlistFile
-                        {
-                            AllowedFrom = startup.Config.Channels.Telegram.AllowedFromUserIds
-                        });
-
-                        if (!AllowlistPolicy.IsAllowed(effective.AllowedFrom, senderIdStr, runtime.AllowlistSemantics))
-                        {
-                            ctx.Response.StatusCode = StatusCodes.Status403Forbidden;
-                            return;
-                        }
-
-                        string? text = null;
-                        if (message.TryGetProperty("text", out var textNode))
-                            text = textNode.GetString();
-
-                        string? marker = null;
-                        if (message.TryGetProperty("photo", out var photoNode) && photoNode.ValueKind == JsonValueKind.Array)
-                        {
-                            string? fileId = null;
-                            foreach (var photo in photoNode.EnumerateArray())
-                            {
-                                if (photo.TryGetProperty("file_id", out var idNode))
-                                    fileId = idNode.GetString();
-                            }
-
-                            if (!string.IsNullOrWhiteSpace(fileId))
-                                marker = $"[IMAGE:telegram:file_id={fileId}]";
-                        }
-
-                        if (!string.IsNullOrWhiteSpace(marker))
-                        {
-                            var caption = message.TryGetProperty("caption", out var capNode) ? capNode.GetString() : null;
-                            text = string.IsNullOrWhiteSpace(caption) ? marker : marker + "\n" + caption;
-                        }
-
-                        if (!string.IsNullOrWhiteSpace(text) && text.Length > startup.Config.Channels.Telegram.MaxInboundChars)
-                            text = text[..startup.Config.Channels.Telegram.MaxInboundChars];
-
-                        if (string.IsNullOrWhiteSpace(text))
-                        {
-                            ctx.Response.StatusCode = StatusCodes.Status200OK;
-                            await ctx.Response.WriteAsync("OK");
-                            return;
-                        }
-
-                        replayMessage = new InboundMessage
-                        {
-                            ChannelId = "telegram",
-                            SenderId = senderIdStr,
-                            Text = text
-                        };
-
-                        await runtime.Pipeline.InboundWriter.WriteAsync(replayMessage, ctx.RequestAborted);
+                        ctx.Response.ContentType = response.ContentType;
+                        await ctx.Response.WriteAsync(response.Body, ctx.RequestAborted);
                     }
-
-                    ctx.Response.StatusCode = StatusCodes.Status200OK;
-                    await ctx.Response.WriteAsync("OK");
                 }
                 catch (Exception ex)
                 {

--- a/src/OpenClaw.Gateway/TelegramWebhookHandler.cs
+++ b/src/OpenClaw.Gateway/TelegramWebhookHandler.cs
@@ -116,10 +116,13 @@ internal sealed class TelegramWebhookHandler
 
     private static bool TryGetMessage(JsonElement root, out JsonElement message)
     {
-        foreach (var propertyName in new[] { "message", "channel_post", "edited_message", "edited_channel_post" })
+        var propertyName = new[] { "message", "channel_post", "edited_message", "edited_channel_post" }
+            .Where(name => root.TryGetProperty(name, out _))
+            .FirstOrDefault();
+
+        if (propertyName is not null && root.TryGetProperty(propertyName, out message))
         {
-            if (root.TryGetProperty(propertyName, out message))
-                return true;
+            return true;
         }
 
         message = default;
@@ -147,12 +150,10 @@ internal sealed class TelegramWebhookHandler
     {
         if (message.TryGetProperty("photo", out var photoNode) && photoNode.ValueKind == JsonValueKind.Array)
         {
-            string? fileId = null;
-            foreach (var photo in photoNode.EnumerateArray())
-            {
-                if (photo.TryGetProperty("file_id", out var idNode))
-                    fileId = idNode.GetString();
-            }
+            var fileId = photoNode.EnumerateArray()
+                .Where(static photo => photo.TryGetProperty("file_id", out _))
+                .Select(static photo => photo.GetProperty("file_id").GetString())
+                .LastOrDefault(static id => !string.IsNullOrWhiteSpace(id));
 
             return string.IsNullOrWhiteSpace(fileId) ? null : $"[IMAGE:telegram:file_id={fileId}]";
         }

--- a/src/OpenClaw.Gateway/TelegramWebhookHandler.cs
+++ b/src/OpenClaw.Gateway/TelegramWebhookHandler.cs
@@ -1,0 +1,250 @@
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Pipeline;
+using OpenClaw.Core.Security;
+
+namespace OpenClaw.Gateway;
+
+internal sealed class TelegramWebhookHandler
+{
+    private readonly TelegramChannelConfig _config;
+    private readonly AllowlistManager _allowlists;
+    private readonly RecentSendersStore _recentSenders;
+    private readonly AllowlistSemantics _allowlistSemantics;
+    private readonly ILogger<TelegramWebhookHandler> _logger;
+
+    public TelegramWebhookHandler(
+        TelegramChannelConfig config,
+        AllowlistManager allowlists,
+        RecentSendersStore recentSenders,
+        AllowlistSemantics allowlistSemantics,
+        ILogger<TelegramWebhookHandler> logger)
+    {
+        _config = config;
+        _allowlists = allowlists;
+        _recentSenders = recentSenders;
+        _allowlistSemantics = allowlistSemantics;
+        _logger = logger;
+    }
+
+    public static string ResolveDeliveryKey(string bodyText)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(bodyText, new JsonDocumentOptions { MaxDepth = 64 });
+            return document.RootElement.TryGetProperty("update_id", out var updateId)
+                ? updateId.GetRawText()
+                : WebhookDeliveryStore.HashDeliveryKey(bodyText);
+        }
+        catch (JsonException)
+        {
+            return WebhookDeliveryStore.HashDeliveryKey(bodyText);
+        }
+    }
+
+    public async ValueTask<WebhookResult> HandleAsync(
+        string bodyText,
+        Func<InboundMessage, CancellationToken, ValueTask> enqueue,
+        CancellationToken ct)
+    {
+        using var document = ParseBody(bodyText);
+        if (document is null)
+            return WebhookResult.BadRequest("Invalid JSON");
+
+        var root = document.RootElement;
+        if (!TryGetMessage(root, out var message))
+            return Ok();
+
+        if (!message.TryGetProperty("chat", out var chat) ||
+            !chat.TryGetProperty("id", out var chatIdNode))
+        {
+            return Ok();
+        }
+
+        var senderId = GetTelegramId(chatIdNode);
+        if (string.IsNullOrWhiteSpace(senderId))
+            return Ok();
+
+        var senderName = GetSenderName(message, chat);
+        await _recentSenders.RecordAsync("telegram", senderId, senderName, ct);
+
+        var effective = _allowlists.GetEffective("telegram", new ChannelAllowlistFile
+        {
+            AllowedFrom = _config.AllowedFromUserIds
+        });
+
+        if (!AllowlistPolicy.IsAllowed(effective.AllowedFrom, senderId, _allowlistSemantics))
+        {
+            _logger.LogInformation("Rejected Telegram update from blocked chat {ChatId}.", senderId);
+            return WebhookResult.Status(StatusCodes.Status403Forbidden);
+        }
+
+        var text = BuildText(message);
+        if (!string.IsNullOrWhiteSpace(text) && text.Length > _config.MaxInboundChars)
+            text = text[.._config.MaxInboundChars];
+
+        if (string.IsNullOrWhiteSpace(text))
+            return Ok();
+
+        var inbound = new InboundMessage
+        {
+            ChannelId = "telegram",
+            SenderId = senderId,
+            SenderName = senderName,
+            Text = text,
+            MessageId = GetOptionalIntString(message, "message_id"),
+            ReplyToMessageId = TryGetReplyToMessageId(message)
+        };
+
+        await enqueue(inbound, ct);
+        return Ok();
+    }
+
+    private static JsonDocument? ParseBody(string bodyText)
+    {
+        try
+        {
+            return JsonDocument.Parse(bodyText, new JsonDocumentOptions { MaxDepth = 64 });
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static bool TryGetMessage(JsonElement root, out JsonElement message)
+    {
+        foreach (var propertyName in new[] { "message", "channel_post", "edited_message", "edited_channel_post" })
+        {
+            if (root.TryGetProperty(propertyName, out message))
+                return true;
+        }
+
+        message = default;
+        return false;
+    }
+
+    private static string? BuildText(JsonElement message)
+    {
+        var text = message.TryGetProperty("text", out var textNode)
+            ? textNode.GetString()
+            : null;
+
+        var marker = TryBuildMediaMarker(message);
+        if (string.IsNullOrWhiteSpace(marker))
+            return text;
+
+        var caption = message.TryGetProperty("caption", out var captionNode)
+            ? captionNode.GetString()
+            : null;
+
+        return string.IsNullOrWhiteSpace(caption) ? marker : marker + "\n" + caption;
+    }
+
+    private static string? TryBuildMediaMarker(JsonElement message)
+    {
+        if (message.TryGetProperty("photo", out var photoNode) && photoNode.ValueKind == JsonValueKind.Array)
+        {
+            string? fileId = null;
+            foreach (var photo in photoNode.EnumerateArray())
+            {
+                if (photo.TryGetProperty("file_id", out var idNode))
+                    fileId = idNode.GetString();
+            }
+
+            return string.IsNullOrWhiteSpace(fileId) ? null : $"[IMAGE:telegram:file_id={fileId}]";
+        }
+
+        if (TryGetFileId(message, "video", out var videoFileId))
+            return $"[VIDEO:telegram:file_id={videoFileId}]";
+
+        if (TryGetFileId(message, "audio", out var audioFileId) ||
+            TryGetFileId(message, "voice", out audioFileId))
+        {
+            return $"[AUDIO:telegram:file_id={audioFileId}]";
+        }
+
+        if (TryGetFileId(message, "document", out var documentFileId))
+            return $"[DOCUMENT:telegram:file_id={documentFileId}]";
+
+        if (TryGetFileId(message, "sticker", out var stickerFileId))
+            return $"[STICKER:telegram:file_id={stickerFileId}]";
+
+        return null;
+    }
+
+    private static bool TryGetFileId(JsonElement message, string propertyName, out string fileId)
+    {
+        fileId = "";
+        if (!message.TryGetProperty(propertyName, out var media) ||
+            !media.TryGetProperty("file_id", out var fileIdNode))
+        {
+            return false;
+        }
+
+        fileId = fileIdNode.GetString() ?? "";
+        return !string.IsNullOrWhiteSpace(fileId);
+    }
+
+    private static string? GetSenderName(JsonElement message, JsonElement chat)
+    {
+        if (message.TryGetProperty("from", out var from))
+        {
+            var userName = GetUserDisplayName(from);
+            if (!string.IsNullOrWhiteSpace(userName))
+                return userName;
+        }
+
+        if (chat.TryGetProperty("title", out var titleNode))
+        {
+            var title = titleNode.GetString();
+            if (!string.IsNullOrWhiteSpace(title))
+                return title;
+        }
+
+        return GetUserDisplayName(chat);
+    }
+
+    private static string? GetUserDisplayName(JsonElement user)
+    {
+        if (user.TryGetProperty("username", out var usernameNode))
+        {
+            var username = usernameNode.GetString();
+            if (!string.IsNullOrWhiteSpace(username))
+                return username.StartsWith('@') ? username : "@" + username;
+        }
+
+        var firstName = user.TryGetProperty("first_name", out var firstNameNode) ? firstNameNode.GetString() : null;
+        var lastName = user.TryGetProperty("last_name", out var lastNameNode) ? lastNameNode.GetString() : null;
+        var fullName = string.Join(" ", new[] { firstName, lastName }.Where(static part => !string.IsNullOrWhiteSpace(part)));
+        return string.IsNullOrWhiteSpace(fullName) ? null : fullName;
+    }
+
+    private static string? TryGetReplyToMessageId(JsonElement message)
+    {
+        if (!message.TryGetProperty("reply_to_message", out var reply) ||
+            !reply.TryGetProperty("message_id", out var messageId))
+        {
+            return null;
+        }
+
+        return GetTelegramId(messageId);
+    }
+
+    private static string? GetOptionalIntString(JsonElement obj, string propertyName)
+        => obj.TryGetProperty(propertyName, out var value) ? GetTelegramId(value) : null;
+
+    private static string GetTelegramId(JsonElement node)
+    {
+        return node.ValueKind switch
+        {
+            JsonValueKind.Number when node.TryGetInt64(out var value) => value.ToString(CultureInfo.InvariantCulture),
+            JsonValueKind.String => node.GetString() ?? "",
+            _ => node.GetRawText()
+        };
+    }
+
+    private static WebhookResult Ok() => new(StatusCodes.Status200OK, "text/plain; charset=utf-8", "OK");
+}

--- a/src/OpenClaw.Gateway/WhatsAppWebhookHandler.cs
+++ b/src/OpenClaw.Gateway/WhatsAppWebhookHandler.cs
@@ -242,12 +242,10 @@ internal sealed class WhatsAppWebhookHandler
         var lines = new List<string>();
         if (payload.Attachments is { Length: > 0 })
         {
-            foreach (var attachment in payload.Attachments)
-            {
-                var marker = BuildMediaMarker(attachment.Type, attachment.Url);
-                if (!string.IsNullOrWhiteSpace(marker))
-                    lines.Add(marker);
-            }
+            lines.AddRange(payload.Attachments
+                .Select(static attachment => BuildMediaMarker(attachment.Type, attachment.Url))
+                .Where(static marker => !string.IsNullOrWhiteSpace(marker))
+                .Select(static marker => marker!));
         }
         else
         {

--- a/src/OpenClaw.Gateway/WhatsAppWebhookHandler.cs
+++ b/src/OpenClaw.Gateway/WhatsAppWebhookHandler.cs
@@ -206,6 +206,7 @@ internal sealed class WhatsAppWebhookHandler
                 text = text[.._config.MaxInboundChars];
             }
 
+            var primaryMedia = ResolvePrimaryBridgeMedia(payload);
             var msg = new InboundMessage
             {
                 ChannelId = "whatsapp",
@@ -220,10 +221,10 @@ internal sealed class WhatsAppWebhookHandler
                 GroupId = payload.GroupId,
                 GroupName = payload.GroupName,
                 MentionedIds = payload.MentionedIds,
-                MediaType = payload.MediaType,
-                MediaUrl = payload.MediaUrl,
-                MediaMimeType = payload.MediaMimeType,
-                MediaFileName = payload.MediaFileName
+                MediaType = primaryMedia.Type,
+                MediaUrl = primaryMedia.Url,
+                MediaMimeType = primaryMedia.MimeType,
+                MediaFileName = primaryMedia.FileName
             };
 
             await enqueue(msg, ct);
@@ -271,12 +272,33 @@ internal sealed class WhatsAppWebhookHandler
             "image" => $"[IMAGE_URL:{mediaUrl}]",
             "video" => $"[VIDEO_URL:{mediaUrl}]",
             "audio" => $"[AUDIO_URL:{mediaUrl}]",
-            "document" => $"[DOCUMENT_URL:{mediaUrl}]",
+            "document" => $"[FILE_URL:{mediaUrl}]",
             "file" => $"[FILE_URL:{mediaUrl}]",
             "sticker" => $"[STICKER_URL:{mediaUrl}]",
             _ => $"[FILE_URL:{mediaUrl}]"
         };
     }
+
+    private static BridgeMediaInfo ResolvePrimaryBridgeMedia(WhatsAppBridgeInboundPayload payload)
+    {
+        if (!string.IsNullOrWhiteSpace(payload.MediaType) || !string.IsNullOrWhiteSpace(payload.MediaUrl))
+        {
+            return new BridgeMediaInfo(
+                payload.MediaType,
+                payload.MediaUrl,
+                payload.MediaMimeType,
+                payload.MediaFileName);
+        }
+
+        var attachment = payload.Attachments?.FirstOrDefault(static item =>
+            !string.IsNullOrWhiteSpace(item.Type) || !string.IsNullOrWhiteSpace(item.Url));
+
+        return attachment is null
+            ? default
+            : new BridgeMediaInfo(attachment.Type, attachment.Url, attachment.MimeType, attachment.FileName);
+    }
+
+    private readonly record struct BridgeMediaInfo(string? Type, string? Url, string? MimeType, string? FileName);
 
     private static async Task<byte[]?> ReadBodyWithLimitAsync(HttpContext context, int maxBytes, CancellationToken ct)
     {

--- a/src/OpenClaw.Gateway/WhatsAppWebhookHandler.cs
+++ b/src/OpenClaw.Gateway/WhatsAppWebhookHandler.cs
@@ -196,7 +196,10 @@ internal sealed class WhatsAppWebhookHandler
             if (!AllowlistPolicy.IsAllowed(effective.AllowedFrom, payload.From, _allowlistSemantics))
                 return WebhookResult.Unauthorized();
 
-            var text = payload.Text ?? "";
+            var text = BuildBridgeInboundText(payload);
+            if (string.IsNullOrWhiteSpace(text))
+                return WebhookResult.Ok();
+
             if (text.Length > _config.MaxInboundChars)
             {
                 _logger.LogWarning("Truncating WhatsApp Bridge message from {Sender} (exceeds {Max} chars).", payload.From, _config.MaxInboundChars);
@@ -208,8 +211,19 @@ internal sealed class WhatsAppWebhookHandler
                 ChannelId = "whatsapp",
                 SenderId = payload.From,
                 Text = text,
+                AccountId = payload.AccountId,
+                SessionId = payload.SessionId,
                 SenderName = payload.SenderName,
-                MessageId = payload.MessageId
+                MessageId = payload.MessageId,
+                ReplyToMessageId = payload.ReplyToMessageId,
+                IsGroup = payload.IsGroup,
+                GroupId = payload.GroupId,
+                GroupName = payload.GroupName,
+                MentionedIds = payload.MentionedIds,
+                MediaType = payload.MediaType,
+                MediaUrl = payload.MediaUrl,
+                MediaMimeType = payload.MediaMimeType,
+                MediaFileName = payload.MediaFileName
             };
 
             await enqueue(msg, ct);
@@ -220,6 +234,48 @@ internal sealed class WhatsAppWebhookHandler
             _logger.LogError(ex, "Failed to parse WhatsApp Bridge webhook.");
             return WebhookResult.BadRequest("Invalid JSON");
         }
+    }
+
+    private static string BuildBridgeInboundText(WhatsAppBridgeInboundPayload payload)
+    {
+        var lines = new List<string>();
+        if (payload.Attachments is { Length: > 0 })
+        {
+            foreach (var attachment in payload.Attachments)
+            {
+                var marker = BuildMediaMarker(attachment.Type, attachment.Url);
+                if (!string.IsNullOrWhiteSpace(marker))
+                    lines.Add(marker);
+            }
+        }
+        else
+        {
+            var marker = BuildMediaMarker(payload.MediaType, payload.MediaUrl);
+            if (!string.IsNullOrWhiteSpace(marker))
+                lines.Add(marker);
+        }
+
+        if (!string.IsNullOrWhiteSpace(payload.Text))
+            lines.Add(payload.Text);
+
+        return string.Join('\n', lines);
+    }
+
+    private static string? BuildMediaMarker(string? mediaType, string? mediaUrl)
+    {
+        if (string.IsNullOrWhiteSpace(mediaType) || string.IsNullOrWhiteSpace(mediaUrl))
+            return null;
+
+        return mediaType.Trim().ToLowerInvariant() switch
+        {
+            "image" => $"[IMAGE_URL:{mediaUrl}]",
+            "video" => $"[VIDEO_URL:{mediaUrl}]",
+            "audio" => $"[AUDIO_URL:{mediaUrl}]",
+            "document" => $"[DOCUMENT_URL:{mediaUrl}]",
+            "file" => $"[FILE_URL:{mediaUrl}]",
+            "sticker" => $"[STICKER_URL:{mediaUrl}]",
+            _ => $"[FILE_URL:{mediaUrl}]"
+        };
     }
 
     private static async Task<byte[]?> ReadBodyWithLimitAsync(HttpContext context, int maxBytes, CancellationToken ct)

--- a/src/OpenClaw.Tests/ChannelAdapterSecurityTests.cs
+++ b/src/OpenClaw.Tests/ChannelAdapterSecurityTests.cs
@@ -386,7 +386,7 @@ public sealed class ChannelAdapterSecurityTests
     [Fact]
     public async Task WhatsAppWebhookHandler_BridgeWebhookMapsMediaAndGroupMetadata()
     {
-        var root = Path.Combine(Path.Combine(Path.GetTempPath(), "openclaw-tests"), Guid.NewGuid().ToString("N"));
+        var root = Path.Join(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         try
         {
@@ -468,7 +468,7 @@ public sealed class ChannelAdapterSecurityTests
     [Fact]
     public async Task WhatsAppWebhookHandler_BridgeAttachmentDerivesPrimaryMediaMetadata()
     {
-        var root = Path.Combine(Path.Combine(Path.GetTempPath(), "openclaw-tests"), Guid.NewGuid().ToString("N"));
+        var root = Path.Join(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         try
         {

--- a/src/OpenClaw.Tests/ChannelAdapterSecurityTests.cs
+++ b/src/OpenClaw.Tests/ChannelAdapterSecurityTests.cs
@@ -386,7 +386,7 @@ public sealed class ChannelAdapterSecurityTests
     [Fact]
     public async Task WhatsAppWebhookHandler_BridgeWebhookMapsMediaAndGroupMetadata()
     {
-        var root = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
+        var root = Path.Combine(Path.Combine(Path.GetTempPath(), "openclaw-tests"), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         try
         {
@@ -468,7 +468,7 @@ public sealed class ChannelAdapterSecurityTests
     [Fact]
     public async Task WhatsAppWebhookHandler_BridgeAttachmentDerivesPrimaryMediaMetadata()
     {
-        var root = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
+        var root = Path.Combine(Path.Combine(Path.GetTempPath(), "openclaw-tests"), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         try
         {

--- a/src/OpenClaw.Tests/ChannelAdapterSecurityTests.cs
+++ b/src/OpenClaw.Tests/ChannelAdapterSecurityTests.cs
@@ -465,6 +465,66 @@ public sealed class ChannelAdapterSecurityTests
         }
     }
 
+    [Fact]
+    public async Task WhatsAppWebhookHandler_BridgeAttachmentDerivesPrimaryMediaMetadata()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var handler = new WhatsAppWebhookHandler(
+                new WhatsAppChannelConfig
+                {
+                    Enabled = true,
+                    Type = "bridge"
+                },
+                new AllowlistManager(root, NullLogger<AllowlistManager>.Instance),
+                new RecentSendersStore(root, NullLogger<RecentSendersStore>.Instance),
+                AllowlistSemantics.Legacy,
+                NullLogger<WhatsAppWebhookHandler>.Instance);
+
+            var context = new DefaultHttpContext();
+            context.Request.Method = HttpMethods.Post;
+            context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(
+                """
+                {
+                  "from": "15551234567@s.whatsapp.net",
+                  "text": "document caption",
+                  "attachments": [
+                    {
+                      "type": "document",
+                      "url": "https://cdn.example.test/report.pdf",
+                      "mimeType": "application/pdf",
+                      "fileName": "report.pdf"
+                    }
+                  ]
+                }
+                """));
+
+            InboundMessage? captured = null;
+            var result = await handler.HandleAsync(
+                context,
+                (message, _) =>
+                {
+                    captured = message;
+                    return ValueTask.CompletedTask;
+                },
+                CancellationToken.None);
+
+            Assert.Equal(200, result.StatusCode);
+            Assert.NotNull(captured);
+            Assert.Equal("[FILE_URL:https://cdn.example.test/report.pdf]\ndocument caption", captured!.Text);
+            Assert.Equal("document", captured.MediaType);
+            Assert.Equal("https://cdn.example.test/report.pdf", captured.MediaUrl);
+            Assert.Equal("application/pdf", captured.MediaMimeType);
+            Assert.Equal("report.pdf", captured.MediaFileName);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     private sealed class CallbackHandler(Func<HttpRequestMessage, HttpResponseMessage> callback) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/OpenClaw.Tests/ChannelAdapterSecurityTests.cs
+++ b/src/OpenClaw.Tests/ChannelAdapterSecurityTests.cs
@@ -383,6 +383,88 @@ public sealed class ChannelAdapterSecurityTests
         }
     }
 
+    [Fact]
+    public async Task WhatsAppWebhookHandler_BridgeWebhookMapsMediaAndGroupMetadata()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var recentSenders = new RecentSendersStore(root, NullLogger<RecentSendersStore>.Instance);
+            var allowlists = new AllowlistManager(root, NullLogger<AllowlistManager>.Instance);
+            var handler = new WhatsAppWebhookHandler(
+                new WhatsAppChannelConfig
+                {
+                    Enabled = true,
+                    Type = "bridge",
+                    BridgeToken = "bridge-secret"
+                },
+                allowlists,
+                recentSenders,
+                AllowlistSemantics.Legacy,
+                NullLogger<WhatsAppWebhookHandler>.Instance);
+
+            var body =
+                """
+                {
+                  "from": "15551234567@s.whatsapp.net",
+                  "account_id": "business",
+                  "session_id": "whatsapp:group:team@g.us",
+                  "sender_name": "Alice",
+                  "text": "caption",
+                  "message_id": "wamid-2",
+                  "reply_to_message_id": "wamid-1",
+                  "is_group": true,
+                  "group_id": "team@g.us",
+                  "group_name": "Team",
+                  "mentioned_ids": ["bot@s.whatsapp.net"],
+                  "media_type": "image",
+                  "media_url": "https://cdn.example.test/cat.jpg",
+                  "media_mime_type": "image/jpeg",
+                  "media_file_name": "cat.jpg"
+                }
+                """;
+
+            var context = new DefaultHttpContext();
+            context.Request.Method = HttpMethods.Post;
+            context.Request.Headers.Authorization = "Bearer bridge-secret";
+            context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+
+            InboundMessage? captured = null;
+            var result = await handler.HandleAsync(
+                context,
+                (message, _) =>
+                {
+                    captured = message;
+                    return ValueTask.CompletedTask;
+                },
+                CancellationToken.None);
+
+            Assert.Equal(200, result.StatusCode);
+            Assert.NotNull(captured);
+            Assert.Equal("15551234567@s.whatsapp.net", captured!.SenderId);
+            Assert.Equal("business", captured.AccountId);
+            Assert.Equal("whatsapp:group:team@g.us", captured.SessionId);
+            Assert.Equal("Alice", captured.SenderName);
+            Assert.Equal("[IMAGE_URL:https://cdn.example.test/cat.jpg]\ncaption", captured.Text);
+            Assert.Equal("wamid-2", captured.MessageId);
+            Assert.Equal("wamid-1", captured.ReplyToMessageId);
+            Assert.True(captured.IsGroup);
+            Assert.Equal("team@g.us", captured.GroupId);
+            Assert.Equal("Team", captured.GroupName);
+            Assert.NotNull(captured.MentionedIds);
+            Assert.Equal(["bot@s.whatsapp.net"], captured.MentionedIds!);
+            Assert.Equal("image", captured.MediaType);
+            Assert.Equal("https://cdn.example.test/cat.jpg", captured.MediaUrl);
+            Assert.Equal("image/jpeg", captured.MediaMimeType);
+            Assert.Equal("cat.jpg", captured.MediaFileName);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     private sealed class CallbackHandler(Func<HttpRequestMessage, HttpResponseMessage> callback) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/OpenClaw.Tests/MediaMarkerProtocolTests.cs
+++ b/src/OpenClaw.Tests/MediaMarkerProtocolTests.cs
@@ -30,5 +30,16 @@ public sealed class MediaMarkerProtocolTests
         Assert.Equal(MediaMarkerKind.TelegramImageFileId, marker.Kind);
         Assert.Equal("abc123", marker.Value);
     }
-}
 
+    [Theory]
+    [InlineData("[VIDEO:telegram:file_id=vid123]", MediaMarkerKind.TelegramVideoFileId, "vid123")]
+    [InlineData("[AUDIO:telegram:file_id=aud123]", MediaMarkerKind.TelegramAudioFileId, "aud123")]
+    [InlineData("[DOCUMENT:telegram:file_id=doc123]", MediaMarkerKind.TelegramDocumentFileId, "doc123")]
+    [InlineData("[STICKER:telegram:file_id=stk123]", MediaMarkerKind.TelegramStickerFileId, "stk123")]
+    public void TryParseMarker_ParsesTelegramMediaFileIds(string input, MediaMarkerKind expectedKind, string expectedValue)
+    {
+        Assert.True(MediaMarkerProtocol.TryParseMarker(input, out var marker));
+        Assert.Equal(expectedKind, marker.Kind);
+        Assert.Equal(expectedValue, marker.Value);
+    }
+}

--- a/src/OpenClaw.Tests/PluginBridgeIntegrationTests.cs
+++ b/src/OpenClaw.Tests/PluginBridgeIntegrationTests.cs
@@ -1302,6 +1302,18 @@ public sealed class PluginBridgeIntegrationTests : IDisposable
         Assert.Equal("image", attachment.GetProperty("type").GetString());
         Assert.Equal("https://cdn.example/image.png", attachment.GetProperty("url").GetString());
 
+        File.Delete(sendPath);
+        await adapter.SendAsync(new OutboundMessage
+        {
+            ChannelId = "whatsapp",
+            RecipientId = "group-1@wa",
+            Text = "[DOCUMENT:telegram:file_id=doc123]\nkeep marker as text"
+        }, CancellationToken.None);
+
+        sendPayload = JsonDocument.Parse(await WaitForFileTextAsync(sendPath, TimeSpan.FromSeconds(5))).RootElement;
+        Assert.Equal("[DOCUMENT:telegram:file_id=doc123]\nkeep marker as text", sendPayload.GetProperty("text").GetString());
+        Assert.Equal(JsonValueKind.Null, sendPayload.GetProperty("attachments").ValueKind);
+
         var typingPayload = JsonDocument.Parse(await WaitForFileTextAsync(typingPath, TimeSpan.FromSeconds(5))).RootElement;
         Assert.Equal("acc-1", typingPayload.GetProperty("accountId").GetString());
         Assert.Equal("group-1@wa", typingPayload.GetProperty("recipientId").GetString());

--- a/src/OpenClaw.Tests/TelegramChannelTests.cs
+++ b/src/OpenClaw.Tests/TelegramChannelTests.cs
@@ -210,7 +210,7 @@ public sealed class TelegramChannelTests
     [Fact]
     public async Task TelegramWebhookHandler_ChannelPost_EnqueuesChatMessage()
     {
-        var root = Path.Combine(Path.Combine(Path.GetTempPath(), "openclaw-tests"), Guid.NewGuid().ToString("N"));
+        var root = Path.Join(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         try
         {
@@ -264,7 +264,7 @@ public sealed class TelegramChannelTests
     [Fact]
     public async Task TelegramWebhookHandler_InvalidJson_ReturnsBadRequest()
     {
-        var root = Path.Combine(Path.Combine(Path.GetTempPath(), "openclaw-tests"), Guid.NewGuid().ToString("N"));
+        var root = Path.Join(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         try
         {

--- a/src/OpenClaw.Tests/TelegramChannelTests.cs
+++ b/src/OpenClaw.Tests/TelegramChannelTests.cs
@@ -177,6 +177,37 @@ public sealed class TelegramChannelTests
     }
 
     [Fact]
+    public async Task SendAsync_BareUsername_DoesNotCallTelegramApi()
+    {
+        var called = false;
+        using var http = new HttpClient(new CallbackHandler(_ =>
+        {
+            called = true;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }));
+
+        await using var channel = new TelegramChannel(
+            new TelegramChannelConfig
+            {
+                Enabled = true,
+                BotTokenRef = "raw:test-token"
+            },
+            NullLogger<TelegramChannel>.Instance,
+            http);
+
+        await channel.SendAsync(
+            new OutboundMessage
+            {
+                ChannelId = "telegram",
+                RecipientId = "openclaw_updates",
+                Text = "hello"
+            },
+            CancellationToken.None);
+
+        Assert.False(called);
+    }
+
+    [Fact]
     public async Task TelegramWebhookHandler_ChannelPost_EnqueuesChatMessage()
     {
         var root = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));

--- a/src/OpenClaw.Tests/TelegramChannelTests.cs
+++ b/src/OpenClaw.Tests/TelegramChannelTests.cs
@@ -210,7 +210,7 @@ public sealed class TelegramChannelTests
     [Fact]
     public async Task TelegramWebhookHandler_ChannelPost_EnqueuesChatMessage()
     {
-        var root = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
+        var root = Path.Combine(Path.Combine(Path.GetTempPath(), "openclaw-tests"), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         try
         {
@@ -264,7 +264,7 @@ public sealed class TelegramChannelTests
     [Fact]
     public async Task TelegramWebhookHandler_InvalidJson_ReturnsBadRequest()
     {
-        var root = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
+        var root = Path.Combine(Path.Combine(Path.GetTempPath(), "openclaw-tests"), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
         try
         {

--- a/src/OpenClaw.Tests/TelegramChannelTests.cs
+++ b/src/OpenClaw.Tests/TelegramChannelTests.cs
@@ -1,6 +1,12 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenClaw.Channels;
 using OpenClaw.Core.Models;
+using OpenClaw.Core.Pipeline;
+using OpenClaw.Core.Security;
+using OpenClaw.Gateway;
 using Xunit;
 
 namespace OpenClaw.Tests;
@@ -44,5 +50,213 @@ public sealed class TelegramChannelTests
         {
             Environment.SetEnvironmentVariable(envName, null);
         }
+    }
+
+    [Fact]
+    public async Task SendAsync_ChannelUsernameAndDocumentMarker_SendsDocumentWithReply()
+    {
+        var requests = new List<(string Url, string Body)>();
+        using var http = new HttpClient(new CallbackHandler(request =>
+        {
+            requests.Add((request.RequestUri!.ToString(), request.Content!.ReadAsStringAsync().GetAwaiter().GetResult()));
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }));
+
+        await using var channel = new TelegramChannel(
+            new TelegramChannelConfig
+            {
+                Enabled = true,
+                BotTokenRef = "raw:test-token"
+            },
+            NullLogger<TelegramChannel>.Instance,
+            http);
+
+        await channel.SendAsync(
+            new OutboundMessage
+            {
+                ChannelId = "telegram",
+                RecipientId = "@openclaw_updates",
+                Text = "[DOCUMENT_URL:https://cdn.example.test/report.pdf]\nReport ready",
+                ReplyToMessageId = "42"
+            },
+            CancellationToken.None);
+
+        var request = Assert.Single(requests);
+        Assert.EndsWith("/sendDocument", request.Url, StringComparison.Ordinal);
+
+        using var document = JsonDocument.Parse(request.Body);
+        var root = document.RootElement;
+        Assert.Equal("@openclaw_updates", root.GetProperty("chat_id").GetString());
+        Assert.Equal("https://cdn.example.test/report.pdf", root.GetProperty("document").GetString());
+        Assert.Equal("Report ready", root.GetProperty("caption").GetString());
+        Assert.Equal(42, root.GetProperty("reply_to_message_id").GetInt32());
+    }
+
+    [Fact]
+    public async Task SendAsync_LongMediaCaption_StaysWithinTelegramCaptionLimit()
+    {
+        var requests = new List<(string Url, string Body)>();
+        using var http = new HttpClient(new CallbackHandler(request =>
+        {
+            requests.Add((request.RequestUri!.ToString(), request.Content!.ReadAsStringAsync().GetAwaiter().GetResult()));
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }));
+
+        await using var channel = new TelegramChannel(
+            new TelegramChannelConfig
+            {
+                Enabled = true,
+                BotTokenRef = "raw:test-token"
+            },
+            NullLogger<TelegramChannel>.Instance,
+            http);
+
+        await channel.SendAsync(
+            new OutboundMessage
+            {
+                ChannelId = "telegram",
+                RecipientId = "-1001234567890",
+                Text = "[IMAGE_URL:https://cdn.example.test/cat.png]\n" + new string('a', 1030)
+            },
+            CancellationToken.None);
+
+        Assert.Equal(2, requests.Count);
+        Assert.EndsWith("/sendPhoto", requests[0].Url, StringComparison.Ordinal);
+        Assert.EndsWith("/sendMessage", requests[1].Url, StringComparison.Ordinal);
+
+        using var photoDocument = JsonDocument.Parse(requests[0].Body);
+        var caption = photoDocument.RootElement.GetProperty("caption").GetString();
+        Assert.NotNull(caption);
+        Assert.Equal(1024, caption!.Length);
+        Assert.EndsWith("…", caption, StringComparison.Ordinal);
+
+        using var messageDocument = JsonDocument.Parse(requests[1].Body);
+        Assert.False(messageDocument.RootElement.TryGetProperty("reply_to_message_id", out _));
+        Assert.Equal(-1001234567890, messageDocument.RootElement.GetProperty("chat_id").GetInt64());
+        Assert.False(string.IsNullOrWhiteSpace(messageDocument.RootElement.GetProperty("text").GetString()));
+    }
+
+    [Fact]
+    public async Task SendAsync_StickerWithText_SendsTextFollowUp()
+    {
+        var requests = new List<(string Url, string Body)>();
+        using var http = new HttpClient(new CallbackHandler(request =>
+        {
+            requests.Add((request.RequestUri!.ToString(), request.Content!.ReadAsStringAsync().GetAwaiter().GetResult()));
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }));
+
+        await using var channel = new TelegramChannel(
+            new TelegramChannelConfig
+            {
+                Enabled = true,
+                BotTokenRef = "raw:test-token"
+            },
+            NullLogger<TelegramChannel>.Instance,
+            http);
+
+        await channel.SendAsync(
+            new OutboundMessage
+            {
+                ChannelId = "telegram",
+                RecipientId = "12345",
+                Text = "[STICKER_URL:https://cdn.example.test/sticker.webp]\nsticker caption"
+            },
+            CancellationToken.None);
+
+        Assert.Equal(2, requests.Count);
+        Assert.EndsWith("/sendSticker", requests[0].Url, StringComparison.Ordinal);
+        Assert.EndsWith("/sendMessage", requests[1].Url, StringComparison.Ordinal);
+
+        using var stickerDocument = JsonDocument.Parse(requests[0].Body);
+        Assert.Equal("https://cdn.example.test/sticker.webp", stickerDocument.RootElement.GetProperty("sticker").GetString());
+        Assert.False(stickerDocument.RootElement.TryGetProperty("caption", out _));
+
+        using var messageDocument = JsonDocument.Parse(requests[1].Body);
+        Assert.Equal("sticker caption", messageDocument.RootElement.GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public async Task TelegramWebhookHandler_ChannelPost_EnqueuesChatMessage()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var handler = new TelegramWebhookHandler(
+                new TelegramChannelConfig
+                {
+                    Enabled = true,
+                    AllowedFromUserIds = ["-1001234567890"]
+                },
+                new AllowlistManager(root, NullLogger<AllowlistManager>.Instance),
+                new RecentSendersStore(root, NullLogger<RecentSendersStore>.Instance),
+                AllowlistSemantics.Strict,
+                NullLogger<TelegramWebhookHandler>.Instance);
+
+            InboundMessage? captured = null;
+            var result = await handler.HandleAsync(
+                """
+                {
+                  "update_id": 1000,
+                  "channel_post": {
+                    "message_id": 7,
+                    "chat": {
+                      "id": -1001234567890,
+                      "title": "OpenClaw Updates",
+                      "type": "channel"
+                    },
+                    "text": "hello channel"
+                  }
+                }
+                """,
+                (message, _) =>
+                {
+                    captured = message;
+                    return ValueTask.CompletedTask;
+                },
+                CancellationToken.None);
+
+            Assert.Equal(200, result.StatusCode);
+            Assert.NotNull(captured);
+            Assert.Equal("-1001234567890", captured!.SenderId);
+            Assert.Equal("OpenClaw Updates", captured.SenderName);
+            Assert.Equal("7", captured.MessageId);
+            Assert.Equal("hello channel", captured.Text);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task TelegramWebhookHandler_InvalidJson_ReturnsBadRequest()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var handler = new TelegramWebhookHandler(
+                new TelegramChannelConfig { Enabled = true },
+                new AllowlistManager(root, NullLogger<AllowlistManager>.Instance),
+                new RecentSendersStore(root, NullLogger<RecentSendersStore>.Instance),
+                AllowlistSemantics.Legacy,
+                NullLogger<TelegramWebhookHandler>.Instance);
+
+            var result = await handler.HandleAsync("{", (_, _) => ValueTask.CompletedTask, CancellationToken.None);
+
+            Assert.Equal(400, result.StatusCode);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private sealed class CallbackHandler(Func<HttpRequestMessage, HttpResponseMessage> callback) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(callback(request));
     }
 }


### PR DESCRIPTION
## Summary
- expand Telegram outbound support for channel usernames, media methods, reply ids, and Telegram text/caption limits
- route Telegram webhooks through a dedicated handler with channel_post, edited update, media file-id marker, allowlist, and invalid JSON handling
- carry WhatsApp bridge media, group, reply, account, and session metadata into inbound messages
- update media marker docs and add regression coverage

## Root Cause
Telegram handling was too narrow: outbound only accepted numeric chat IDs and photo media, while inbound parsing lived inline in the endpoint and ignored channel posts and several media types. WhatsApp bridge inbound payloads also dropped bridge metadata before entering the pipeline.

## Validation
- dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj --no-restore (1066 passed)
- node --check for whatsapp-baileys-worker .mjs files

## Notes
- Go whatsmeow worker tests were not run locally because go is not installed in this environment.
