### PR TITLE
[codex] Add Microsoft.Extensions.AI provider bridge

### DIFF
--- a/OpenClaw.Net.slnx
+++ b/OpenClaw.Net.slnx
@@ -7,6 +7,7 @@
   <Folder Name="/samples/">
     <Project Path="samples/OpenClaw.DurableAgentReview/OpenClaw.DurableAgentReview.csproj" />
     <Project Path="samples/OpenClaw.HelloAgent/OpenClaw.HelloAgent.csproj" />
+    <Project Path="samples/OpenClaw.MicrosoftExtensionsAIProvider/OpenClaw.MicrosoftExtensionsAIProvider.csproj" />
     <Project Path="samples/OpenClaw.SemanticKernelInteropHost/OpenClaw.SemanticKernelInteropHost.csproj" />
   </Folder>
   <Folder Name="/src/">
@@ -16,6 +17,7 @@
     <Project Path="src/OpenClaw.Payments.Abstractions/OpenClaw.Payments.Abstractions.csproj" />
     <Project Path="src/OpenClaw.Payments.Core/OpenClaw.Payments.Core.csproj" />
     <Project Path="src/OpenClaw.Payments.StripeLink/OpenClaw.Payments.StripeLink.csproj" />
+    <Project Path="src/OpenClaw.Providers.MicrosoftExtensionsAI/OpenClaw.Providers.MicrosoftExtensionsAI.csproj" />
     <Project Path="src/OpenClaw.Plugins.Payment/OpenClaw.Plugins.Payment.csproj" />
     <Project Path="src/OpenClaw.Plugins.Mempalace/OpenClaw.Plugins.Mempalace.csproj" />
     <Project Path="src/OpenClaw.MicrosoftAgentFrameworkAdapter/OpenClaw.MicrosoftAgentFrameworkAdapter.csproj" />

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -36,6 +36,7 @@ OpenClaw.NET keeps plugin compatibility explicit by runtime mode. The goal is to
 | `api.registerCommand()` | Supported with caveats | `jit` only. Registered as dynamic chat commands. |
 | `api.on(...)` | Supported with caveats | `jit` only. `tool:before` / `tool:after` hooks are bridged with timeout protections. |
 | `api.registerProvider()` | Supported with caveats | `jit` only. Plugin-provided LLMs are wired through the dynamic provider seam. |
+| `OpenClaw.Providers.MicrosoftExtensionsAI` | Supported with caveats | `jit` only through native dynamic plugins. Use this to bring an arbitrary `IChatClient`; AOT users should use built-in providers or OpenAI-compatible endpoints. |
 | Standalone `.js`, `.mjs`, `.ts` in `.openclaw/extensions` | Supported with caveats | `.ts` requires local `jiti`. |
 | Manifest/package discovery via `Plugins:Load:Paths` | Supported | Includes `openclaw.plugin.json` and `package.json` `openclaw.extensions`. |
 | `openclaw plugins install --dry-run` trust inspection | Supported | Prints trust level, declared surface, diagnostics, and blocks install when compatibility errors are present. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Use this page as the map. If you are unsure where to go next, the groups below a
 | [plugins/payment.md](plugins/payment.md) | Native payment tool, virtual cards, machine payments, providers, and safe agent-facing actions. |
 | [cli/payment.md](cli/payment.md) | `openclaw payment ...` gateway-backed CLI commands and safe output contract. |
 | [mempalace-memory.md](mempalace-memory.md) | Optional ElBruno.MempalaceNet memory provider and temporal KG tool. |
+| [providers/microsoft-extensions-ai.md](providers/microsoft-extensions-ai.md) | Optional JIT bridge for arbitrary `Microsoft.Extensions.AI.IChatClient` providers. |
 | [SESSIONS.md](SESSIONS.md) | Session lifecycle, the `SessionManager`, and the `sessions_spawn` / `sessions_yield` / `sessions` tools. |
 | [CANVAS_A2UI.md](CANVAS_A2UI.md) | Supported Canvas and A2UI behavior for agent-rendered visual workspaces. |
 | [integrations/microsoft-agent-framework.md](integrations/microsoft-agent-framework.md) | Supported optional Microsoft Agent Framework runtime adapter, runtime selection, A2A setup, and migration from old experimental config. |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -180,6 +180,11 @@ OpenClaw supports native routing for several providers out-of-the-box. Change th
 - **Required**: `ApiKey`, `Model`, and usually `Endpoint`
 - **Notes**: These providers are accessed via the OpenAI-compatible REST abstractions. Ensure that you provide the proper base API URL as the `Endpoint` when required by the target service.
 
+#### 7. Microsoft.Extensions.AI provider bridge
+- **Provider**: your dynamic provider id, for example `"my-meai-provider"`
+- **Required**: JIT runtime mode, dynamic native plugins enabled, a factory implementing `IMicrosoftExtensionsAiChatClientFactory`, and at least one model id
+- **Notes**: This optional bridge is for advanced .NET integrations where you already have an `IChatClient`. OpenClaw still owns routing, policy, budget checks, tracing, approvals, sessions, and usage accounting. See [Microsoft.Extensions.AI Provider Bridge](providers/microsoft-extensions-ai.md).
+
 ---
 
 ## Tooling & Sandbox

--- a/docs/providers/microsoft-extensions-ai.md
+++ b/docs/providers/microsoft-extensions-ai.md
@@ -1,0 +1,107 @@
+# Microsoft.Extensions.AI Provider Bridge
+
+OpenClaw.NET already uses `Microsoft.Extensions.AI.IChatClient` internally as the chat boundary. The optional `OpenClaw.Providers.MicrosoftExtensionsAI` package makes that boundary explicit for developers who want to bring an arbitrary `IChatClient` implementation as an OpenClaw provider.
+
+Use this bridge when a provider already exposes an `IChatClient` and you want OpenClaw to keep owning policy, tracing, budget checks, approvals, session handling, prompt cache behavior, retries, and provider usage accounting.
+
+Do not use this bridge as a replacement for the built-in provider routes when those already fit. OpenAI, Claude, Gemini, Azure OpenAI, Ollama, and OpenAI-compatible endpoints remain the simplest supported paths.
+
+## Runtime Mode
+
+The bridge is a JIT-only native dynamic plugin. It is intentionally not a NativeAOT promise because arbitrary third-party `IChatClient` factories can require reflection, dynamic loading, or provider SDK behavior that is not trim-safe.
+
+Use:
+
+```json
+{
+  "OpenClaw": {
+    "Runtime": {
+      "Mode": "jit"
+    },
+    "Plugins": {
+      "DynamicNative": {
+        "Enabled": true
+      }
+    }
+  }
+}
+```
+
+## Factory Contract
+
+Create a public parameterless factory that implements:
+
+```csharp
+using Microsoft.Extensions.AI;
+using OpenClaw.Providers.MicrosoftExtensionsAI;
+
+public sealed class MyChatClientFactory : IMicrosoftExtensionsAiChatClientFactory
+{
+    public IChatClient Create(MicrosoftExtensionsAiProviderFactoryContext context)
+    {
+        return CreateYourProviderClient(context);
+    }
+}
+```
+
+The factory receives:
+
+- `PluginId`: the dynamic native plugin id.
+- `ProviderId`: the OpenClaw provider id being registered.
+- `Models`: the configured model ids.
+- `Config`: provider-specific JSON from the plugin config.
+- `Logger`: the OpenClaw plugin logger.
+
+## Config Shape
+
+Configure one or more providers under the bridge plugin entry:
+
+```json
+{
+  "OpenClaw": {
+    "Llm": {
+      "Provider": "my-meai-provider",
+      "Model": "my-model"
+    },
+    "Plugins": {
+      "DynamicNative": {
+        "Enabled": true,
+        "Load": {
+          "Paths": ["/path/to/openclaw-microsoft-extensions-ai-provider"]
+        },
+        "Entries": {
+          "openclaw-microsoft-extensions-ai-provider": {
+            "Config": {
+              "providers": [
+                {
+                  "providerId": "my-meai-provider",
+                  "models": ["my-model"],
+                  "factoryAssemblyPath": "My.Provider.Factory.dll",
+                  "factoryTypeName": "My.Provider.Factory.MyChatClientFactory",
+                  "config": {
+                    "apiKey": "env:MY_PROVIDER_KEY"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+`factoryAssemblyPath` may be absolute or relative to the bridge plugin assembly directory. `factoryTypeName` may also be assembly-qualified when the factory assembly is already loadable.
+
+## Validation
+
+Startup fails the bridge plugin load when:
+
+- `providers` is missing or empty.
+- `providerId` is blank or duplicated.
+- `models` is empty after trimming blank entries.
+- `factoryTypeName` is blank or cannot be resolved.
+- The resolved factory type does not implement `IMicrosoftExtensionsAiChatClientFactory`.
+- The factory cannot be created with a public parameterless constructor.
+- The factory returns `null`.

--- a/docs/providers/microsoft-extensions-ai.md
+++ b/docs/providers/microsoft-extensions-ai.md
@@ -92,7 +92,7 @@ Configure one or more providers under the bridge plugin entry:
 }
 ```
 
-`factoryAssemblyPath` may be absolute or relative to the bridge plugin assembly directory. `factoryTypeName` may also be assembly-qualified when the factory assembly is already loadable.
+`factoryAssemblyPath` may be absolute or relative to the bridge plugin assembly directory. Relative paths must resolve inside the bridge plugin directory. `factoryTypeName` may also be assembly-qualified when the factory assembly is already loadable.
 
 ## Validation
 

--- a/samples/OpenClaw.MicrosoftExtensionsAIProvider/OpenClaw.MicrosoftExtensionsAIProvider.csproj
+++ b/samples/OpenClaw.MicrosoftExtensionsAIProvider/OpenClaw.MicrosoftExtensionsAIProvider.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>OpenClaw.MicrosoftExtensionsAIProvider</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenClaw.Providers.MicrosoftExtensionsAI\OpenClaw.Providers.MicrosoftExtensionsAI.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/OpenClaw.MicrosoftExtensionsAIProvider/README.md
+++ b/samples/OpenClaw.MicrosoftExtensionsAIProvider/README.md
@@ -1,0 +1,43 @@
+# Microsoft.Extensions.AI Provider Sample
+
+This sample shows how to expose an arbitrary `Microsoft.Extensions.AI.IChatClient` through the optional OpenClaw.NET provider bridge.
+
+Build the bridge and this sample, then place both assemblies beside `OpenClaw.Providers.MicrosoftExtensionsAI.dll` in the dynamic native plugin folder.
+
+Example dynamic native plugin config:
+
+```json
+{
+  "OpenClaw": {
+    "Runtime": {
+      "Mode": "jit"
+    },
+    "Llm": {
+      "Provider": "microsoft-extensions-ai-sample",
+      "Model": "sample-model"
+    },
+    "Plugins": {
+      "DynamicNative": {
+        "Enabled": true,
+        "Load": {
+          "Paths": ["/path/to/openclaw-microsoft-extensions-ai-provider"]
+        },
+        "Entries": {
+          "openclaw-microsoft-extensions-ai-provider": {
+            "Config": {
+              "providers": [
+                {
+                  "providerId": "microsoft-extensions-ai-sample",
+                  "models": ["sample-model"],
+                  "factoryAssemblyPath": "OpenClaw.MicrosoftExtensionsAIProvider.dll",
+                  "factoryTypeName": "OpenClaw.MicrosoftExtensionsAIProvider.SampleDeterministicChatClientFactory"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/samples/OpenClaw.MicrosoftExtensionsAIProvider/SampleDeterministicChatClientFactory.cs
+++ b/samples/OpenClaw.MicrosoftExtensionsAIProvider/SampleDeterministicChatClientFactory.cs
@@ -1,0 +1,43 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+using OpenClaw.Providers.MicrosoftExtensionsAI;
+
+namespace OpenClaw.MicrosoftExtensionsAIProvider;
+
+public sealed class SampleDeterministicChatClientFactory : IMicrosoftExtensionsAiChatClientFactory
+{
+    public IChatClient Create(MicrosoftExtensionsAiProviderFactoryContext context)
+        => new SampleDeterministicChatClient(context.ProviderId);
+
+    private sealed class SampleDeterministicChatClient(string providerId) : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var userText = messages.LastOrDefault(static message => message.Role == ChatRole.User)?.Text ?? "";
+            var model = options?.ModelId ?? "default";
+            return Task.FromResult(new ChatResponse(new ChatMessage(
+                ChatRole.Assistant,
+                $"sample provider={providerId} model={model} user={userText}")));
+        }
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var response = await GetResponseAsync(messages, options, cancellationToken);
+            foreach (var update in response.ToChatResponseUpdates())
+                yield return update;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => serviceType == typeof(IChatClient) ? this : null;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/OpenClaw.Providers.MicrosoftExtensionsAI/IMicrosoftExtensionsAiChatClientFactory.cs
+++ b/src/OpenClaw.Providers.MicrosoftExtensionsAI/IMicrosoftExtensionsAiChatClientFactory.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.AI;
+
+namespace OpenClaw.Providers.MicrosoftExtensionsAI;
+
+/// <summary>
+/// Creates the Microsoft.Extensions.AI chat client used by one OpenClaw provider registration.
+/// </summary>
+public interface IMicrosoftExtensionsAiChatClientFactory
+{
+    IChatClient Create(MicrosoftExtensionsAiProviderFactoryContext context);
+}

--- a/src/OpenClaw.Providers.MicrosoftExtensionsAI/MicrosoftExtensionsAiProviderConfig.cs
+++ b/src/OpenClaw.Providers.MicrosoftExtensionsAI/MicrosoftExtensionsAiProviderConfig.cs
@@ -1,0 +1,17 @@
+using System.Text.Json;
+
+namespace OpenClaw.Providers.MicrosoftExtensionsAI;
+
+public sealed class MicrosoftExtensionsAiProviderConfig
+{
+    public MicrosoftExtensionsAiProviderRegistrationConfig[] Providers { get; set; } = [];
+}
+
+public sealed class MicrosoftExtensionsAiProviderRegistrationConfig
+{
+    public string ProviderId { get; set; } = "";
+    public string[]? Models { get; set; } = [];
+    public string FactoryTypeName { get; set; } = "";
+    public string? FactoryAssemblyPath { get; set; }
+    public JsonElement? Config { get; set; }
+}

--- a/src/OpenClaw.Providers.MicrosoftExtensionsAI/MicrosoftExtensionsAiProviderFactoryContext.cs
+++ b/src/OpenClaw.Providers.MicrosoftExtensionsAI/MicrosoftExtensionsAiProviderFactoryContext.cs
@@ -1,0 +1,16 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace OpenClaw.Providers.MicrosoftExtensionsAI;
+
+/// <summary>
+/// Context passed to a factory while creating an OpenClaw provider-backed IChatClient.
+/// </summary>
+public sealed class MicrosoftExtensionsAiProviderFactoryContext
+{
+    public required string PluginId { get; init; }
+    public required string ProviderId { get; init; }
+    public required IReadOnlyList<string> Models { get; init; }
+    public JsonElement? Config { get; init; }
+    public required ILogger Logger { get; init; }
+}

--- a/src/OpenClaw.Providers.MicrosoftExtensionsAI/MicrosoftExtensionsAiProviderPlugin.cs
+++ b/src/OpenClaw.Providers.MicrosoftExtensionsAI/MicrosoftExtensionsAiProviderPlugin.cs
@@ -133,21 +133,36 @@ public sealed class MicrosoftExtensionsAiProviderPlugin : INativeDynamicPlugin
     {
         var pluginDirectory = Path.GetDirectoryName(typeof(MicrosoftExtensionsAiProviderPlugin).Assembly.Location)
             ?? AppContext.BaseDirectory;
+        var pluginRoot = EnsureTrailingSeparator(Path.GetFullPath(pluginDirectory));
         var fullPath = Path.IsPathRooted(factoryAssemblyPath)
             ? Path.GetFullPath(factoryAssemblyPath)
-            : Path.GetFullPath(Path.Combine(pluginDirectory, factoryAssemblyPath));
+            : Path.GetFullPath(Path.Join(pluginRoot, factoryAssemblyPath));
+
+        if (!Path.IsPathRooted(factoryAssemblyPath) &&
+            !fullPath.StartsWith(pluginRoot, GetPathComparison()))
+        {
+            throw new InvalidOperationException(
+                $"Microsoft.Extensions.AI factory assembly '{factoryAssemblyPath}' must stay within the bridge plugin directory.");
+        }
 
         if (!File.Exists(fullPath))
             throw new InvalidOperationException($"Microsoft.Extensions.AI factory assembly '{factoryAssemblyPath}' was not found at '{fullPath}'.");
 
         var loadContext = AssemblyLoadContext.GetLoadContext(typeof(MicrosoftExtensionsAiProviderPlugin).Assembly)
             ?? AssemblyLoadContext.Default;
+        var pathComparison = GetPathComparison();
         var loaded = loadContext.Assemblies.FirstOrDefault(assembly =>
             !string.IsNullOrWhiteSpace(assembly.Location) &&
-            string.Equals(Path.GetFullPath(assembly.Location), fullPath, StringComparison.Ordinal));
+            string.Equals(Path.GetFullPath(assembly.Location), fullPath, pathComparison));
 
         return loaded ?? loadContext.LoadFromAssemblyPath(fullPath);
     }
+
+    private static string EnsureTrailingSeparator(string path)
+        => Path.EndsInDirectorySeparator(path) ? path : path + Path.DirectorySeparatorChar;
+
+    private static StringComparison GetPathComparison()
+        => OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
     private static string RemoveAssemblyQualification(string typeName)
     {

--- a/src/OpenClaw.Providers.MicrosoftExtensionsAI/MicrosoftExtensionsAiProviderPlugin.cs
+++ b/src/OpenClaw.Providers.MicrosoftExtensionsAI/MicrosoftExtensionsAiProviderPlugin.cs
@@ -1,0 +1,157 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text.Json;
+using OpenClaw.PluginKit;
+
+namespace OpenClaw.Providers.MicrosoftExtensionsAI;
+
+public sealed class MicrosoftExtensionsAiProviderPlugin : INativeDynamicPlugin
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public void Register(INativeDynamicPluginContext context)
+    {
+        var config = ReadConfig(context.Config);
+        if (config.Providers is not { Length: > 0 })
+            throw new InvalidOperationException("Microsoft.Extensions.AI provider bridge requires at least one provider registration in config.providers.");
+
+        var seenProviderIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var provider in config.Providers)
+        {
+            var providerId = NormalizeRequired(provider.ProviderId, "providerId");
+            if (!seenProviderIds.Add(providerId))
+                throw new InvalidOperationException($"Duplicate Microsoft.Extensions.AI provider id '{providerId}' in bridge config.");
+
+            var models = NormalizeModels(provider.Models, providerId);
+            var factoryTypeName = NormalizeRequired(provider.FactoryTypeName, "factoryTypeName");
+            var factory = CreateFactory(factoryTypeName, provider.FactoryAssemblyPath);
+            var client = factory.Create(new MicrosoftExtensionsAiProviderFactoryContext
+            {
+                PluginId = context.PluginId,
+                ProviderId = providerId,
+                Models = models,
+                Config = provider.Config,
+                Logger = context.Logger
+            });
+
+            if (client is null)
+                throw new InvalidOperationException($"Microsoft.Extensions.AI factory '{factoryTypeName}' returned null for provider '{providerId}'.");
+
+            context.RegisterProvider(providerId, models, client);
+        }
+    }
+
+    private static MicrosoftExtensionsAiProviderConfig ReadConfig(JsonElement? config)
+    {
+        if (config is null || config.Value.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+            throw new InvalidOperationException("Microsoft.Extensions.AI provider bridge requires dynamic native plugin config.");
+
+        try
+        {
+            return config.Value.Deserialize<MicrosoftExtensionsAiProviderConfig>(JsonOptions)
+                ?? throw new InvalidOperationException("Microsoft.Extensions.AI provider bridge config could not be deserialized.");
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException("Microsoft.Extensions.AI provider bridge config is invalid JSON.", ex);
+        }
+    }
+
+    private static string NormalizeRequired(string? value, string fieldName)
+    {
+        var normalized = value?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+            throw new InvalidOperationException($"Microsoft.Extensions.AI provider bridge config field '{fieldName}' is required.");
+
+        return normalized;
+    }
+
+    private static string[] NormalizeModels(IEnumerable<string>? models, string providerId)
+    {
+        var normalized = models?
+            .Where(static model => !string.IsNullOrWhiteSpace(model))
+            .Select(static model => model.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray() ?? [];
+
+        if (normalized.Length == 0)
+            throw new InvalidOperationException($"Microsoft.Extensions.AI provider '{providerId}' must declare at least one model.");
+
+        return normalized;
+    }
+
+    private static IMicrosoftExtensionsAiChatClientFactory CreateFactory(string factoryTypeName, string? factoryAssemblyPath)
+    {
+        var factoryType = ResolveFactoryType(factoryTypeName, factoryAssemblyPath);
+        if (!typeof(IMicrosoftExtensionsAiChatClientFactory).IsAssignableFrom(factoryType))
+        {
+            throw new InvalidOperationException(
+                $"Microsoft.Extensions.AI factory type '{factoryType.FullName}' must implement {nameof(IMicrosoftExtensionsAiChatClientFactory)}.");
+        }
+
+        try
+        {
+            return (IMicrosoftExtensionsAiChatClientFactory?)Activator.CreateInstance(factoryType)
+                ?? throw new InvalidOperationException($"Microsoft.Extensions.AI factory type '{factoryType.FullName}' could not be created.");
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            throw new InvalidOperationException(
+                $"Microsoft.Extensions.AI factory type '{factoryType.FullName}' could not be created. It must expose a public parameterless constructor.",
+                ex);
+        }
+    }
+
+    private static Type ResolveFactoryType(string factoryTypeName, string? factoryAssemblyPath)
+    {
+        if (!string.IsNullOrWhiteSpace(factoryAssemblyPath))
+        {
+            var assembly = LoadFactoryAssembly(factoryAssemblyPath);
+            return assembly.GetType(factoryTypeName, throwOnError: false, ignoreCase: false)
+                ?? assembly.GetType(RemoveAssemblyQualification(factoryTypeName), throwOnError: false, ignoreCase: false)
+                ?? throw new InvalidOperationException($"Microsoft.Extensions.AI factory type '{factoryTypeName}' could not be found in '{factoryAssemblyPath}'.");
+        }
+
+        var resolved = Type.GetType(factoryTypeName, throwOnError: false, ignoreCase: false);
+        if (resolved is not null)
+            return resolved;
+
+        var loadContext = AssemblyLoadContext.GetLoadContext(typeof(MicrosoftExtensionsAiProviderPlugin).Assembly);
+        resolved = loadContext?.Assemblies
+            .Select(assembly => assembly.GetType(factoryTypeName, throwOnError: false, ignoreCase: false))
+            .FirstOrDefault(type => type is not null);
+
+        return resolved
+            ?? throw new InvalidOperationException(
+                $"Microsoft.Extensions.AI factory type '{factoryTypeName}' could not be resolved. Use an assembly-qualified type name or set factoryAssemblyPath.");
+    }
+
+    private static Assembly LoadFactoryAssembly(string factoryAssemblyPath)
+    {
+        var pluginDirectory = Path.GetDirectoryName(typeof(MicrosoftExtensionsAiProviderPlugin).Assembly.Location)
+            ?? AppContext.BaseDirectory;
+        var fullPath = Path.IsPathRooted(factoryAssemblyPath)
+            ? Path.GetFullPath(factoryAssemblyPath)
+            : Path.GetFullPath(Path.Combine(pluginDirectory, factoryAssemblyPath));
+
+        if (!File.Exists(fullPath))
+            throw new InvalidOperationException($"Microsoft.Extensions.AI factory assembly '{factoryAssemblyPath}' was not found at '{fullPath}'.");
+
+        var loadContext = AssemblyLoadContext.GetLoadContext(typeof(MicrosoftExtensionsAiProviderPlugin).Assembly)
+            ?? AssemblyLoadContext.Default;
+        var loaded = loadContext.Assemblies.FirstOrDefault(assembly =>
+            !string.IsNullOrWhiteSpace(assembly.Location) &&
+            string.Equals(Path.GetFullPath(assembly.Location), fullPath, StringComparison.Ordinal));
+
+        return loaded ?? loadContext.LoadFromAssemblyPath(fullPath);
+    }
+
+    private static string RemoveAssemblyQualification(string typeName)
+    {
+        var commaIndex = typeName.IndexOf(',', StringComparison.Ordinal);
+        return commaIndex < 0 ? typeName : typeName[..commaIndex].Trim();
+    }
+}

--- a/src/OpenClaw.Providers.MicrosoftExtensionsAI/OpenClaw.Providers.MicrosoftExtensionsAI.csproj
+++ b/src/OpenClaw.Providers.MicrosoftExtensionsAI/OpenClaw.Providers.MicrosoftExtensionsAI.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>OpenClaw.Providers.MicrosoftExtensionsAI</RootNamespace>
+    <IsAotCompatible>false</IsAotCompatible>
+    <IsTrimmable>false</IsTrimmable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <IsPackable>true</IsPackable>
+    <PackageId>OpenClaw.Providers.MicrosoftExtensionsAI</PackageId>
+    <Description>Optional Microsoft.Extensions.AI provider bridge for registering arbitrary IChatClient implementations with OpenClaw.NET.</Description>
+    <PackageTags>openclaw;microsoft-extensions-ai;ai;agent;dotnet;providers</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenClaw.PluginKit\OpenClaw.PluginKit.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="openclaw.native-plugin.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/src/OpenClaw.Providers.MicrosoftExtensionsAI/openclaw.native-plugin.json
+++ b/src/OpenClaw.Providers.MicrosoftExtensionsAI/openclaw.native-plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "openclaw-microsoft-extensions-ai-provider",
+  "name": "OpenClaw Microsoft.Extensions.AI provider bridge",
+  "version": "1.0.0",
+  "assemblyPath": "OpenClaw.Providers.MicrosoftExtensionsAI.dll",
+  "typeName": "OpenClaw.Providers.MicrosoftExtensionsAI.MicrosoftExtensionsAiProviderPlugin",
+  "capabilities": ["providers"],
+  "jitOnly": true
+}

--- a/src/OpenClaw.TestPluginFixtures/MicrosoftExtensionsAiProviderFixtures.cs
+++ b/src/OpenClaw.TestPluginFixtures/MicrosoftExtensionsAiProviderFixtures.cs
@@ -1,0 +1,60 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+using OpenClaw.Providers.MicrosoftExtensionsAI;
+
+namespace OpenClaw.TestPluginFixtures;
+
+public sealed class DeterministicMicrosoftExtensionsAiChatClientFactory : IMicrosoftExtensionsAiChatClientFactory
+{
+    public IChatClient Create(MicrosoftExtensionsAiProviderFactoryContext context)
+    {
+        var responseText = context.Config is { ValueKind: System.Text.Json.JsonValueKind.Object } config &&
+            config.TryGetProperty("responseText", out var responseTextElement) &&
+            responseTextElement.ValueKind == System.Text.Json.JsonValueKind.String
+                ? responseTextElement.GetString() ?? "fixture response"
+                : "fixture response";
+
+        return new DeterministicChatClient(context.ProviderId, responseText);
+    }
+
+    private sealed class DeterministicChatClient(string providerId, string responseText) : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var userText = messages.LastOrDefault(static message => message.Role == ChatRole.User)?.Text ?? "";
+            var model = options?.ModelId ?? "default";
+            return Task.FromResult(new ChatResponse(new ChatMessage(
+                ChatRole.Assistant,
+                $"{responseText} provider={providerId} model={model} user={userText}")));
+        }
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var response = await GetResponseAsync(messages, options, cancellationToken);
+            foreach (var update in response.ToChatResponseUpdates())
+                yield return update;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => serviceType == typeof(IChatClient) ? this : null;
+
+        public void Dispose()
+        {
+        }
+    }
+}
+
+public sealed class NullMicrosoftExtensionsAiChatClientFactory : IMicrosoftExtensionsAiChatClientFactory
+{
+    public IChatClient Create(MicrosoftExtensionsAiProviderFactoryContext context) => null!;
+}
+
+public sealed class InvalidMicrosoftExtensionsAiChatClientFactory
+{
+}

--- a/src/OpenClaw.TestPluginFixtures/OpenClaw.TestPluginFixtures.csproj
+++ b/src/OpenClaw.TestPluginFixtures/OpenClaw.TestPluginFixtures.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenClaw.Core\OpenClaw.Core.csproj" />
+    <ProjectReference Include="..\OpenClaw.Providers.MicrosoftExtensionsAI\OpenClaw.Providers.MicrosoftExtensionsAI.csproj" />
     <ProjectReference Include="..\OpenClaw.PluginKit\OpenClaw.PluginKit.csproj" />
   </ItemGroup>
 </Project>

--- a/src/OpenClaw.Tests/MicrosoftExtensionsAiProviderBridgeTests.cs
+++ b/src/OpenClaw.Tests/MicrosoftExtensionsAiProviderBridgeTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
@@ -38,6 +39,7 @@ public sealed class MicrosoftExtensionsAiProviderBridgeTests : IDisposable
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException)
         {
+            Debug.WriteLine($"Failed to delete temporary test directory '{_tempDir}': {ex}");
         }
     }
 

--- a/src/OpenClaw.Tests/MicrosoftExtensionsAiProviderBridgeTests.cs
+++ b/src/OpenClaw.Tests/MicrosoftExtensionsAiProviderBridgeTests.cs
@@ -1,0 +1,316 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenClaw.Agent;
+using OpenClaw.Agent.Plugins;
+using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Memory;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Observability;
+using OpenClaw.Core.Plugins;
+using OpenClaw.Gateway;
+using OpenClaw.PluginKit;
+using OpenClaw.Providers.MicrosoftExtensionsAI;
+using OpenClaw.TestPluginFixtures;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class MicrosoftExtensionsAiProviderBridgeTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public MicrosoftExtensionsAiProviderBridgeTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "openclaw-meai-provider-tests", Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Register_ValidProvider_RegistersChatClient()
+    {
+        var context = CreateContext(new
+        {
+            providers = new[]
+            {
+                new
+                {
+                    providerId = "meai-test",
+                    models = new[] { "model-a" },
+                    factoryTypeName = typeof(DeterministicMicrosoftExtensionsAiChatClientFactory).AssemblyQualifiedName
+                }
+            }
+        });
+
+        new MicrosoftExtensionsAiProviderPlugin().Register(context);
+
+        var provider = Assert.Single(context.Providers);
+        Assert.Equal("meai-test", provider.ProviderId);
+        Assert.Equal(["model-a"], provider.Models);
+        Assert.NotNull(provider.Client);
+    }
+
+    [Fact]
+    public void Register_MultipleProviders_RegistersEachProvider()
+    {
+        var factoryType = typeof(DeterministicMicrosoftExtensionsAiChatClientFactory).AssemblyQualifiedName;
+        var context = CreateContext(new
+        {
+            providers = new[]
+            {
+                new { providerId = "meai-a", models = new[] { "model-a" }, factoryTypeName = factoryType },
+                new { providerId = "meai-b", models = new[] { "model-b", "model-c" }, factoryTypeName = factoryType }
+            }
+        });
+
+        new MicrosoftExtensionsAiProviderPlugin().Register(context);
+
+        Assert.Equal(2, context.Providers.Count);
+        Assert.Contains(context.Providers, provider => provider.ProviderId == "meai-a");
+        Assert.Contains(context.Providers, provider => provider.ProviderId == "meai-b");
+    }
+
+    [Fact]
+    public void Register_BlankProviderId_Throws()
+    {
+        var context = CreateContext(new
+        {
+            providers = new[]
+            {
+                new
+                {
+                    providerId = " ",
+                    models = new[] { "model-a" },
+                    factoryTypeName = typeof(DeterministicMicrosoftExtensionsAiChatClientFactory).AssemblyQualifiedName
+                }
+            }
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => new MicrosoftExtensionsAiProviderPlugin().Register(context));
+        Assert.Contains("providerId", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Register_MissingFactoryType_Throws()
+    {
+        var context = CreateContext(new
+        {
+            providers = new[]
+            {
+                new
+                {
+                    providerId = "meai-test",
+                    models = new[] { "model-a" },
+                    factoryTypeName = ""
+                }
+            }
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => new MicrosoftExtensionsAiProviderPlugin().Register(context));
+        Assert.Contains("factoryTypeName", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Register_InvalidFactoryType_Throws()
+    {
+        var context = CreateContext(new
+        {
+            providers = new[]
+            {
+                new
+                {
+                    providerId = "meai-test",
+                    models = new[] { "model-a" },
+                    factoryTypeName = typeof(InvalidMicrosoftExtensionsAiChatClientFactory).AssemblyQualifiedName
+                }
+            }
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => new MicrosoftExtensionsAiProviderPlugin().Register(context));
+        Assert.Contains(nameof(IMicrosoftExtensionsAiChatClientFactory), ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Register_NullFactoryResult_Throws()
+    {
+        var context = CreateContext(new
+        {
+            providers = new[]
+            {
+                new
+                {
+                    providerId = "meai-test",
+                    models = new[] { "model-a" },
+                    factoryTypeName = typeof(NullMicrosoftExtensionsAiChatClientFactory).AssemblyQualifiedName
+                }
+            }
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => new MicrosoftExtensionsAiProviderPlugin().Register(context));
+        Assert.Contains("returned null", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task LoadAsync_NativeDynamicPlugin_RegistersChatClientProvider()
+    {
+        var pluginDir = CreateBridgePluginDirectory("meai-native-load");
+        var config = CreateNativeConfig(pluginDir, "model-a", "native fixture");
+
+        await using var host = new NativeDynamicPluginHost(
+            config,
+            RuntimeModeResolver.Resolve(new RuntimeConfig { Mode = "jit" }, dynamicCodeSupported: true),
+            NullLogger.Instance);
+
+        _ = await host.LoadAsync(null, CancellationToken.None);
+
+        var provider = Assert.Single(host.ProviderRegistrationsDetailed);
+        Assert.Equal("meai-native-load", provider.ProviderId);
+        Assert.Equal(["model-a"], provider.Models);
+        Assert.NotNull(provider.Client);
+    }
+
+    [Fact]
+    public async Task GatewayExecution_UsesBridgeClientThroughProviderRegistry()
+    {
+        var pluginDir = CreateBridgePluginDirectory("meai-runtime");
+        var config = CreateNativeConfig(pluginDir, "runtime-model", "runtime fixture", providerId: "meai-runtime");
+
+        await using var host = new NativeDynamicPluginHost(
+            config,
+            RuntimeModeResolver.Resolve(new RuntimeConfig { Mode = "jit" }, dynamicCodeSupported: true),
+            NullLogger.Instance);
+
+        _ = await host.LoadAsync(null, CancellationToken.None);
+        var provider = Assert.Single(host.ProviderRegistrationsDetailed);
+
+        var gatewayConfig = new GatewayConfig
+        {
+            Llm = new LlmProviderConfig
+            {
+                Provider = provider.ProviderId,
+                Model = "runtime-model",
+                RetryCount = 0,
+                TimeoutSeconds = 0
+            }
+        };
+        var providerRegistry = new LlmProviderRegistry();
+        Assert.True(providerRegistry.TryRegisterDynamic(provider.ProviderId, provider.Client, "test", provider.Models));
+        var storagePath = Path.Combine(_tempDir, "runtime");
+        Directory.CreateDirectory(storagePath);
+        var providerUsage = new ProviderUsageTracker();
+        var service = new GatewayLlmExecutionService(
+            gatewayConfig,
+            providerRegistry,
+            new ProviderPolicyService(storagePath, NullLogger<ProviderPolicyService>.Instance),
+            new RuntimeEventStore(storagePath, NullLogger<RuntimeEventStore>.Instance),
+            new RuntimeMetrics(),
+            providerUsage,
+            NullLogger<GatewayLlmExecutionService>.Instance);
+
+        var session = new Session
+        {
+            Id = "meai-session",
+            ChannelId = "test",
+            SenderId = "user"
+        };
+        var result = await service.GetResponseAsync(
+            session,
+            [new ChatMessage(ChatRole.User, "hello")],
+            new ChatOptions(),
+            new TurnContext { SessionId = session.Id, ChannelId = session.ChannelId },
+            new LlmExecutionEstimate
+            {
+                EstimatedInputTokens = 4,
+                EstimatedInputTokensByComponent = new InputTokenComponentEstimate()
+            },
+            CancellationToken.None);
+
+        Assert.Equal("meai-runtime", result.ProviderId);
+        Assert.Equal("runtime-model", result.ModelId);
+        Assert.Contains("runtime fixture provider=meai-runtime model=runtime-model user=hello", result.Response.Text, StringComparison.Ordinal);
+        var usage = Assert.Single(providerUsage.Snapshot());
+        Assert.Equal("meai-runtime", usage.ProviderId);
+        Assert.Equal("runtime-model", usage.ModelId);
+        Assert.Equal(1, usage.Requests);
+    }
+
+    private NativeDynamicPluginsConfig CreateNativeConfig(
+        string pluginDir,
+        string model,
+        string responseText,
+        string providerId = "meai-native-load")
+        => new()
+        {
+            Enabled = true,
+            Load = new PluginLoadConfig { Paths = [pluginDir] },
+            Entries = new Dictionary<string, PluginEntryConfig>(StringComparer.Ordinal)
+            {
+                ["openclaw-microsoft-extensions-ai-provider"] = new()
+                {
+                    Config = JsonSerializer.SerializeToElement(new
+                    {
+                        providers = new[]
+                        {
+                            new
+                            {
+                                providerId,
+                                models = new[] { model },
+                                factoryAssemblyPath = Path.GetFileName(typeof(DeterministicMicrosoftExtensionsAiChatClientFactory).Assembly.Location),
+                                factoryTypeName = typeof(DeterministicMicrosoftExtensionsAiChatClientFactory).FullName,
+                                config = new { responseText }
+                            }
+                        }
+                    })
+                }
+            }
+        };
+
+    private string CreateBridgePluginDirectory(string directoryName)
+    {
+        var pluginDir = Path.Combine(_tempDir, directoryName);
+        Directory.CreateDirectory(pluginDir);
+        var bridgeAssembly = typeof(MicrosoftExtensionsAiProviderPlugin).Assembly.Location;
+        var fixtureAssembly = typeof(DeterministicMicrosoftExtensionsAiChatClientFactory).Assembly.Location;
+        File.Copy(bridgeAssembly, Path.Combine(pluginDir, Path.GetFileName(bridgeAssembly)), overwrite: true);
+        File.Copy(fixtureAssembly, Path.Combine(pluginDir, Path.GetFileName(fixtureAssembly)), overwrite: true);
+        File.WriteAllText(
+            Path.Combine(pluginDir, "openclaw.native-plugin.json"),
+            $$"""
+            {
+              "id": "openclaw-microsoft-extensions-ai-provider",
+              "name": "OpenClaw Microsoft.Extensions.AI provider bridge",
+              "version": "1.0.0",
+              "assemblyPath": {{JsonSerializer.Serialize(Path.GetFileName(bridgeAssembly))}},
+              "typeName": "OpenClaw.Providers.MicrosoftExtensionsAI.MicrosoftExtensionsAiProviderPlugin",
+              "capabilities": ["providers"],
+              "jitOnly": true
+            }
+            """);
+        return pluginDir;
+    }
+
+    private static CapturingPluginContext CreateContext(object config)
+        => new(JsonSerializer.SerializeToElement(config));
+
+    private sealed class CapturingPluginContext(JsonElement? config) : INativeDynamicPluginContext
+    {
+        public string PluginId => "test-meai-plugin";
+        public JsonElement? Config { get; } = config;
+        public ILogger Logger => NullLogger.Instance;
+        public List<(string ProviderId, string[] Models, IChatClient Client)> Providers { get; } = [];
+
+        public void RegisterTool(ITool tool) { }
+        public void RegisterChannel(IChannelAdapter adapter) { }
+        public void RegisterCommand(string name, string description, Func<string, CancellationToken, Task<string>> handler) { }
+        public void RegisterProvider(string providerId, string[] models, IChatClient client) => Providers.Add((providerId, models, client));
+        public void RegisterMemoryProvider(string providerId, Func<NativeDynamicMemoryProviderContext, IMemoryStore> factory) { }
+        public void RegisterHook(IToolHook hook) { }
+        public void RegisterService(INativeDynamicPluginService service) { }
+    }
+}

--- a/src/OpenClaw.Tests/MicrosoftExtensionsAiProviderBridgeTests.cs
+++ b/src/OpenClaw.Tests/MicrosoftExtensionsAiProviderBridgeTests.cs
@@ -23,13 +23,22 @@ public sealed class MicrosoftExtensionsAiProviderBridgeTests : IDisposable
 
     public MicrosoftExtensionsAiProviderBridgeTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), "openclaw-meai-provider-tests", Guid.NewGuid().ToString("n"));
+        var tempRoot = Path.Join(Path.GetTempPath(), "openclaw-meai-provider-tests");
+        Directory.CreateDirectory(tempRoot);
+        _tempDir = Path.Join(tempRoot, Guid.NewGuid().ToString("n"));
         Directory.CreateDirectory(_tempDir);
     }
 
     public void Dispose()
     {
-        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, recursive: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException)
+        {
+        }
     }
 
     [Fact]
@@ -157,6 +166,27 @@ public sealed class MicrosoftExtensionsAiProviderBridgeTests : IDisposable
     }
 
     [Fact]
+    public void Register_RelativeFactoryAssemblyOutsidePluginDirectory_Throws()
+    {
+        var context = CreateContext(new
+        {
+            providers = new[]
+            {
+                new
+                {
+                    providerId = "meai-test",
+                    models = new[] { "model-a" },
+                    factoryAssemblyPath = "../OpenClaw.TestPluginFixtures.dll",
+                    factoryTypeName = typeof(DeterministicMicrosoftExtensionsAiChatClientFactory).FullName
+                }
+            }
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => new MicrosoftExtensionsAiProviderPlugin().Register(context));
+        Assert.Contains("must stay within the bridge plugin directory", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task LoadAsync_NativeDynamicPlugin_RegistersChatClientProvider()
     {
         var pluginDir = CreateBridgePluginDirectory("meai-native-load");
@@ -201,7 +231,7 @@ public sealed class MicrosoftExtensionsAiProviderBridgeTests : IDisposable
         };
         var providerRegistry = new LlmProviderRegistry();
         Assert.True(providerRegistry.TryRegisterDynamic(provider.ProviderId, provider.Client, "test", provider.Models));
-        var storagePath = Path.Combine(_tempDir, "runtime");
+        var storagePath = Path.Join(_tempDir, "runtime");
         Directory.CreateDirectory(storagePath);
         var providerUsage = new ProviderUsageTracker();
         var service = new GatewayLlmExecutionService(
@@ -273,14 +303,14 @@ public sealed class MicrosoftExtensionsAiProviderBridgeTests : IDisposable
 
     private string CreateBridgePluginDirectory(string directoryName)
     {
-        var pluginDir = Path.Combine(_tempDir, directoryName);
+        var pluginDir = Path.Join(_tempDir, directoryName);
         Directory.CreateDirectory(pluginDir);
         var bridgeAssembly = typeof(MicrosoftExtensionsAiProviderPlugin).Assembly.Location;
         var fixtureAssembly = typeof(DeterministicMicrosoftExtensionsAiChatClientFactory).Assembly.Location;
-        File.Copy(bridgeAssembly, Path.Combine(pluginDir, Path.GetFileName(bridgeAssembly)), overwrite: true);
-        File.Copy(fixtureAssembly, Path.Combine(pluginDir, Path.GetFileName(fixtureAssembly)), overwrite: true);
+        File.Copy(bridgeAssembly, Path.Join(pluginDir, Path.GetFileName(bridgeAssembly)), overwrite: true);
+        File.Copy(fixtureAssembly, Path.Join(pluginDir, Path.GetFileName(fixtureAssembly)), overwrite: true);
         File.WriteAllText(
-            Path.Combine(pluginDir, "openclaw.native-plugin.json"),
+            Path.Join(pluginDir, "openclaw.native-plugin.json"),
             $$"""
             {
               "id": "openclaw-microsoft-extensions-ai-provider",

--- a/src/OpenClaw.Tests/OpenClaw.Tests.csproj
+++ b/src/OpenClaw.Tests/OpenClaw.Tests.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\OpenClaw.Payments.Abstractions\OpenClaw.Payments.Abstractions.csproj" />
     <ProjectReference Include="..\OpenClaw.Payments.Core\OpenClaw.Payments.Core.csproj" />
     <ProjectReference Include="..\OpenClaw.Payments.StripeLink\OpenClaw.Payments.StripeLink.csproj" />
+    <ProjectReference Include="..\OpenClaw.Providers.MicrosoftExtensionsAI\OpenClaw.Providers.MicrosoftExtensionsAI.csproj" />
     <ProjectReference Include="..\OpenClaw.Plugins.Payment\OpenClaw.Plugins.Payment.csproj" />
     <ProjectReference Include="..\OpenClaw.SemanticKernelAdapter\OpenClaw.SemanticKernelAdapter.csproj" />
     <ProjectReference Include="..\OpenClaw.PluginKit\OpenClaw.PluginKit.csproj" />


### PR DESCRIPTION
## Summary
- add optional `OpenClaw.Providers.MicrosoftExtensionsAI` native dynamic plugin bridge for arbitrary `IChatClient` providers
- add a deterministic sample provider factory and bridge documentation
- add focused validation and runtime coverage for config validation, native dynamic registration, and gateway execution through the provider registry

## Validation
- `/usr/local/share/dotnet/dotnet build OpenClaw.Net.slnx -c Debug`
- `/usr/local/share/dotnet/dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj -c Debug`
