### PR TITLE
Bound NativeAOT prerequisite install

### DIFF
--- a/.github/scripts/install-nativeaot-prereqs.sh
+++ b/.github/scripts/install-nativeaot-prereqs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+missing=()
+
+if ! command -v clang >/dev/null 2>&1; then
+  missing+=("clang")
+fi
+
+if ! dpkg-query -W -f='${Status}' zlib1g-dev 2>/dev/null | grep -q "install ok installed"; then
+  missing+=("zlib1g-dev")
+fi
+
+if [ "${#missing[@]}" -eq 0 ]; then
+  echo "NativeAOT prerequisites already installed; skipping apt."
+  exit 0
+fi
+
+attempts="${APT_INSTALL_ATTEMPTS:-3}"
+timeout_seconds="${APT_INSTALL_TIMEOUT_SECONDS:-120}"
+
+for attempt in $(seq 1 "$attempts"); do
+  echo "::group::Install missing NativeAOT prerequisites, attempt ${attempt}/${attempts}"
+  set +e
+  timeout "${timeout_seconds}s" sudo env DEBIAN_FRONTEND=noninteractive apt-get install \
+    -y \
+    --no-install-recommends \
+    -o Acquire::Retries=2 \
+    -o Dpkg::Lock::Timeout=60 \
+    "${missing[@]}"
+  status=$?
+  set -e
+  echo "::endgroup::"
+
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+
+  if [ "$attempt" -eq "$attempts" ]; then
+    echo "::error::Failed to install NativeAOT prerequisites after ${attempts} attempts."
+    exit "$status"
+  fi
+
+  echo "::warning::apt-get install failed or timed out with exit code ${status}; retrying."
+  sleep $((attempt * 10))
+done

--- a/.github/scripts/install-nativeaot-prereqs.sh
+++ b/.github/scripts/install-nativeaot-prereqs.sh
@@ -16,10 +16,23 @@ if [ "${#missing[@]}" -eq 0 ]; then
   exit 0
 fi
 
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "::error::${name} must be a positive integer; got '${value}'."
+    exit 2
+  fi
+}
+
 attempts="${APT_INSTALL_ATTEMPTS:-3}"
 timeout_seconds="${APT_INSTALL_TIMEOUT_SECONDS:-120}"
 
-for attempt in $(seq 1 "$attempts"); do
+require_positive_integer "APT_INSTALL_ATTEMPTS" "$attempts"
+require_positive_integer "APT_INSTALL_TIMEOUT_SECONDS" "$timeout_seconds"
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
   echo "::group::Install missing NativeAOT prerequisites, attempt ${attempt}/${attempts}"
   set +e
   timeout "${timeout_seconds}s" sudo env DEBIAN_FRONTEND=noninteractive apt-get install \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,9 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Install AOT prerequisites
-        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+      - name: Ensure AOT prerequisites
+        timeout-minutes: 8
+        run: bash .github/scripts/install-nativeaot-prereqs.sh
 
       - name: Publish and smoke-test standard NativeAOT binaries
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,10 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Install Linux NativeAOT prerequisites
+      - name: Ensure Linux NativeAOT prerequisites
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+        timeout-minutes: 8
+        run: bash .github/scripts/install-nativeaot-prereqs.sh
 
       - name: Publish, smoke-test, and package assets
         shell: pwsh


### PR DESCRIPTION
## Summary
- replace broad NativeAOT prerequisite apt update/install with a shared bounded install script
- skip apt entirely when clang and zlib1g-dev are already present on the runner
- retry only apt-get install with a timeout and no apt-get update fallback
- apply the same behavior to CI and release workflows

## Validation
- bash -n .github/scripts/install-nativeaot-prereqs.sh
- ruby YAML parse for .github/workflows/ci.yml and .github/workflows/release.yml
- verified no remaining apt-get update usage under .github workflows/scripts