### PR TITLE
Persist stable OpenAI sessions after request aborts

### DIFF
--- a/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/CoreServicesExtensions.cs
@@ -92,7 +92,11 @@ internal static class CoreServicesExtensions
             return memory as ISessionAdminStore
                 ?? throw new InvalidOperationException($"{memory.GetType().Name} must implement ISessionAdminStore.");
         });
-        services.AddSingleton<ISessionSearchStore>(sp => (ISessionSearchStore)sp.GetRequiredService<IMemoryStore>());
+        services.AddSingleton<ISessionSearchStore>(sp =>
+        {
+            var memory = sp.GetRequiredService<IMemoryStore>();
+            return memory as ISessionSearchStore ?? EmptySessionSearchStore.Instance;
+        });
         AddFeatureStores(services, config);
         services.AddSingleton<ProviderUsageTracker>();
         services.AddSingleton<ToolUsageTracker>();

--- a/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.ChatCompletions.cs
+++ b/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.ChatCompletions.cs
@@ -77,7 +77,7 @@ internal static partial class OpenAiEndpoints
                 ? await runtime.SessionManager.GetOrCreateByIdAsync(BuildScopedStableSessionId(stableBinding), "openai-http", requesterKey, ctx.RequestAborted)
                 : await runtime.SessionManager.GetOrCreateAsync("openai-http", requestId, ctx.RequestAborted);
             IAsyncDisposable? stableSessionLock = null;
-            var discardStableSessionOnExit = false;
+            var persistStableSessionOnExit = false;
             ToolApprovalCallback? approvalCallback = null;
 
             try
@@ -91,6 +91,8 @@ internal static partial class OpenAiEndpoints
                         await ctx.Response.WriteAsync(bindingError ?? "Stable session binding is inconsistent with the current requester scope.", ctx.RequestAborted);
                         return;
                     }
+
+                    persistStableSessionOnExit = true;
                 }
 
                 var httpMwCtx = new MessageContext
@@ -350,31 +352,14 @@ internal static partial class OpenAiEndpoints
                         ctx.RequestAborted);
                 }
             }
-            catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
-            {
-                discardStableSessionOnExit = !string.IsNullOrWhiteSpace(stableSessionId);
-                throw;
-            }
             finally
             {
-                if (!string.IsNullOrWhiteSpace(stableSessionId))
-                {
-                    if (discardStableSessionOnExit)
-                    {
-                        runtime.SessionManager.RemoveActive(session.Id);
-                    }
-                    else
-                    {
-                        await PersistStableSessionAsync(runtime.SessionManager, session, sessionLockHeld: stableSessionLock is not null);
-                    }
-
-                    if (stableSessionLock is not null)
-                        await stableSessionLock.DisposeAsync();
-                }
-                else
-                {
-                    runtime.SessionManager.RemoveActive(session.Id);
-                }
+                await FinalizeOpenAiSessionAsync(
+                    runtime.SessionManager,
+                    session,
+                    isStableSession: stableBinding is not null,
+                    persistStableSession: persistStableSessionOnExit,
+                    stableSessionLock);
             }
         });
     }

--- a/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.Responses.cs
+++ b/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.Responses.cs
@@ -66,7 +66,7 @@ internal static partial class OpenAiEndpoints
                 ? await runtime.SessionManager.GetOrCreateByIdAsync(BuildScopedStableSessionId(stableBinding), "openai-responses", requesterKey, ctx.RequestAborted)
                 : await runtime.SessionManager.GetOrCreateAsync("openai-responses", requestId, ctx.RequestAborted);
             IAsyncDisposable? stableSessionLock = null;
-            var discardStableSessionOnExit = false;
+            var persistStableSessionOnExit = false;
             ToolApprovalCallback? approvalCallback = null;
 
             try
@@ -80,6 +80,8 @@ internal static partial class OpenAiEndpoints
                         await ctx.Response.WriteAsync(bindingError ?? "Stable session binding is inconsistent with the current requester scope.", ctx.RequestAborted);
                         return;
                     }
+
+                    persistStableSessionOnExit = true;
                 }
 
                 var httpMwCtx = new MessageContext
@@ -557,7 +559,6 @@ internal static partial class OpenAiEndpoints
                     }
                     catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
                     {
-                        discardStableSessionOnExit = !string.IsNullOrWhiteSpace(stableSessionId);
                         throw;
                     }
                     catch (Exception)
@@ -597,31 +598,14 @@ internal static partial class OpenAiEndpoints
                         ctx.RequestAborted);
                 }
             }
-            catch (OperationCanceledException) when (ctx.RequestAborted.IsCancellationRequested)
-            {
-                discardStableSessionOnExit = !string.IsNullOrWhiteSpace(stableSessionId);
-                throw;
-            }
             finally
             {
-                if (!string.IsNullOrWhiteSpace(stableSessionId))
-                {
-                    if (discardStableSessionOnExit)
-                    {
-                        runtime.SessionManager.RemoveActive(session.Id);
-                    }
-                    else
-                    {
-                        await PersistStableSessionAsync(runtime.SessionManager, session, sessionLockHeld: stableSessionLock is not null);
-                    }
-
-                    if (stableSessionLock is not null)
-                        await stableSessionLock.DisposeAsync();
-                }
-                else
-                {
-                    runtime.SessionManager.RemoveActive(session.Id);
-                }
+                await FinalizeOpenAiSessionAsync(
+                    runtime.SessionManager,
+                    session,
+                    isStableSession: stableBinding is not null,
+                    persistStableSession: persistStableSessionOnExit,
+                    stableSessionLock);
             }
         });
     }

--- a/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.StableSessions.cs
+++ b/src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.StableSessions.cs
@@ -22,6 +22,33 @@ internal static partial class OpenAiEndpoints
         }
     }
 
+    private static async Task FinalizeOpenAiSessionAsync(
+        SessionManager sessionManager,
+        Session session,
+        bool isStableSession,
+        bool persistStableSession,
+        IAsyncDisposable? stableSessionLock)
+    {
+        try
+        {
+            if (!isStableSession)
+            {
+                sessionManager.RemoveActive(session.Id);
+                return;
+            }
+
+            if (persistStableSession)
+                await PersistStableSessionAsync(sessionManager, session, sessionLockHeld: stableSessionLock is not null);
+            else if (stableSessionLock is null && session.StableSessionBinding is null && session.History.Count == 0)
+                sessionManager.RemoveActive(session.Id);
+        }
+        finally
+        {
+            if (stableSessionLock is not null)
+                await stableSessionLock.DisposeAsync();
+        }
+    }
+
     private static bool TryGetOptionalStableSessionId(HttpContext ctx, out string? stableSessionId, out string? error)
     {
         stableSessionId = null;

--- a/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
+++ b/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
@@ -2118,6 +2118,56 @@ public sealed class GatewayAdminEndpointTests
     }
 
     [Fact]
+    public async Task ChatCompletions_StableSession_PersistsHistoryWhenRequestAborts()
+    {
+        await using var harness = await CreateHarnessAsync(nonLoopbackBind: true);
+        var agentEntered = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        harness.Runtime.AgentRuntime.RunAsync(
+                Arg.Any<Session>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<ToolApprovalCallback?>(),
+                Arg.Any<JsonElement?>())
+            .Returns(async callInfo =>
+            {
+                var session = callInfo.Arg<Session>();
+                var userMessage = callInfo.ArgAt<string>(1);
+                var ct = callInfo.ArgAt<CancellationToken>(2);
+                session.History.Add(new ChatTurn { Role = "user", Content = userMessage });
+                session.History.Add(new ChatTurn { Role = "assistant", Content = "partial before abort" });
+                agentEntered.TrySetResult(session.Id);
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                return "unreachable";
+            });
+
+        using var request = CreateStableChatCompletionRequest("stable-chat-abort", "hello", harness.AuthToken);
+        using var abortCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var responseTask = harness.Client.SendAsync(request, abortCts.Token);
+
+        var sessionId = await agentEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        abortCts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask.WaitAsync(TimeSpan.FromSeconds(2)));
+
+        var persisted = await WaitForPersistedSessionAsync(harness.MemoryStore, sessionId, TimeSpan.FromSeconds(2));
+        Assert.Equal("stable-chat-abort", persisted.StableSessionBinding?.ExternalSessionId);
+        Assert.Collection(
+            persisted.History,
+            turn =>
+            {
+                Assert.Equal("user", turn.Role);
+                Assert.Equal("hello", turn.Content);
+            },
+            turn =>
+            {
+                Assert.Equal("assistant", turn.Role);
+                Assert.Equal("partial before abort", turn.Content);
+            });
+
+        Assert.True(harness.Runtime.SessionManager.RemoveActive(sessionId));
+    }
+
+    [Fact]
     public async Task ChatCompletions_StableSession_RejectsUnsafeStableSessionId()
     {
         await using var harness = await CreateHarnessAsync(nonLoopbackBind: false);
@@ -2471,6 +2521,61 @@ public sealed class GatewayAdminEndpointTests
         var activeSession = await FindStableSessionAsync(harness, "stable-responses-save-failure");
         Assert.NotNull(activeSession);
         Assert.True(harness.Runtime.SessionManager.RemoveActive(activeSession!.Id));
+    }
+
+    [Fact]
+    public async Task Responses_StableSession_PersistsHistoryWhenRequestAborts()
+    {
+        await using var harness = await CreateHarnessAsync(nonLoopbackBind: true);
+        var agentEntered = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        harness.Runtime.AgentRuntime.RunAsync(
+                Arg.Any<Session>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<ToolApprovalCallback?>(),
+                Arg.Any<JsonElement?>())
+            .Returns(async callInfo =>
+            {
+                var session = callInfo.Arg<Session>();
+                var userMessage = callInfo.ArgAt<string>(1);
+                var ct = callInfo.ArgAt<CancellationToken>(2);
+                session.History.Add(new ChatTurn { Role = "user", Content = userMessage });
+                session.History.Add(new ChatTurn { Role = "assistant", Content = "partial response before abort" });
+                agentEntered.TrySetResult(session.Id);
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                return "unreachable";
+            });
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/responses")
+        {
+            Content = JsonContent("""{"input":"hello"}""")
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+        request.Headers.Add("X-OpenClaw-Session-Id", "stable-responses-abort");
+        using var abortCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var responseTask = harness.Client.SendAsync(request, abortCts.Token);
+
+        var sessionId = await agentEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        abortCts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask.WaitAsync(TimeSpan.FromSeconds(2)));
+
+        var persisted = await WaitForPersistedSessionAsync(harness.MemoryStore, sessionId, TimeSpan.FromSeconds(2));
+        Assert.Equal("stable-responses-abort", persisted.StableSessionBinding?.ExternalSessionId);
+        Assert.Collection(
+            persisted.History,
+            turn =>
+            {
+                Assert.Equal("user", turn.Role);
+                Assert.Equal("hello", turn.Content);
+            },
+            turn =>
+            {
+                Assert.Equal("assistant", turn.Role);
+                Assert.Equal("partial response before abort", turn.Content);
+            });
+
+        Assert.True(harness.Runtime.SessionManager.RemoveActive(sessionId));
     }
 
     [Fact]
@@ -4918,6 +5023,21 @@ public sealed class GatewayAdminEndpointTests
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         await using var sessionLock = await harness.Runtime.SessionManager.AcquireSessionLockAsync(sessionId, cts.Token);
+    }
+
+    private static async Task<Session> WaitForPersistedSessionAsync(IMemoryStore store, string sessionId, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var session = await store.GetSessionAsync(sessionId, CancellationToken.None);
+            if (session is not null)
+                return session;
+
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException($"Session '{sessionId}' was not persisted in time.");
     }
 
     private static void UpdateMax(ref int target, int value)

--- a/src/OpenClaw.Tests/PaymentRuntimeTests.cs
+++ b/src/OpenClaw.Tests/PaymentRuntimeTests.cs
@@ -70,7 +70,8 @@ public sealed class PaymentRuntimeTests
         Assert.Contains("4242", result, StringComparison.Ordinal);
         Assert.DoesNotContain("4242424242424242", result, StringComparison.Ordinal);
         Assert.DoesNotContain("\"cvv\"", result, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("123", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"cvv\":\"123\"", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("cvv: 123", result, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- persist accepted stable OpenAI sessions even when the client request aborts
- centralize OpenAI stable-session finalization shared by chat completions and responses
- fall back to empty session search for memory backends that do not implement ISessionSearchStore
- add regression coverage for chat completions and responses abort persistence

## Tests
- dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj --filter "FullyQualifiedName~GatewayAdminEndpointTests|FullyQualifiedName~CoreServicesExtensionsTests"