### PR TITLE
Add A2UI v0.9 surface support and testing enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ artifacts/
 *.suo
 *.userosscache
 *.sln.docstates
+*.csproj.lscache
 
 # OS
 .DS_Store

--- a/docs/CANVAS_A2UI.md
+++ b/docs/CANVAS_A2UI.md
@@ -1,33 +1,35 @@
 # Canvas and A2UI
 
-Canvas and A2UI are supported as a first-party, session-scoped visual workspace for websocket clients. The v1 implementation focuses on local Canvas content and A2UI v0.8 JSONL rendering. It is not a replacement for the browser tool and does not support arbitrary remote webpage navigation or remote-page script execution.
+Canvas and A2UI are supported as a first-party visual workspace for websocket clients. OpenClaw.NET supports the existing A2UI v0.8 JSONL flow and A2UI v0.9 structured surface operations. It is not a replacement for the browser tool and does not support arbitrary remote webpage navigation or remote-page script execution.
 
 ## What Ships
 
 - Gateway Canvas configuration under `OpenClaw:Canvas`.
-- Typed websocket envelopes for Canvas commands, A2UI pushes, results, and user events.
-- Native agent tools: `canvas_present`, `canvas_hide`, `canvas_navigate`, `canvas_snapshot`, `a2ui_push`, `a2ui_reset`, and `a2ui_eval`.
-- A broker that forwards commands only to the current websocket session, tracks request acknowledgements/results, records runtime events, and times out stalled commands.
-- Webchat Canvas host with a side panel, A2UI renderer, sandboxed local HTML iframe, and lightweight snapshots.
-- Companion Canvas tab with native Avalonia A2UI rendering and event/snapshot feedback.
+- Typed websocket envelopes for Canvas commands, A2UI pushes, structured v0.9 operations, results, and user events/actions.
+- Native agent tools: `canvas_present`, `canvas_hide`, `canvas_navigate`, `canvas_snapshot`, `a2ui_push`, `a2ui_reset`, `a2ui_eval`, `a2ui_create_surface`, `a2ui_update_components`, `a2ui_update_data_model`, `a2ui_delete_surface`, and `a2ui_sync_ui_to_data`.
+- A broker that forwards commands only to the current websocket session, tracks request acknowledgements/results, records runtime events, negotiates catalogs, and locks the selected catalog per surface lifecycle.
+- Webchat Canvas host with a side panel, sandboxed local HTML iframe, per-surface A2UI rendering, lightweight snapshots, and conservative fallbacks for advanced components.
+- Companion Canvas tab with native Avalonia A2UI rendering, per-surface state, event/action feedback, and snapshot feedback.
 
 ## Capability Scope
 
 Supported:
 
-- A2UI v0.8 JSONL frames.
-- Components: `text`, `markdown`, `card`, `button`, `input`, `select`, `checklist`, `table`, `image`, `progress`, and simple `chart`.
+- A2UI v0.8 JSONL frames through `a2ui_push`.
+- A2UI v0.9 structured surface operations: `createSurface`, `updateComponents`, `updateDataModel`, `deleteSurface`, `action`, `syncUIToData`, and `error`.
+- Multiple independent surfaces routed by `surfaceId`.
+- Per-surface component trees, data models, diagnostics, and snapshots.
+- Catalog negotiation through `supportedCatalogIds`.
 - Present/hide/reset/push/snapshot command flow.
 - Local HTML navigation by passing `html` to `canvas_navigate` in webchat.
 - `about:blank` navigation.
-- A2UI events returned to the same conversation as structured session turns.
-- Lightweight JSON snapshots containing rendered tree state, component values, diagnostics, and local HTML text when available.
+- v0.8 `a2ui_event` and v0.9 `a2ui_action` feedback returned to the same conversation as structured session turns.
+- Lightweight JSON snapshots containing rendered tree state, component values, diagnostics, data model state, and local HTML text when available.
 
 Unsupported:
 
 - `http:` and `https:` Canvas navigation.
 - Script execution against remote webpages.
-- A2UI v0.9 `createSurface`.
 - Cross-session Canvas sharing.
 - Native local HTML/WebView rendering in Companion. Companion returns an explicit unsupported diagnostic for local HTML navigation and A2UI eval.
 
@@ -45,7 +47,7 @@ Canvas settings live under `OpenClaw:Canvas`:
 | `MaxFramesPerPush` | `100` | Maximum A2UI frames in one push. |
 | `EnableLocalHtml` | `true` | Allows `canvas_navigate` with inline `html`. |
 | `EnableRemoteNavigation` | `false` | Remote webpage Canvas navigation remains unsupported. |
-| `EnableEval` | `true` | Allows capability-gated `a2ui_eval` commands when a client advertises `a2ui.eval`. First-party v1 clients do not advertise it. |
+| `EnableEval` | `true` | Allows capability-gated `a2ui_eval` commands when a client advertises `a2ui.eval`. First-party clients do not advertise it. |
 
 When strict public-bind hardening is applied and `AllowOnPublicBind=false`, Canvas is disabled. Without strict mode, public-bind startup refuses unsafe Canvas forwarding unless you explicitly opt in.
 
@@ -60,6 +62,11 @@ Server-to-client websocket envelope types:
 - `a2ui_push`
 - `a2ui_reset`
 - `a2ui_eval`
+- `a2ui_create_surface`
+- `a2ui_update_components`
+- `a2ui_update_data_model`
+- `a2ui_delete_surface`
+- `a2ui_sync_ui_to_data`
 
 Client-to-server websocket envelope types:
 
@@ -68,10 +75,33 @@ Client-to-server websocket envelope types:
 - `canvas_snapshot_result`
 - `canvas_eval_result`
 - `a2ui_event`
+- `a2ui_action`
+- `a2ui_error`
+- `a2ui_sync_result`
 
-Common Canvas fields include `requestId`, `sessionId`, `surfaceId`, `contentType`, `frames`, `html`, `url`, `script`, `snapshotMode`, `snapshotJson`, `componentId`, `event`, `valueJson`, `sequence`, `capabilities`, `success`, and `error`.
+Common Canvas fields include `requestId`, `sessionId`, `surfaceId`, `contentType`, `frames`, `html`, `url`, `script`, `snapshotMode`, `snapshotJson`, `componentId`, `event`, `action`, `valueJson`, `dataModelJson`, `sequence`, `capabilities`, `supportedCatalogIds`, `catalogId`, `components`, `parametersJson`, `syncMode`, `success`, and `error`.
 
-Example A2UI push:
+Example `canvas_ready` with v0.9 support:
+
+```json
+{
+  "type": "canvas_ready",
+  "capabilities": [
+    "a2ui.v0_8",
+    "a2ui.v0_9",
+    "canvas.present",
+    "canvas.hide",
+    "canvas.local_html",
+    "snapshot.state"
+  ],
+  "supportedCatalogIds": [
+    "urn:a2ui:catalog:openclaw_v0_8",
+    "urn:a2ui:catalog:agenui_catalog"
+  ]
+}
+```
+
+Example A2UI v0.8 push:
 
 ```json
 {
@@ -83,21 +113,81 @@ Example A2UI push:
 }
 ```
 
-Example event feedback:
+Example A2UI v0.9 `createSurface`:
 
 ```json
 {
-  "type": "a2ui_event",
+  "type": "a2ui_create_surface",
+  "operation": "createSurface",
+  "requestId": "canvas_123",
   "sessionId": "session_123",
-  "surfaceId": "main",
-  "componentId": "approve",
-  "event": "click",
-  "valueJson": "true",
-  "sequence": 7
+  "surfaceId": "details",
+  "catalogId": "urn:a2ui:catalog:agenui_catalog",
+  "surfaceTitle": "Details",
+  "components": [
+    "{\"type\":\"Text\",\"id\":\"title\",\"text\":\"Order details\"}",
+    "{\"type\":\"Button\",\"id\":\"approve\",\"label\":\"Approve\"}"
+  ],
+  "dataModelJson": "{\"order\":{\"status\":\"ready\"}}"
 }
 ```
 
-## A2UI Validation
+Example A2UI v0.9 `updateComponents`:
+
+```json
+{
+  "type": "a2ui_update_components",
+  "operation": "updateComponents",
+  "requestId": "canvas_124",
+  "sessionId": "session_123",
+  "surfaceId": "details",
+  "components": [
+    "{\"type\":\"Text\",\"id\":\"title\",\"text\":\"Updated order\"}"
+  ]
+}
+```
+
+Example A2UI v0.9 `updateDataModel`:
+
+```json
+{
+  "type": "a2ui_update_data_model",
+  "operation": "updateDataModel",
+  "requestId": "canvas_125",
+  "sessionId": "session_123",
+  "surfaceId": "details",
+  "dataModelJson": "{\"order\":{\"status\":\"approved\"}}"
+}
+```
+
+Example A2UI v0.9 action feedback:
+
+```json
+{
+  "type": "a2ui_action",
+  "operation": "action",
+  "sessionId": "session_123",
+  "surfaceId": "details",
+  "componentId": "approve",
+  "action": "click",
+  "valueJson": "true",
+  "sequence": 12
+}
+```
+
+Example A2UI v0.9 `deleteSurface`:
+
+```json
+{
+  "type": "a2ui_delete_surface",
+  "operation": "deleteSurface",
+  "requestId": "canvas_126",
+  "sessionId": "session_123",
+  "surfaceId": "details"
+}
+```
+
+## A2UI v0.8 JSONL Validation
 
 `a2ui_push` accepts JSONL only: one JSON object per line. The gateway validates payload size, frame count, required `type` and `id` fields, component-specific required fields, and supported component types before forwarding.
 
@@ -111,26 +201,78 @@ Examples:
 {"type":"progress","id":"deploy","value":0.45}
 ```
 
-The validator rejects v0.9 `createSurface` frames with an explicit diagnostic.
+The v0.8 JSONL validator still rejects v0.9 `createSurface` frames with an explicit diagnostic. Use the structured v0.9 tools instead.
+
+## A2UI v0.9 Surfaces
+
+Each v0.9 surface has its own state:
+
+- `surfaceId`
+- selected `catalogId`
+- title
+- component tree/list
+- data model JSON/object
+- component values
+- diagnostics
+- active/deleted state
+
+Lifecycle behavior:
+
+- `a2ui_create_surface` creates or replaces the target surface and locks the negotiated catalog for `senderId + sessionId + surfaceId`.
+- `a2ui_update_components` replaces only the targeted surface component tree.
+- `a2ui_update_data_model` updates only the targeted surface data model and lets clients refresh bound UI without resending component definitions.
+- `a2ui_sync_ui_to_data` asks the client to return its current UI/data state for the target surface.
+- `a2ui_delete_surface` removes the target surface and clears its catalog lock.
+- `a2ui_reset` remains the v0.8 compatibility clear operation and clears the client Canvas state.
+- `canvas_snapshot` returns surface-specific state when `surfaceId` is present.
+
+## Catalog Negotiation
+
+Built-in catalog IDs:
+
+- `urn:a2ui:catalog:openclaw_v0_8`
+- `urn:a2ui:catalog:agenui_catalog`
+
+Selection rules:
+
+1. The client advertises `supportedCatalogIds` in `canvas_ready`.
+2. If `a2ui_create_surface` specifies `catalogId`, the broker validates that the client advertised it.
+3. If no `catalogId` is specified, the broker prefers `urn:a2ui:catalog:agenui_catalog` when available, otherwise `urn:a2ui:catalog:openclaw_v0_8`.
+4. The chosen catalog is locked per surface lifecycle.
+5. Later updates for the same surface must use the locked catalog until `a2ui_delete_surface` clears the surface entry.
+
+The AGenUI catalog supports at least these component types:
+
+- `Text`, `Image`, `Icon`, `Divider`, `Video`, `AudioPlayer`, `Markdown`, `Button`, `TextField`, `CheckBox`, `Slider`, `ChoicePicker`, `DateTimeInput`, `Row`, `Column`, `Card`, `List`, `Tabs`, `Modal`, `Table`, `Carousel`, `Web`, `RichText`, and `Chart`.
+
+Compatibility aliases map v0.8 lowercase names to catalog names, including `text` to `Text`, `markdown` to `Markdown`, `card` to `Card`, `button` to `Button`, `input` to `TextField`, `select` to `ChoicePicker`, `checklist` to `CheckBox`, `table` to `Table`, `image` to `Image`, `progress` to `Slider`, and `chart` to `Chart`.
 
 ## Client Behavior
 
 Webchat advertises:
 
 - `a2ui.v0_8`
+- `a2ui.v0_9`
 - `canvas.present`
 - `canvas.hide`
 - `canvas.local_html`
 - `snapshot.state`
+- supported catalogs `urn:a2ui:catalog:openclaw_v0_8` and `urn:a2ui:catalog:agenui_catalog`
+
+Webchat renders v0.8 pushes into the default `main` surface and renders v0.9 operations into per-surface tabs. It supports renderer mappings for the AGenUI catalog and uses safe built-in placeholders for advanced media, carousel, and web components when a native renderer or sandbox is not available. Basic binding fields include `valueBinding`, `textBinding`, `itemsBinding`, `visibleBinding`, and `disabledBinding`, plus simple `{path.to.value}` interpolation.
 
 Companion advertises:
 
 - `a2ui.v0_8`
+- `a2ui.v0_9`
 - `canvas.present`
 - `canvas.hide`
 - `snapshot.state`
+- supported catalogs `urn:a2ui:catalog:openclaw_v0_8` and `urn:a2ui:catalog:agenui_catalog`
 
-The gateway uses advertised capabilities before forwarding commands. If a session is not websocket-backed, if the client is disconnected, or if the client lacks a required capability, Canvas tools fail with a normal tool error instead of attempting a best-effort send. No first-party v1 client advertises `a2ui.eval`; the tool remains capability-gated for future local sandboxes.
+Companion renders supported components natively, keeps one surface collection with an active surface selector, routes v0.8 pushes into `main`, and records diagnostics for unsupported advanced AGenUI components instead of failing the surface update.
+
+The gateway uses advertised capabilities before forwarding commands. If a session is not websocket-backed, if the client is disconnected, or if the client lacks a required capability/catalog, Canvas tools fail with a normal tool error instead of attempting a best-effort send. No first-party client advertises `a2ui.eval`; the tool remains capability-gated for future local sandboxes.
 
 ## Security Model
 
@@ -140,6 +282,7 @@ Canvas inherits the gateway’s local-first posture:
 - Non-websocket sessions cannot receive Canvas commands.
 - Public-bind deployments must explicitly opt into Canvas forwarding.
 - Remote webpage Canvas navigation is rejected.
+- Remote media and web components are rendered conservatively as placeholders or safe links unless a client explicitly supports a safe local rendering path.
 - A2UI eval is capability-gated and never targets third-party pages.
 - Command and result sizes are bounded.
 - Canvas command lifecycle events are written to the runtime event log.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -60,17 +60,19 @@ These APIs are not bridged. If a plugin uses them, initialization fails fast wit
 
 ## Canvas and A2UI Compatibility
 
-OpenClaw.NET ships a v1 Canvas/A2UI workspace for websocket clients. The supported target is local Canvas content plus A2UI v0.8 JSONL; remote webpage Canvas control and A2UI v0.9 surfaces remain intentionally unsupported. See [CANVAS_A2UI.md](CANVAS_A2UI.md).
+OpenClaw.NET ships a Canvas/A2UI workspace for websocket clients. The supported target is local Canvas content, A2UI v0.8 JSONL compatibility, and A2UI v0.9 structured surfaces with catalog negotiation; remote webpage Canvas control remains intentionally unsupported. See [CANVAS_A2UI.md](CANVAS_A2UI.md).
 
 | Surface | Status | Notes |
 | --- | --- | --- |
-| Canvas present/hide/snapshot commands | Supported | Typed websocket envelopes routed through the session-scoped broker. |
+| Canvas present/hide/snapshot commands | Supported | Typed websocket envelopes routed through the session-scoped broker. Snapshots can target a specific `surfaceId`. |
 | Local Canvas navigation | Supported with caveats | `about:blank` is supported. Inline local HTML is supported in webchat via sandboxed `srcdoc`; Companion reports an unsupported diagnostic without a native WebView. |
 | Remote webpage Canvas navigation/eval | Not supported | `http:` and `https:` URLs are rejected; use the browser tool for remote pages. |
-| A2UI v0.8 JSONL rendering | Supported | Webchat and Companion render text, markdown, card, button, input, select, checklist, table, image, progress, and simple chart frames. |
-| A2UI interaction event feedback | Supported | Client events return as structured `a2ui_event` session turns. |
-| A2UI eval | Supported with caveats | The gateway tool is capability-gated, but no first-party v1 client advertises `a2ui.eval`; webchat and Companion return unsupported diagnostics. |
-| A2UI v0.9 `createSurface` | Not supported | Validation rejects it with an explicit diagnostic. |
+| A2UI v0.8 JSONL rendering | Supported | Webchat and Companion render text, markdown, card, button, input, select, checklist, table, image, progress, and simple chart frames through `a2ui_push`. |
+| A2UI v0.9 structured surfaces | Supported | `a2ui_create_surface`, `a2ui_update_components`, `a2ui_update_data_model`, `a2ui_delete_surface`, and `a2ui_sync_ui_to_data` are capability-gated on `a2ui.v0_9`. |
+| A2UI catalog negotiation | Supported | Clients advertise `supportedCatalogIds`; the broker chooses or validates the requested catalog and locks it per `senderId + sessionId + surfaceId`. |
+| A2UI interaction feedback | Supported | v0.8 client events return as `a2ui_event`; v0.9 surface actions return as `a2ui_action` session turns. |
+| A2UI eval | Supported with caveats | The gateway tool is capability-gated, but no first-party client advertises `a2ui.eval`; webchat and Companion return unsupported diagnostics. |
+| Advanced AGenUI components | Supported with caveats | Webchat and Companion render native subsets and use conservative placeholders/diagnostics for media, carousel, web, or unsupported advanced components. |
 
 ## Channel Compatibility
 

--- a/docs/TOOLS_GUIDE.md
+++ b/docs/TOOLS_GUIDE.md
@@ -88,15 +88,19 @@ Gateway-registered first-party payment tool over the native payment runtime. Dis
 - Safety: money-moving actions are approval-gated by policy; tool results include safe metadata only.
 - Docs: [plugins/payment.md](plugins/payment.md) and [security/payments.md](security/payments.md).
 
-### 7b. Canvas and A2UI Tools (`canvas_present`, `canvas_hide`, `canvas_navigate`, `canvas_snapshot`, `a2ui_push`, `a2ui_reset`, `a2ui_eval`)
+### 7b. Canvas and A2UI Tools (`canvas_present`, `canvas_hide`, `canvas_navigate`, `canvas_snapshot`, `a2ui_push`, `a2ui_reset`, `a2ui_eval`, `a2ui_create_surface`, `a2ui_update_components`, `a2ui_update_data_model`, `a2ui_delete_surface`, `a2ui_sync_ui_to_data`)
+
 Control the current websocket session's Canvas visual workspace.
 - **Config**: `OpenClaw:Canvas:*`
 - **Scope**: websocket sessions only; commands are routed to the active client sender for the current session.
-- **A2UI**: `a2ui_push` accepts A2UI v0.8 JSONL frames for text, markdown, card, button, input, select, checklist, table, image, progress, and simple chart components.
+- **A2UI v0.8**: `a2ui_push` accepts JSONL frames for text, markdown, card, button, input, select, checklist, table, image, progress, and simple chart components.
+- **A2UI v0.9**: structured surface tools create, update, sync, and delete independent `surfaceId` contexts with component arrays and data models.
+- **Catalogs**: v0.9 tools use client-advertised `supportedCatalogIds`; the broker validates requested catalogs and locks the selected catalog for each surface lifecycle.
 - **Navigation**: `canvas_navigate` supports inline local HTML and `about:blank`; remote `http:` / `https:` Canvas navigation is rejected. Use the `browser` tool for remote webpages.
-- **Eval**: `a2ui_eval` is capability-gated. First-party v1 clients do not advertise `a2ui.eval`, so browser-side script execution remains disabled by default.
-- **Snapshots**: `canvas_snapshot` returns lightweight JSON state, not a remote browser screenshot.
+- **Eval**: `a2ui_eval` is capability-gated. First-party clients do not advertise `a2ui.eval`, so browser-side script execution remains disabled by default.
+- **Snapshots**: `canvas_snapshot` returns lightweight JSON state for the requested surface, not a remote browser screenshot.
 - **Safety**: non-loopback deployments must explicitly opt in with `OpenClaw:Canvas:AllowOnPublicBind=true`.
+- **Details**: see [CANVAS_A2UI.md](CANVAS_A2UI.md).
 
 ---
 

--- a/docs/testing/a2ui-webchat-testing-guide.md
+++ b/docs/testing/a2ui-webchat-testing-guide.md
@@ -1,0 +1,283 @@
+# A2UI WebChat Testing Technical Guide
+
+## 1. Document Objective
+
+This document provides guidance for testing A2UI functionality in OpenClaw using WebChat or the Companion Canvas tab, covering:
+
+- A2UI v0.8 JSONL push rendering
+- A2UI v0.9 structured surface lifecycle
+- Cross-surface isolation and regression checks
+- Troubleshooting and fixes for common failure scenarios
+
+## 2. Session Summary
+
+### 2.1 Completed
+
+- Clarified the A2UI test entry points and execution path in WebChat.
+- Provided executable step-by-step scripts for v0.8 + v0.9 + regression checks.
+- Successfully verified that `a2ui_update_data_model` and `canvas_snapshot` work on the `details` surface.
+
+### 2.2 Key Issue
+
+`a2ui_create_surface` failed. The root cause was an incorrect `components` parameter format.
+
+Incorrect example:
+
+["Text","Button"]
+
+Required format:
+
+- `components` must be a string array
+- Every item in the array must be a valid JSON string
+- Each component object should include at least `type` and `id`
+
+### 2.3 Observed Impact
+
+Because surface creation failed:
+
+- `dataModelJson` in the `details` snapshot could still update to `{"status":"approved"}`
+- but `components` remained empty
+- and `frameCount` was 0
+
+This matches what was observed in the session and confirms that data model updates do not imply that the component tree was created.
+
+## 3. Test Scope
+
+### 3.1 Covered
+
+- `canvas_present`
+- `a2ui_push`
+- `a2ui_create_surface`
+- `a2ui_update_data_model`
+- `a2ui_update_components`
+- `a2ui_sync_ui_to_data`
+- `a2ui_delete_surface`
+- `a2ui_reset`
+- `canvas_snapshot`
+
+### 3.2 Out of Scope
+
+- Remote webpage canvas navigation (`http/https`)
+- Remote page script execution
+
+## 4. Prerequisites
+
+1. Start the gateway: `dotnet run --project src/OpenClaw.Gateway`
+2. Open WebChat: `/chat`
+3. Ensure the current session is a websocket session
+4. Ensure Canvas is enabled (`OpenClaw:Canvas:Enabled=true`)
+
+It is recommended to run one basic tool call in WebChat first to verify the toolchain is working.
+
+
+## 5. Standard Test Flow
+
+This section provides a “dialog-style minimum smoke script (12 steps)” that you can paste directly into WebChat or the Companion Canvas tab, one step at a time. Wait for each response before sending the next step.
+
+---
+User: Please open Canvas with `surfaceId=main`.
+
+Assistant: Call `canvas_present`
+```json
+{
+	"surfaceId": "main"
+}
+```
+(Expected: `main` surface opens successfully, without errors)
+
+User: Please push a v0.8 text frame to the `main` surface.
+
+Assistant: Call `a2ui_push`
+```json
+{
+	"surfaceId": "main",
+	"contentType": "application/x-a2ui+jsonl;version=0.8",
+	"frames": "{\"type\":\"text\",\"id\":\"hello\",\"text\":\"ok\"}"
+}
+```
+(Expected: one text block is rendered on `main`)
+
+User: Please snapshot the `main` surface.
+
+Assistant: Call `canvas_snapshot`
+```json
+{
+	"surfaceId": "main"
+}
+```
+(Expected: `components` is non-empty, `frameCount=1`)
+
+User: Please create a v0.9 surface with `surfaceId=details`.
+
+Assistant: Call `a2ui_create_surface`
+```json
+{
+	"surfaceId": "details",
+	"components": [
+		"{\"type\":\"Text\",\"id\":\"title\",\"text\":\"ok\"}"
+	]
+}
+```
+(Expected: `details` surface is created and tab becomes visible)
+
+User: Please snapshot the `details` surface.
+
+Assistant: Call `canvas_snapshot`
+```json
+{
+	"surfaceId": "details"
+}
+```
+(Expected: `components` is non-empty, `frameCount=1`)
+
+User: Please change `details` data model status to `approved`.
+
+Assistant: Call `a2ui_update_data_model`
+```json
+{
+	"surfaceId": "details",
+	"dataModelJson": "{\"status\":\"approved\"}"
+}
+```
+(Expected: no error; snapshot `dataModelJson` changes to `approved`)
+
+User: Please change the `details` surface content to `updated`.
+
+Assistant: Call `a2ui_update_components`
+```json
+{
+	"surfaceId": "details",
+	"components": [
+		"{\"type\":\"Text\",\"id\":\"title\",\"text\":\"updated\"}"
+	]
+}
+```
+(Expected: rendered content on `details` changes to `updated`)
+
+User: Please snapshot the `details` surface.
+
+Assistant: Call `canvas_snapshot`
+```json
+{
+	"surfaceId": "details"
+}
+```
+(Expected: only 1 component remains and its content is `updated`)
+
+User: Please sync UI and data for the `details` surface.
+
+Assistant: Call `a2ui_sync_ui_to_data`
+```json
+{
+	"surfaceId": "details",
+	"syncMode": "full"
+}
+```
+(Expected: current UI/data state is returned)
+
+User: Please delete the `details` surface.
+
+Assistant: Call `a2ui_delete_surface`
+```json
+{
+	"surfaceId": "details"
+}
+```
+(Expected: `details` surface is removed and the tab disappears)
+
+User: Please snapshot the `details` surface.
+
+Assistant: Call `canvas_snapshot`
+```json
+{
+	"surfaceId": "details"
+}
+```
+(Expected: empty result or surface not found)
+
+User: Please reset the `main` surface.
+
+Assistant: Call `a2ui_reset`
+```json
+{
+	"surfaceId": "main"
+}
+```
+(Expected: `main` surface is cleared)
+
+---
+
+## 6. Result Criteria Matrix
+
+- `createSurface` success: `details.components` is non-empty and `frameCount > 0`
+- `updateDataModel` success: `dataModelJson` is updated correctly
+- `updateComponents` success: component tree is replaced and reflected in snapshot
+- Surface isolation correctness: `main` and `details` states are independent
+- `delete`/`reset` correctness: target surface state is cleared
+
+## 7. Troubleshooting
+
+### 7.1 createSurface Parse Failure
+
+Check in this order:
+
+1. Whether `components` is a string array
+2. Whether each string is valid JSON
+3. Whether each component includes `type` and `id`
+
+### 7.2 Snapshot Has dataModel but Empty components
+
+This usually means:
+
+- `createSurface` did not succeed
+- only `updateDataModel` was executed
+
+Fix: correct `createSurface` first, then continue with subsequent steps.
+
+### 7.3 catalog-Related Failures
+
+- If `catalogId` mismatches client negotiation, omit `catalogId` first and use automatic negotiation
+- Keep catalog consistent within a single surface lifecycle
+
+## 8. Implemented Automated Test Coverage
+
+The following capabilities are already implemented in the test project and validated via `CanvasToolTests`:
+
+- v0.9 lifecycle WebSocket-level integration test
+	- Test: `A2UiV09Lifecycle_WebSocketRoundTrip_CoversCreateUpdateSnapshotSyncAndDelete`
+	- Coverage: `createSurface -> snapshot -> updateDataModel -> updateComponents -> snapshot -> syncUIToData -> deleteSurface`
+- Negative validation for invalid `components` parameters
+	- Test: `A2UiCreateSurface_RejectsNonStringComponentArray`
+	- Test: `A2UiUpdateComponents_RejectsNonStringComponentArray`
+	- Coverage: rejects non-string-array component elements and prevents send
+- Unified snapshot assertion template
+	- File: `CanvasSnapshotAssertions.cs`
+	- Method: `AssertV09Snapshot`
+	- Unified checks: `dataModelJson`, `components`, `frameCount`, `diagnostics`
+
+## 9. Support Matrix and Test Evidence
+
+### 9.1 Capability Support Matrix
+
+- WebChat / Companion Canvas tab
+	- Verified: A2UI v0.8 push rendering, A2UI v0.9 surface lifecycle, snapshot regression checks
+	- Known limitation: `a2ui_eval` is capability-restricted by default (first-party clients do not declare this capability by default)
+- catalog negotiation
+	- Recommended strategy: omit `catalogId` first and rely on automatic negotiation
+	- Fallback strategy: if the session only exposes a v0.8 catalog, run v0.8 scripts for rendering and regression
+
+### 9.2 Automated Test Evidence
+
+- Executed command
+	- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj --filter "FullyQualifiedName~CanvasToolTests"`
+- Latest result
+	- Total: 25
+	- Passed: 25
+	- Failed: 0
+	- Skipped: 0
+
+### 9.3 Final Conclusion
+
+- Confirmed core pitfall: `a2ui_create_surface.components` must be a JSON string array.
+- Established a closed loop of manual scripts + WebSocket-level automated tests + unified snapshot assertions.
+- This document is directly usable for end-to-end validation and regression execution in both WebChat and the Companion Canvas tab.

--- a/src/OpenClaw.Channels/WebSocketChannel.cs
+++ b/src/OpenClaw.Channels/WebSocketChannel.cs
@@ -114,7 +114,7 @@ public sealed class WebSocketChannel : IChannelAdapter
                 if (parsed.CanvasEnvelope is not null)
                 {
                     await HandleCanvasClientEnvelopeAsync(clientId, parsed.CanvasEnvelope, ct);
-                    if (!string.Equals(parsed.CanvasEnvelope.Type, "a2ui_event", StringComparison.Ordinal))
+                    if (!IsCanvasClientInteractionEnvelope(parsed.CanvasEnvelope.Type))
                         continue;
                 }
 
@@ -130,7 +130,9 @@ public sealed class WebSocketChannel : IChannelAdapter
                     RequestId = parsed.CanvasEnvelope?.RequestId,
                     SurfaceId = parsed.CanvasEnvelope?.SurfaceId,
                     ComponentId = parsed.CanvasEnvelope?.ComponentId,
-                    Event = parsed.CanvasEnvelope?.Event,
+                    Event = string.Equals(parsed.CanvasEnvelope?.Type, "a2ui_action", StringComparison.Ordinal)
+                        ? parsed.CanvasEnvelope?.Action
+                        : parsed.CanvasEnvelope?.Event,
                     ValueJson = parsed.CanvasEnvelope?.ValueJson,
                     Sequence = parsed.CanvasEnvelope?.Sequence,
                     ApprovalId = parsed.ApprovalId,
@@ -552,9 +554,12 @@ public sealed class WebSocketChannel : IChannelAdapter
 
             if (env is not null && IsCanvasClientEnvelope(env.Type))
             {
-                var text = string.Equals(env.Type, "a2ui_event", StringComparison.Ordinal)
-                    ? BuildA2UiEventText(env)
-                    : "";
+                var text = env.Type switch
+                {
+                    "a2ui_event" => BuildA2UiEventText(env),
+                    "a2ui_action" => BuildA2UiActionText(env),
+                    _ => ""
+                };
                 return new ParsedWsInbound(
                     true,
                     env.Type,
@@ -582,7 +587,10 @@ public sealed class WebSocketChannel : IChannelAdapter
     }
 
     private static bool IsCanvasClientEnvelope(string? type)
-        => type is "canvas_ready" or "canvas_ack" or "canvas_snapshot_result" or "canvas_eval_result" or "a2ui_event";
+        => type is "canvas_ready" or "canvas_ack" or "canvas_snapshot_result" or "canvas_eval_result" or "a2ui_event" or "a2ui_action" or "a2ui_error" or "a2ui_sync_result";
+
+    private static bool IsCanvasClientInteractionEnvelope(string? type)
+        => type is "a2ui_event" or "a2ui_action";
 
     private static string BuildA2UiEventText(WsClientEnvelope env)
     {
@@ -593,6 +601,21 @@ public sealed class WebSocketChannel : IChannelAdapter
                $"  \"componentId\": {JsonStringLiteral(env.ComponentId ?? "")},\n" +
                $"  \"event\": {JsonStringLiteral(env.Event ?? "")},\n" +
                $"  \"value\": {value},\n" +
+               $"  \"sequence\": {(env.Sequence ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)}\n" +
+               "}";
+    }
+
+    private static string BuildA2UiActionText(WsClientEnvelope env)
+    {
+        var value = NormalizeJsonValue(env.ValueJson);
+        var dataModel = NormalizeJsonValue(env.DataModelJson);
+        return "{\n" +
+               "  \"type\": \"a2ui_action\",\n" +
+               $"  \"surfaceId\": {JsonStringLiteral(env.SurfaceId ?? "main")},\n" +
+               $"  \"componentId\": {JsonStringLiteral(env.ComponentId ?? "")},\n" +
+               $"  \"action\": {JsonStringLiteral(env.Action ?? "")},\n" +
+               $"  \"value\": {value},\n" +
+               $"  \"dataModel\": {dataModel},\n" +
                $"  \"sequence\": {(env.Sequence ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture)}\n" +
                "}";
     }

--- a/src/OpenClaw.Companion/ViewModels/A2UiFrameItem.cs
+++ b/src/OpenClaw.Companion/ViewModels/A2UiFrameItem.cs
@@ -53,13 +53,14 @@ public sealed partial class A2UiFrameItem : ObservableObject
     public bool HasDisplayText => !string.IsNullOrWhiteSpace(DisplayText);
     public bool HasOptions => Options.Count > 0;
     public bool HasTable => Columns.Count > 0 || Rows.Count > 0;
-    public bool IsButton => TypeEquals("button");
-    public bool IsInput => TypeEquals("input");
-    public bool IsSelect => TypeEquals("select");
-    public bool IsChecklist => TypeEquals("checklist");
-    public bool IsProgress => TypeEquals("progress");
-    public bool IsImage => TypeEquals("image");
-    public bool IsChart => TypeEquals("chart");
+    public bool IsButton => TypeEquals("button") || TypeEquals("Button");
+    public bool IsInput => TypeEquals("input") || TypeEquals("TextField");
+    public bool IsSelect => TypeEquals("select") || TypeEquals("ChoicePicker");
+    public bool IsChecklist => TypeEquals("checklist") || TypeEquals("CheckBox");
+    public bool IsProgress => TypeEquals("progress") || TypeEquals("Slider");
+    public bool IsImage => TypeEquals("image") || TypeEquals("Image");
+    public bool IsChart => TypeEquals("chart") || TypeEquals("Chart");
+    public bool IsUnsupportedFallback => !IsButton && !IsInput && !IsSelect && !IsChecklist && !IsProgress && !IsImage && !IsChart && !HasText && !HasBody && !HasTable && !HasDisplayText;
 
     public static A2UiFrameItem FromJson(string surfaceId, JsonElement root, Func<A2UiFrameItem, string, string, Task> onEvent)
     {

--- a/src/OpenClaw.Companion/ViewModels/A2UiSurfaceItem.cs
+++ b/src/OpenClaw.Companion/ViewModels/A2UiSurfaceItem.cs
@@ -1,0 +1,31 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace OpenClaw.Companion.ViewModels;
+
+public sealed partial class A2UiSurfaceItem : ObservableObject
+{
+    public A2UiSurfaceItem(string surfaceId, string catalogId, string title)
+    {
+        SurfaceId = surfaceId;
+        CatalogId = catalogId;
+        Title = title;
+    }
+
+    public string SurfaceId { get; }
+
+    [ObservableProperty]
+    private string _catalogId;
+
+    [ObservableProperty]
+    private string _title;
+
+    public ObservableCollection<A2UiFrameItem> Components { get; } = new();
+    public ObservableCollection<string> Diagnostics { get; } = new();
+
+    [ObservableProperty]
+    private string? _dataModelJson;
+
+    [ObservableProperty]
+    private bool _isActive;
+}

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Canvas.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Canvas.cs
@@ -26,13 +26,30 @@ public sealed partial class MainWindowViewModel
     [ObservableProperty]
     private string _canvasHtmlStatus = "";
 
+    public ObservableCollection<A2UiSurfaceItem> CanvasSurfaces { get; } = new();
+
+    [ObservableProperty]
+    private A2UiSurfaceItem? _activeCanvasSurface;
+
     public ObservableCollection<A2UiFrameItem> CanvasFrames { get; } = new();
 
     public bool HasCanvasFrames => CanvasFrames.Count > 0;
+    public bool HasCanvasSurfaces => CanvasSurfaces.Count > 0;
+    public bool HasActiveCanvasSurfaceDiagnostics => ActiveCanvasSurface?.Diagnostics.Count > 0;
     public bool HasCanvasHtmlStatus => !string.IsNullOrWhiteSpace(CanvasHtmlStatus);
 
     partial void OnCanvasHtmlStatusChanged(string value)
         => OnPropertyChanged(nameof(HasCanvasHtmlStatus));
+
+    partial void OnActiveCanvasSurfaceChanged(A2UiSurfaceItem? oldValue, A2UiSurfaceItem? newValue)
+    {
+        if (oldValue is not null)
+            oldValue.IsActive = false;
+        if (newValue is not null)
+            newValue.IsActive = true;
+        SyncCompatibilityCanvasFrames();
+        OnPropertyChanged(nameof(HasActiveCanvasSurfaceDiagnostics));
+    }
 
     private async Task SendCanvasReadyAsync()
     {
@@ -47,7 +64,13 @@ public sealed partial class MainWindowViewModel
                 "a2ui.v0_8",
                 "canvas.present",
                 "canvas.hide",
-                "snapshot.state"
+                "snapshot.state",
+                "a2ui.v0_9"
+            ],
+            SupportedCatalogIds =
+            [
+                A2UiCatalogRegistry.OpenClawV08CatalogId,
+                A2UiCatalogRegistry.AGenUiCatalogId
             ]
         }, CancellationToken.None);
     }
@@ -86,14 +109,37 @@ public sealed partial class MainWindowViewModel
                     return;
 
                 case "a2ui_reset":
+                    CanvasSurfaces.Clear();
+                    ActiveCanvasSurface = null;
                     CanvasFrames.Clear();
                     OnPropertyChanged(nameof(HasCanvasFrames));
+                    OnPropertyChanged(nameof(HasCanvasSurfaces));
                     CanvasStatus = "Canvas reset.";
                     await SendCanvasAckAsync(envelope, success: true, error: null);
                     return;
 
                 case "a2ui_push":
-                    await ApplyA2UiPushAsync(envelope, surfaceId);
+                    await ApplyA2UiPushAsync(envelope, "main");
+                    return;
+
+                case "a2ui_create_surface":
+                    await ApplyA2UiCreateSurfaceAsync(envelope, surfaceId);
+                    return;
+
+                case "a2ui_update_components":
+                    await ApplyA2UiUpdateComponentsAsync(envelope, surfaceId);
+                    return;
+
+                case "a2ui_update_data_model":
+                    await ApplyA2UiUpdateDataModelAsync(envelope, surfaceId);
+                    return;
+
+                case "a2ui_delete_surface":
+                    await ApplyA2UiDeleteSurfaceAsync(envelope, surfaceId);
+                    return;
+
+                case "a2ui_sync_ui_to_data":
+                    await SendA2UiSyncResultAsync(envelope);
                     return;
 
                 case "canvas_snapshot":
@@ -115,10 +161,13 @@ public sealed partial class MainWindowViewModel
     {
         if (string.Equals(envelope.Url, "about:blank", StringComparison.OrdinalIgnoreCase))
         {
+            CanvasSurfaces.Clear();
+            ActiveCanvasSurface = null;
             CanvasFrames.Clear();
             CanvasHtmlStatus = "";
             CanvasStatus = "Canvas navigated to blank.";
             OnPropertyChanged(nameof(HasCanvasFrames));
+            OnPropertyChanged(nameof(HasCanvasSurfaces));
             await SendCanvasAckAsync(envelope, success: true, error: null);
             return;
         }
@@ -140,19 +189,152 @@ public sealed partial class MainWindowViewModel
             return;
         }
 
+        var surface = GetOrCreateSurface(surfaceId, A2UiCatalogRegistry.OpenClawV08CatalogId, "Main");
         foreach (var line in envelope.Frames!.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'))
         {
             if (string.IsNullOrWhiteSpace(line))
                 continue;
 
             using var doc = JsonDocument.Parse(line);
-            CanvasFrames.Add(A2UiFrameItem.FromJson(surfaceId, doc.RootElement, SendA2UiEventAsync));
+            surface.Components.Add(A2UiFrameItem.FromJson(surfaceId, doc.RootElement, SendA2UiEventAsync));
         }
 
+        ActiveCanvasSurface = surface;
         IsCanvasVisible = true;
         CanvasStatus = $"Rendered {validation.FrameCount} A2UI frame(s).";
-        OnPropertyChanged(nameof(HasCanvasFrames));
+        NotifySurfaceStateChanged();
         await SendCanvasAckAsync(envelope, success: true, error: null);
+    }
+
+    private async Task ApplyA2UiCreateSurfaceAsync(WsServerEnvelope envelope, string surfaceId)
+    {
+        var components = BuildV09Components(surfaceId, envelope.Components, out var diagnostics);
+        var surface = GetOrCreateSurface(surfaceId, envelope.CatalogId, envelope.SurfaceTitle);
+        surface.CatalogId = string.IsNullOrWhiteSpace(envelope.CatalogId) ? A2UiCatalogRegistry.AGenUiCatalogId : envelope.CatalogId!;
+        surface.Title = string.IsNullOrWhiteSpace(envelope.SurfaceTitle) ? surfaceId : envelope.SurfaceTitle!;
+        surface.DataModelJson = envelope.DataModelJson;
+        surface.Components.Clear();
+        surface.Diagnostics.Clear();
+        foreach (var item in components)
+            surface.Components.Add(item);
+        foreach (var diagnostic in diagnostics)
+            surface.Diagnostics.Add(diagnostic);
+        ActiveCanvasSurface = surface;
+        IsCanvasVisible = true;
+        CanvasStatus = $"Created A2UI surface '{surface.Title}'.";
+        NotifySurfaceStateChanged();
+        await SendCanvasAckAsync(envelope, success: true, error: null);
+    }
+
+    private async Task ApplyA2UiUpdateComponentsAsync(WsServerEnvelope envelope, string surfaceId)
+    {
+        var components = BuildV09Components(surfaceId, envelope.Components, out var diagnostics);
+        var surface = GetOrCreateSurface(surfaceId, envelope.CatalogId, envelope.SurfaceTitle);
+        surface.Components.Clear();
+        surface.Diagnostics.Clear();
+        foreach (var item in components)
+            surface.Components.Add(item);
+        foreach (var diagnostic in diagnostics)
+            surface.Diagnostics.Add(diagnostic);
+        ActiveCanvasSurface = surface;
+        IsCanvasVisible = true;
+        CanvasStatus = $"Updated A2UI surface '{surface.Title}'.";
+        NotifySurfaceStateChanged();
+        await SendCanvasAckAsync(envelope, success: true, error: null);
+    }
+
+    private async Task ApplyA2UiUpdateDataModelAsync(WsServerEnvelope envelope, string surfaceId)
+    {
+        var surface = GetOrCreateSurface(surfaceId, envelope.CatalogId, envelope.SurfaceTitle);
+        surface.DataModelJson = envelope.DataModelJson;
+        ActiveCanvasSurface = surface;
+        IsCanvasVisible = true;
+        CanvasStatus = $"Updated A2UI data model for '{surface.Title}'.";
+        NotifySurfaceStateChanged();
+        await SendCanvasAckAsync(envelope, success: true, error: null);
+    }
+
+    private async Task ApplyA2UiDeleteSurfaceAsync(WsServerEnvelope envelope, string surfaceId)
+    {
+        var surface = CanvasSurfaces.FirstOrDefault(s => string.Equals(s.SurfaceId, surfaceId, StringComparison.OrdinalIgnoreCase));
+        if (surface is not null)
+            CanvasSurfaces.Remove(surface);
+
+        if (ReferenceEquals(ActiveCanvasSurface, surface))
+            ActiveCanvasSurface = CanvasSurfaces.FirstOrDefault();
+        else
+            SyncCompatibilityCanvasFrames();
+
+        IsCanvasVisible = CanvasSurfaces.Count > 0;
+        CanvasStatus = $"Deleted A2UI surface '{surfaceId}'.";
+        NotifySurfaceStateChanged();
+        await SendCanvasAckAsync(envelope, success: true, error: null);
+    }
+
+    private A2UiSurfaceItem GetOrCreateSurface(string surfaceId, string? catalogId, string? title)
+    {
+        var surface = CanvasSurfaces.FirstOrDefault(s => string.Equals(s.SurfaceId, surfaceId, StringComparison.OrdinalIgnoreCase));
+        if (surface is not null)
+            return surface;
+
+        surface = new A2UiSurfaceItem(
+            surfaceId,
+            string.IsNullOrWhiteSpace(catalogId) ? A2UiCatalogRegistry.AGenUiCatalogId : catalogId!,
+            string.IsNullOrWhiteSpace(title) ? surfaceId : title!);
+        CanvasSurfaces.Add(surface);
+        OnPropertyChanged(nameof(HasCanvasSurfaces));
+        return surface;
+    }
+
+    private void AddV09Components(A2UiSurfaceItem surface, string[]? components)
+    {
+        if (components is null)
+            return;
+
+        var items = BuildV09Components(surface.SurfaceId, components, out var diagnostics);
+        foreach (var item in items)
+            surface.Components.Add(item);
+        foreach (var diagnostic in diagnostics)
+            surface.Diagnostics.Add(diagnostic);
+    }
+
+    private IReadOnlyList<A2UiFrameItem> BuildV09Components(string surfaceId, string[]? components, out IReadOnlyList<string> diagnostics)
+    {
+        var items = new List<A2UiFrameItem>();
+        var diagnosticItems = new List<string>();
+        if (components is not null)
+        {
+            foreach (var componentJson in components)
+            {
+                using var doc = JsonDocument.Parse(componentJson);
+                var item = A2UiFrameItem.FromJson(surfaceId, doc.RootElement, SendA2UiActionAsync);
+                if (item.IsUnsupportedFallback)
+                    diagnosticItems.Add($"Unsupported AGenUI component '{item.Type}' rendered as fallback.");
+                items.Add(item);
+            }
+        }
+
+        diagnostics = diagnosticItems;
+        return items;
+    }
+
+    private void SyncCompatibilityCanvasFrames()
+    {
+        CanvasFrames.Clear();
+        if (ActiveCanvasSurface is not null)
+        {
+            foreach (var component in ActiveCanvasSurface.Components)
+                CanvasFrames.Add(component);
+        }
+        OnPropertyChanged(nameof(HasCanvasFrames));
+    }
+
+    private void NotifySurfaceStateChanged()
+    {
+        SyncCompatibilityCanvasFrames();
+        OnPropertyChanged(nameof(HasCanvasFrames));
+        OnPropertyChanged(nameof(HasCanvasSurfaces));
+        OnPropertyChanged(nameof(HasActiveCanvasSurfaceDiagnostics));
     }
 
     private async Task SendCanvasAckAsync(WsServerEnvelope envelope, bool success, string? error)
@@ -179,6 +361,22 @@ public sealed partial class MainWindowViewModel
             Success = success,
             ValueJson = valueJson,
             Error = error
+        }, CancellationToken.None);
+    }
+
+    private async Task SendA2UiSyncResultAsync(WsServerEnvelope envelope)
+    {
+        var dataModelJson = BuildA2UiSyncDataModelJson(envelope.SurfaceId);
+        await _client.SendEnvelopeAsync(new WsClientEnvelope
+        {
+            Type = "a2ui_sync_result",
+            RequestId = envelope.RequestId,
+            SessionId = _canvasSessionId,
+            SurfaceId = envelope.SurfaceId,
+            ComponentId = envelope.ComponentId,
+            SyncMode = envelope.SyncMode,
+            Success = true,
+            ValueJson = dataModelJson
         }, CancellationToken.None);
     }
 
@@ -214,10 +412,43 @@ public sealed partial class MainWindowViewModel
         }, CancellationToken.None);
     }
 
+    private async Task SendA2UiActionAsync(A2UiFrameItem frame, string actionName, string parametersJson)
+    {
+        if (!_client.IsConnected)
+            return;
+
+        await _client.SendEnvelopeAsync(new WsClientEnvelope
+        {
+            Type = "a2ui_action",
+            Operation = "action",
+            SessionId = _canvasSessionId,
+            SurfaceId = frame.SurfaceId,
+            ComponentId = frame.Id,
+            Action = actionName,
+            ValueJson = parametersJson,
+            Sequence = Interlocked.Increment(ref _canvasEventSequence)
+        }, CancellationToken.None);
+    }
+
+    private string BuildA2UiSyncDataModelJson(string? surfaceId)
+    {
+        var surface = FindCanvasSurface(surfaceId);
+        if (IsJsonObject(surface?.DataModelJson))
+            return surface!.DataModelJson!;
+
+        var values = (surface?.Components ?? CanvasFrames)
+            .Where(static frame => !string.IsNullOrWhiteSpace(frame.ValueText) || !string.IsNullOrWhiteSpace(frame.SelectedValue))
+            .ToDictionary(static frame => frame.Id, static frame => (object?)(frame.SelectedValue ?? frame.ValueText));
+        return JsonSerializer.Serialize(values);
+    }
+
     private string BuildCanvasSnapshotJson(string? surfaceId)
     {
-        var totalFrames = CanvasFrames.Count;
-        var frames = CanvasFrames.Take(MaxSnapshotFrames).Select(frame => new
+        var resolvedSurfaceId = ResolveSurfaceId(surfaceId);
+        var surface = FindCanvasSurface(resolvedSurfaceId);
+        var sourceFrames = surface?.Components ?? CanvasFrames;
+        var totalFrames = sourceFrames.Count;
+        var frames = sourceFrames.Take(MaxSnapshotFrames).Select(frame => new
         {
             frame.SurfaceId,
             frame.Id,
@@ -229,16 +460,24 @@ public sealed partial class MainWindowViewModel
             SelectedValue = TruncateSnapshotText(frame.SelectedValue)
         }).ToArray();
 
+        var diagnostics = new List<string>();
+        if (!string.IsNullOrWhiteSpace(CanvasHtmlStatus))
+            diagnostics.Add(CanvasHtmlStatus);
+        if (surface is not null)
+            diagnostics.AddRange(surface.Diagnostics);
+
+        var dataModel = ParseJsonObjectOrNull(surface?.DataModelJson, diagnostics);
         var snapshot = JsonSerializer.Serialize(new
         {
             type = "canvas_snapshot",
-            surfaceId = string.IsNullOrWhiteSpace(surfaceId) ? "main" : surfaceId,
+            surfaceId = resolvedSurfaceId,
             visible = IsCanvasVisible,
             frameCount = totalFrames,
             returnedFrameCount = frames.Length,
             truncated = totalFrames > frames.Length,
+            dataModel,
             frames,
-            diagnostics = string.IsNullOrWhiteSpace(CanvasHtmlStatus) ? Array.Empty<string>() : new[] { CanvasHtmlStatus }
+            diagnostics = diagnostics.ToArray()
         });
 
         if (snapshot.Length <= MaxSnapshotJsonChars)
@@ -247,7 +486,7 @@ public sealed partial class MainWindowViewModel
         return JsonSerializer.Serialize(new
         {
             type = "canvas_snapshot",
-            surfaceId = string.IsNullOrWhiteSpace(surfaceId) ? "main" : surfaceId,
+            surfaceId = resolvedSurfaceId,
             visible = IsCanvasVisible,
             frameCount = totalFrames,
             returnedFrameCount = 0,
@@ -255,6 +494,48 @@ public sealed partial class MainWindowViewModel
             frames = Array.Empty<object>(),
             diagnostics = new[] { $"Snapshot exceeded {MaxSnapshotJsonChars} characters and was truncated." }
         });
+    }
+
+    private A2UiSurfaceItem? FindCanvasSurface(string? surfaceId)
+    {
+        var resolvedSurfaceId = ResolveSurfaceId(surfaceId);
+        return CanvasSurfaces.FirstOrDefault(s => string.Equals(s.SurfaceId, resolvedSurfaceId, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private string ResolveSurfaceId(string? surfaceId)
+        => string.IsNullOrWhiteSpace(surfaceId) ? ActiveCanvasSurface?.SurfaceId ?? "main" : surfaceId!;
+
+    private static JsonElement? ParseJsonObjectOrNull(string? json, ICollection<string> diagnostics)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            diagnostics.Add("Surface dataModelJson is not valid JSON and was omitted from the snapshot.");
+            return null;
+        }
+    }
+
+    private static bool IsJsonObject(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return false;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.ValueKind == JsonValueKind.Object;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 
     private static string? TruncateSnapshotText(string? value)
@@ -265,12 +546,15 @@ public sealed partial class MainWindowViewModel
     [RelayCommand]
     private void ClearCanvas()
     {
+        CanvasSurfaces.Clear();
+        ActiveCanvasSurface = null;
         CanvasFrames.Clear();
         CanvasHtmlStatus = "";
         CanvasStatus = "Canvas cleared.";
         OnPropertyChanged(nameof(HasCanvasFrames));
+        OnPropertyChanged(nameof(HasCanvasSurfaces));
     }
 
     private static bool IsCanvasServerEnvelope(string type)
-        => type is "canvas_present" or "canvas_hide" or "canvas_navigate" or "canvas_snapshot" or "a2ui_push" or "a2ui_reset" or "a2ui_eval";
+        => type is "canvas_present" or "canvas_hide" or "canvas_navigate" or "canvas_snapshot" or "a2ui_push" or "a2ui_reset" or "a2ui_eval" or "a2ui_create_surface" or "a2ui_update_components" or "a2ui_update_data_model" or "a2ui_delete_surface" or "a2ui_sync_ui_to_data";
 }

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Canvas.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Canvas.cs
@@ -437,9 +437,28 @@ public sealed partial class MainWindowViewModel
             return surface!.DataModelJson!;
 
         var values = (surface?.Components ?? CanvasFrames)
-            .Where(static frame => !string.IsNullOrWhiteSpace(frame.ValueText) || !string.IsNullOrWhiteSpace(frame.SelectedValue))
-            .ToDictionary(static frame => frame.Id, static frame => (object?)(frame.SelectedValue ?? frame.ValueText));
+            .Select(static frame => new { frame.Id, Value = GetA2UiSyncValue(frame) })
+            .Where(static item => item.Value is not null)
+            .ToDictionary(static item => item.Id, static item => item.Value);
         return JsonSerializer.Serialize(values);
+    }
+
+    private static object? GetA2UiSyncValue(A2UiFrameItem frame)
+    {
+        if (frame.IsChecklist)
+        {
+            var selectedOptions = frame.Options
+                .Where(static option => option.IsSelected)
+                .Select(static option => option.Value)
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .ToArray();
+            if (selectedOptions.Length > 0)
+                return selectedOptions;
+        }
+
+        return !string.IsNullOrWhiteSpace(frame.SelectedValue)
+            ? frame.SelectedValue
+            : string.IsNullOrWhiteSpace(frame.ValueText) ? null : frame.ValueText;
     }
 
     private string BuildCanvasSnapshotJson(string? surfaceId)
@@ -513,7 +532,9 @@ public sealed partial class MainWindowViewModel
         try
         {
             using var doc = JsonDocument.Parse(json);
-            return doc.RootElement.Clone();
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                ? doc.RootElement.Clone()
+                : null;
         }
         catch (JsonException)
         {

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Canvas.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Canvas.cs
@@ -228,8 +228,14 @@ public sealed partial class MainWindowViewModel
 
     private async Task ApplyA2UiUpdateComponentsAsync(WsServerEnvelope envelope, string surfaceId)
     {
+        var surface = FindCanvasSurface(surfaceId);
+        if (surface is null)
+        {
+            await SendCanvasAckAsync(envelope, success: false, error: $"Unknown A2UI surface '{surfaceId}'.");
+            return;
+        }
+
         var components = BuildV09Components(surfaceId, envelope.Components, out var diagnostics);
-        var surface = GetOrCreateSurface(surfaceId, envelope.CatalogId, envelope.SurfaceTitle);
         surface.Components.Clear();
         surface.Diagnostics.Clear();
         foreach (var item in components)
@@ -245,7 +251,13 @@ public sealed partial class MainWindowViewModel
 
     private async Task ApplyA2UiUpdateDataModelAsync(WsServerEnvelope envelope, string surfaceId)
     {
-        var surface = GetOrCreateSurface(surfaceId, envelope.CatalogId, envelope.SurfaceTitle);
+        var surface = FindCanvasSurface(surfaceId);
+        if (surface is null)
+        {
+            await SendCanvasAckAsync(envelope, success: false, error: $"Unknown A2UI surface '{surfaceId}'.");
+            return;
+        }
+
         surface.DataModelJson = envelope.DataModelJson;
         ActiveCanvasSurface = surface;
         IsCanvasVisible = true;
@@ -433,10 +445,10 @@ public sealed partial class MainWindowViewModel
     private string BuildA2UiSyncDataModelJson(string? surfaceId)
     {
         var surface = FindCanvasSurface(surfaceId);
-        if (IsJsonObject(surface?.DataModelJson))
-            return surface!.DataModelJson!;
-
-        var values = (surface?.Components ?? CanvasFrames)
+        IReadOnlyCollection<A2UiFrameItem> sourceFrames = string.IsNullOrWhiteSpace(surfaceId)
+            ? surface is not null ? surface.Components : CanvasFrames
+            : surface is not null ? surface.Components : Array.Empty<A2UiFrameItem>();
+        var values = sourceFrames
             .Select(static frame => new { frame.Id, Value = GetA2UiSyncValue(frame) })
             .Where(static item => item.Value is not null)
             .ToDictionary(static item => item.Id, static item => item.Value);
@@ -465,7 +477,9 @@ public sealed partial class MainWindowViewModel
     {
         var resolvedSurfaceId = ResolveSurfaceId(surfaceId);
         var surface = FindCanvasSurface(resolvedSurfaceId);
-        var sourceFrames = surface?.Components ?? CanvasFrames;
+        IReadOnlyCollection<A2UiFrameItem> sourceFrames = string.IsNullOrWhiteSpace(surfaceId)
+            ? surface is not null ? surface.Components : CanvasFrames
+            : surface is not null ? surface.Components : Array.Empty<A2UiFrameItem>();
         var totalFrames = sourceFrames.Count;
         var frames = sourceFrames.Take(MaxSnapshotFrames).Select(frame => new
         {

--- a/src/OpenClaw.Companion/Views/MainWindow.axaml
+++ b/src/OpenClaw.Companion/Views/MainWindow.axaml
@@ -155,14 +155,24 @@
                 <Grid RowDefinitions="Auto,*" RowSpacing="10">
                     <Border Grid.Row="0" Padding="10" CornerRadius="8" BorderThickness="1"
                             BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
-                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                        <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
                             <StackPanel Grid.Column="0" Spacing="2">
                                 <TextBlock Text="{Binding CanvasStatus}" TextWrapping="Wrap" />
                                 <TextBlock Text="{Binding CanvasHtmlStatus}" FontSize="11" Opacity="0.65"
                                            TextWrapping="Wrap"
                                            IsVisible="{Binding HasCanvasHtmlStatus}" />
                             </StackPanel>
-                            <Button Grid.Column="1" Content="Clear"
+                            <ComboBox x:Name="CanvasSurfaceSelector" Grid.Column="1" MinWidth="180"
+                                      ItemsSource="{Binding CanvasSurfaces}"
+                                      SelectedItem="{Binding ActiveCanvasSurface}"
+                                      IsVisible="{Binding HasCanvasSurfaces}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate DataType="vm:A2UiSurfaceItem">
+                                        <TextBlock Text="{Binding Title}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                            <Button Grid.Column="2" Content="Clear"
                                     Command="{Binding ClearCanvasCommand}" />
                         </Grid>
                     </Border>
@@ -176,7 +186,7 @@
                                        IsVisible="{Binding !HasCanvasFrames}" />
                             <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto"
                                           IsVisible="{Binding HasCanvasFrames}">
-                                <ItemsControl ItemsSource="{Binding CanvasFrames}">
+                                <ItemsControl x:Name="CanvasComponentHost" ItemsSource="{Binding ActiveCanvasSurface.Components}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate DataType="vm:A2UiFrameItem">
                                             <Border Margin="0,0,0,8" Padding="10" CornerRadius="6" BorderThickness="1"
@@ -225,6 +235,9 @@
                                                                FontFamily="Consolas, Menlo, monospace"
                                                                FontSize="12"
                                                                IsVisible="{Binding HasDisplayText}" />
+                                                    <TextBlock Text="{Binding Type, StringFormat='Unsupported component: {0}'}"
+                                                               FontSize="11" Opacity="0.65" TextWrapping="Wrap"
+                                                               IsVisible="{Binding IsUnsupportedFallback}" />
                                                 </StackPanel>
                                             </Border>
                                         </DataTemplate>

--- a/src/OpenClaw.Core/Canvas/A2UiCatalogDescriptor.cs
+++ b/src/OpenClaw.Core/Canvas/A2UiCatalogDescriptor.cs
@@ -1,0 +1,9 @@
+namespace OpenClaw.Core.Canvas;
+
+public sealed record A2UiCatalogDescriptor(
+    string CatalogId,
+    IReadOnlySet<string> ComponentTypes,
+    IReadOnlySet<string> FunctionTypes,
+    IReadOnlySet<string> SharedTypes,
+    IReadOnlyDictionary<string, string> Aliases,
+    string DisplayName);

--- a/src/OpenClaw.Core/Canvas/A2UiCatalogRegistry.cs
+++ b/src/OpenClaw.Core/Canvas/A2UiCatalogRegistry.cs
@@ -1,0 +1,134 @@
+namespace OpenClaw.Core.Canvas;
+
+public static class A2UiCatalogRegistry
+{
+    public const string OpenClawV08CatalogId = "urn:a2ui:catalog:openclaw_v0_8";
+    public const string AGenUiCatalogId = "urn:a2ui:catalog:agenui_catalog";
+
+    private static readonly string[] AGenUiComponentTypes =
+    [
+        "Text",
+        "Image",
+        "Icon",
+        "Divider",
+        "Video",
+        "AudioPlayer",
+        "Markdown",
+        "Button",
+        "TextField",
+        "CheckBox",
+        "Slider",
+        "ChoicePicker",
+        "DateTimeInput",
+        "Row",
+        "Column",
+        "Card",
+        "List",
+        "Tabs",
+        "Modal",
+        "Table",
+        "Carousel",
+        "Web",
+        "RichText",
+        "Chart"
+    ];
+
+    private static readonly string[] OpenClawV08ComponentTypes =
+    [
+        "Text",
+        "Markdown",
+        "Card",
+        "Button",
+        "TextField",
+        "ChoicePicker",
+        "CheckBox",
+        "Table",
+        "Image",
+        "Slider",
+        "Chart"
+    ];
+
+    private static readonly IReadOnlyDictionary<string, string> V08Aliases = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["text"] = "Text",
+        ["markdown"] = "Markdown",
+        ["card"] = "Card",
+        ["button"] = "Button",
+        ["input"] = "TextField",
+        ["select"] = "ChoicePicker",
+        ["checklist"] = "CheckBox",
+        ["table"] = "Table",
+        ["image"] = "Image",
+        ["progress"] = "Slider",
+        ["chart"] = "Chart"
+    };
+
+    private static readonly IReadOnlyDictionary<string, A2UiCatalogDescriptor> Catalogs =
+        new Dictionary<string, A2UiCatalogDescriptor>(StringComparer.OrdinalIgnoreCase)
+        {
+            [OpenClawV08CatalogId] = Create(OpenClawV08CatalogId, OpenClawV08ComponentTypes, V08Aliases, "OpenClaw A2UI v0.8"),
+            [AGenUiCatalogId] = Create(AGenUiCatalogId, AGenUiComponentTypes, V08Aliases, "AGenUI Catalog")
+        };
+
+    public static IReadOnlyCollection<A2UiCatalogDescriptor> BuiltInCatalogs => Catalogs.Values.ToArray();
+
+    public static bool TryGetCatalog(string? catalogId, out A2UiCatalogDescriptor catalog)
+    {
+        if (!string.IsNullOrWhiteSpace(catalogId) && Catalogs.TryGetValue(catalogId, out catalog!))
+            return true;
+
+        catalog = null!;
+        return false;
+    }
+
+    public static bool TryChooseCatalog(IEnumerable<string>? supportedCatalogIds, string? requestedCatalogId, out A2UiCatalogDescriptor catalog)
+    {
+        if (!string.IsNullOrWhiteSpace(requestedCatalogId))
+            return TryGetCatalog(requestedCatalogId, out catalog);
+
+        if (supportedCatalogIds is not null)
+        {
+            var supported = supportedCatalogIds.ToArray();
+            if (supported.Any(static catalogId => string.Equals(catalogId, AGenUiCatalogId, StringComparison.OrdinalIgnoreCase)))
+                return TryGetCatalog(AGenUiCatalogId, out catalog);
+
+            foreach (var catalogId in supported)
+            {
+                if (TryGetCatalog(catalogId, out catalog))
+                    return true;
+            }
+        }
+
+        return TryGetCatalog(AGenUiCatalogId, out catalog);
+    }
+
+    public static string? ResolveComponentType(A2UiCatalogDescriptor catalog, string? componentType)
+    {
+        if (string.IsNullOrWhiteSpace(componentType))
+            return null;
+
+        if (catalog.ComponentTypes.Contains(componentType))
+            return componentType;
+
+        if (catalog.Aliases.TryGetValue(componentType, out var canonical) && catalog.ComponentTypes.Contains(canonical))
+            return canonical;
+
+        return null;
+    }
+
+    public static bool IsSupportedComponentType(A2UiCatalogDescriptor catalog, string? componentType)
+        => ResolveComponentType(catalog, componentType) is not null;
+
+    private static A2UiCatalogDescriptor Create(
+        string catalogId,
+        IEnumerable<string> componentTypes,
+        IReadOnlyDictionary<string, string> aliases,
+        string displayName)
+        => new(
+            catalogId,
+            new HashSet<string>(componentTypes, StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            aliases,
+            displayName);
+}

--- a/src/OpenClaw.Core/Canvas/A2UiCatalogRegistry.cs
+++ b/src/OpenClaw.Core/Canvas/A2UiCatalogRegistry.cs
@@ -84,7 +84,15 @@ public static class A2UiCatalogRegistry
     public static bool TryChooseCatalog(IEnumerable<string>? supportedCatalogIds, string? requestedCatalogId, out A2UiCatalogDescriptor catalog)
     {
         if (!string.IsNullOrWhiteSpace(requestedCatalogId))
+        {
+            if (supportedCatalogIds is not null && !supportedCatalogIds.Any(catalogId => string.Equals(catalogId, requestedCatalogId, StringComparison.OrdinalIgnoreCase)))
+            {
+                catalog = null!;
+                return false;
+            }
+
             return TryGetCatalog(requestedCatalogId, out catalog);
+        }
 
         if (supportedCatalogIds is not null)
         {
@@ -96,6 +104,12 @@ public static class A2UiCatalogRegistry
             {
                 if (TryGetCatalog(catalogId, out catalog))
                     return true;
+            }
+
+            if (supported.Length > 0)
+            {
+                catalog = null!;
+                return false;
             }
         }
 

--- a/src/OpenClaw.Core/Canvas/A2UiV09MessageValidator.cs
+++ b/src/OpenClaw.Core/Canvas/A2UiV09MessageValidator.cs
@@ -1,0 +1,210 @@
+using System.Text.Json;
+using OpenClaw.Core.Models;
+
+namespace OpenClaw.Core.Canvas;
+
+public static class A2UiV09MessageValidator
+{
+    private static readonly HashSet<string> SupportedOperations = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "createSurface",
+        "updateComponents",
+        "updateDataModel",
+        "deleteSurface",
+        "syncUIToData",
+        "action",
+        "error"
+    };
+
+    public static A2UiValidationResult Validate(WsServerEnvelope envelope)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        if (string.IsNullOrWhiteSpace(envelope.Operation))
+            return A2UiValidationResult.Invalid("A2UI v0.9 operation is required.");
+
+        if (!SupportedOperations.Contains(envelope.Operation))
+            return A2UiValidationResult.Invalid($"A2UI v0.9 operation '{envelope.Operation}' is not supported.");
+
+        return envelope.Operation.ToLowerInvariant() switch
+        {
+            "createsurface" => ValidateCreateSurface(envelope),
+            "updatecomponents" => ValidateUpdateComponents(envelope),
+            "updatedatamodel" => ValidateUpdateDataModel(envelope),
+            "deletesurface" => ValidateSurfaceOperation(envelope, "deleteSurface"),
+            "syncuitodata" => ValidateSyncUIToData(envelope),
+            "action" => ValidateAction(envelope),
+            "error" => ValidateError(envelope),
+            _ => A2UiValidationResult.Invalid($"A2UI v0.9 operation '{envelope.Operation}' is not supported.")
+        };
+    }
+
+    private static A2UiValidationResult ValidateCreateSurface(WsServerEnvelope envelope)
+    {
+        var surfaceError = ValidateSurfaceId(envelope);
+        if (surfaceError is not null)
+            return A2UiValidationResult.Invalid(surfaceError);
+
+        if (!A2UiCatalogRegistry.TryChooseCatalog(envelope.SupportedCatalogIds, envelope.CatalogId, out var catalog))
+            return A2UiValidationResult.Invalid("A2UI v0.9 createSurface uses an unsupported catalog ID.");
+
+        if (envelope.Components is { } components)
+        {
+            var componentValidation = ValidateComponents(components, catalog, "createSurface");
+            if (!componentValidation.IsValid)
+                return componentValidation;
+        }
+
+        return ValidateOptionalJsonObject(envelope.DataModelJson, "dataModelJson")
+            ?? A2UiValidationResult.Valid(1);
+    }
+
+    private static A2UiValidationResult ValidateUpdateComponents(WsServerEnvelope envelope)
+    {
+        var surfaceError = ValidateSurfaceId(envelope);
+        if (surfaceError is not null)
+            return A2UiValidationResult.Invalid(surfaceError);
+
+        if (!A2UiCatalogRegistry.TryChooseCatalog(envelope.SupportedCatalogIds, envelope.CatalogId, out var catalog))
+            return A2UiValidationResult.Invalid("A2UI v0.9 updateComponents uses an unsupported catalog ID.");
+
+        if (envelope.Components is null || envelope.Components.Length == 0)
+            return A2UiValidationResult.Invalid("A2UI v0.9 updateComponents requires components as a non-empty JSON string array.");
+
+        return ValidateComponents(envelope.Components, catalog, "updateComponents");
+    }
+
+    private static A2UiValidationResult ValidateComponents(string[] components, A2UiCatalogDescriptor catalog, string operation)
+    {
+        if (components.Length == 0)
+            return A2UiValidationResult.Invalid($"A2UI v0.9 {operation} requires components as a non-empty JSON string array.");
+
+        for (var i = 0; i < components.Length; i++)
+        {
+            var index = i + 1;
+            var componentJson = components[i];
+            if (string.IsNullOrWhiteSpace(componentJson))
+                return A2UiValidationResult.Invalid($"A2UI v0.9 component {index} must be a non-empty JSON string.");
+
+            JsonDocument doc;
+            try
+            {
+                doc = JsonDocument.Parse(componentJson);
+            }
+            catch (JsonException ex)
+            {
+                return A2UiValidationResult.Invalid($"A2UI v0.9 component {index} is not valid JSON: {ex.Message}");
+            }
+
+            using (doc)
+            {
+                var component = doc.RootElement;
+                if (component.ValueKind != JsonValueKind.Object)
+                    return A2UiValidationResult.Invalid($"A2UI v0.9 component {index} must be a JSON object.");
+
+                if (!component.TryGetProperty("type", out var typeProp) || typeProp.ValueKind != JsonValueKind.String)
+                    return A2UiValidationResult.Invalid($"A2UI v0.9 component {index} is missing string property 'type'.");
+
+                var type = typeProp.GetString();
+                if (!A2UiCatalogRegistry.IsSupportedComponentType(catalog, type))
+                    return A2UiValidationResult.Invalid($"A2UI v0.9 component {index} has unsupported component type '{type}'.");
+            }
+        }
+
+        return A2UiValidationResult.Valid(1);
+    }
+
+    private static A2UiValidationResult ValidateUpdateDataModel(WsServerEnvelope envelope)
+    {
+        var surfaceError = ValidateSurfaceId(envelope);
+        if (surfaceError is not null)
+            return A2UiValidationResult.Invalid(surfaceError);
+
+        if (string.IsNullOrWhiteSpace(envelope.DataModelJson))
+            return A2UiValidationResult.Invalid("A2UI v0.9 updateDataModel requires dataModelJson.");
+
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(envelope.DataModelJson);
+        }
+        catch (JsonException ex)
+        {
+            return A2UiValidationResult.Invalid($"A2UI v0.9 dataModelJson is not valid JSON: {ex.Message}");
+        }
+
+        using (doc)
+        {
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                ? A2UiValidationResult.Valid(1)
+                : A2UiValidationResult.Invalid("A2UI v0.9 dataModelJson must be a JSON object.");
+        }
+    }
+
+    private static A2UiValidationResult ValidateSurfaceOperation(WsServerEnvelope envelope, string operation)
+    {
+        var surfaceError = ValidateSurfaceId(envelope);
+        return surfaceError is null
+            ? A2UiValidationResult.Valid(1)
+            : A2UiValidationResult.Invalid($"A2UI v0.9 {operation} {surfaceError}");
+    }
+
+    private static A2UiValidationResult ValidateSyncUIToData(WsServerEnvelope envelope)
+    {
+        var surfaceError = ValidateSurfaceId(envelope);
+        if (surfaceError is not null)
+            return A2UiValidationResult.Invalid($"A2UI v0.9 syncUIToData {surfaceError}");
+
+        return ValidateOptionalJsonObject(envelope.DataModelJson, "dataModelJson")
+            ?? A2UiValidationResult.Valid(1);
+    }
+
+    private static A2UiValidationResult ValidateAction(WsServerEnvelope envelope)
+    {
+        var surfaceError = ValidateSurfaceId(envelope);
+        if (surfaceError is not null)
+            return A2UiValidationResult.Invalid($"A2UI v0.9 action {surfaceError}");
+
+        if (string.IsNullOrWhiteSpace(envelope.Action))
+            return A2UiValidationResult.Invalid("A2UI v0.9 action requires action.");
+
+        return ValidateOptionalJsonObject(envelope.ParametersJson, "parametersJson")
+            ?? A2UiValidationResult.Valid(1);
+    }
+
+    private static A2UiValidationResult ValidateError(WsServerEnvelope envelope)
+    {
+        if (string.IsNullOrWhiteSpace(envelope.Error) && string.IsNullOrWhiteSpace(envelope.DiagnosticCode))
+            return A2UiValidationResult.Invalid("A2UI v0.9 error requires error or diagnosticCode.");
+
+        return A2UiValidationResult.Valid(1);
+    }
+
+    private static A2UiValidationResult? ValidateOptionalJsonObject(string? json, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(json);
+        }
+        catch (JsonException ex)
+        {
+            return A2UiValidationResult.Invalid($"A2UI v0.9 {propertyName} is not valid JSON: {ex.Message}");
+        }
+
+        using (doc)
+        {
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                ? null
+                : A2UiValidationResult.Invalid($"A2UI v0.9 {propertyName} must be a JSON object.");
+        }
+    }
+
+    private static string? ValidateSurfaceId(WsServerEnvelope envelope)
+        => string.IsNullOrWhiteSpace(envelope.SurfaceId)
+            ? "requires non-empty surfaceId."
+            : null;
+}

--- a/src/OpenClaw.Core/Canvas/A2UiV09MessageValidator.cs
+++ b/src/OpenClaw.Core/Canvas/A2UiV09MessageValidator.cs
@@ -105,6 +105,9 @@ public static class A2UiV09MessageValidator
                 if (!component.TryGetProperty("type", out var typeProp) || typeProp.ValueKind != JsonValueKind.String)
                     return A2UiValidationResult.Invalid($"A2UI v0.9 component {index} is missing string property 'type'.");
 
+                if (!HasNonEmptyString(component, "id"))
+                    return A2UiValidationResult.Invalid($"A2UI v0.9 component {index} is missing string property 'id'.");
+
                 var type = typeProp.GetString();
                 if (!A2UiCatalogRegistry.IsSupportedComponentType(catalog, type))
                     return A2UiValidationResult.Invalid($"A2UI v0.9 component {index} has unsupported component type '{type}'.");
@@ -113,6 +116,11 @@ public static class A2UiV09MessageValidator
 
         return A2UiValidationResult.Valid(1);
     }
+
+    private static bool HasNonEmptyString(JsonElement root, string propertyName)
+        => root.TryGetProperty(propertyName, out var prop) &&
+           prop.ValueKind == JsonValueKind.String &&
+           !string.IsNullOrWhiteSpace(prop.GetString());
 
     private static A2UiValidationResult ValidateUpdateDataModel(WsServerEnvelope envelope)
     {

--- a/src/OpenClaw.Core/Governance/ToolGovernanceDescriptorCatalog.cs
+++ b/src/OpenClaw.Core/Governance/ToolGovernanceDescriptorCatalog.cs
@@ -113,6 +113,11 @@ public static class ToolGovernanceDescriptorCatalog
         Write("a2ui_push", "canvas", ToolGovernanceRiskLevel.Medium, ["ui.write"]),
         Write("a2ui_reset", "canvas", ToolGovernanceRiskLevel.Medium, ["ui.write"]),
         Write("a2ui_eval", "canvas", ToolGovernanceRiskLevel.High, ["ui.evaluate", "code.execute"], executeCode: true, approval: true),
+        Write("a2ui_create_surface", "canvas", ToolGovernanceRiskLevel.Medium, ["ui.write"]),
+        Write("a2ui_update_components", "canvas", ToolGovernanceRiskLevel.Medium, ["ui.write"]),
+        Write("a2ui_update_data_model", "canvas", ToolGovernanceRiskLevel.Medium, ["ui.write"]),
+        Write("a2ui_delete_surface", "canvas", ToolGovernanceRiskLevel.Medium, ["ui.write"]),
+        Write("a2ui_sync_ui_to_data", "canvas", ToolGovernanceRiskLevel.Medium, ["ui.write"]),
 
         Write("external_cli", "external-cli", ToolGovernanceRiskLevel.High, ["process.execute", "external.cli"], fileSystem: true, executeCode: true, approval: true),
         Write("payment", "payment", ToolGovernanceRiskLevel.Critical, ["payment.execute", "data.export"], external: true, approval: true),

--- a/src/OpenClaw.Core/Models/WebSocketEnvelopes.cs
+++ b/src/OpenClaw.Core/Models/WebSocketEnvelopes.cs
@@ -8,6 +8,19 @@ public sealed record WsClientEnvelope
 {
     public required string Type { get; init; }
     public string? RequestId { get; init; }
+    public string? ProtocolVersion { get; init; }
+    public string? Operation { get; init; }
+    public string? CatalogId { get; init; }
+    public string[]? SupportedCatalogIds { get; init; }
+    public string[]? Components { get; init; }
+    public string? DataModelJson { get; init; }
+    public string? SurfaceTitle { get; init; }
+    public string? SurfaceKind { get; init; }
+    public string? ParentSurfaceId { get; init; }
+    public string? Action { get; init; }
+    public string? ParametersJson { get; init; }
+    public string? SyncMode { get; init; }
+    public string? DiagnosticCode { get; init; }
     public string? Text { get; init; }
     public string? Content { get; init; }
     public string? SessionId { get; init; }
@@ -41,6 +54,19 @@ public sealed record WsServerEnvelope
 {
     public required string Type { get; init; }
     public string? RequestId { get; init; }
+    public string? ProtocolVersion { get; init; }
+    public string? Operation { get; init; }
+    public string? CatalogId { get; init; }
+    public string[]? SupportedCatalogIds { get; init; }
+    public string[]? Components { get; init; }
+    public string? DataModelJson { get; init; }
+    public string? SurfaceTitle { get; init; }
+    public string? SurfaceKind { get; init; }
+    public string? ParentSurfaceId { get; init; }
+    public string? Action { get; init; }
+    public string? ParametersJson { get; init; }
+    public string? SyncMode { get; init; }
+    public string? DiagnosticCode { get; init; }
     public string? Text { get; init; }
     public string? InReplyToMessageId { get; init; }
     public string? SessionId { get; init; }

--- a/src/OpenClaw.Gateway/CanvasCommandBroker.cs
+++ b/src/OpenClaw.Gateway/CanvasCommandBroker.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Text;
 using System.Text.Json;
 using OpenClaw.Channels;
+using OpenClaw.Core.Canvas;
 using OpenClaw.Core.Models;
 
 namespace OpenClaw.Gateway;
@@ -19,7 +20,8 @@ internal sealed class CanvasCommandBroker
     private readonly WebSocketChannel _webSocketChannel;
     private readonly RuntimeEventStore _runtimeEvents;
     private readonly ConcurrentDictionary<string, PendingCommand> _pending = new(StringComparer.Ordinal);
-    private readonly ConcurrentDictionary<string, string[]> _clientCapabilities = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, ClientCanvasProfile> _clientProfiles = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<SurfaceCatalogKey, string> _surfaceCatalogs = new();
 
     public CanvasCommandBroker(GatewayConfig config, WebSocketChannel webSocketChannel, RuntimeEventStore runtimeEvents)
     {
@@ -30,7 +32,51 @@ internal sealed class CanvasCommandBroker
     }
 
     public IReadOnlyList<string> GetClientCapabilities(string senderId)
-        => _clientCapabilities.TryGetValue(senderId, out var capabilities) ? capabilities : [];
+        => _clientProfiles.TryGetValue(senderId, out var profile) ? profile.Capabilities : [];
+
+    public IReadOnlyList<string> GetClientSupportedCatalogIds(string senderId)
+        => _clientProfiles.TryGetValue(senderId, out var profile) ? profile.SupportedCatalogIds : [];
+
+    public bool TryChooseCatalog(
+        string senderId,
+        string? requestedCatalogId,
+        out A2UiCatalogDescriptor? catalog,
+        out string? error)
+    {
+        catalog = null;
+        error = null;
+        var supportedCatalogIds = GetClientSupportedCatalogIds(senderId);
+
+        if (!string.IsNullOrWhiteSpace(requestedCatalogId))
+        {
+            if (!A2UiCatalogRegistry.TryGetCatalog(requestedCatalogId, out var requested))
+            {
+                error = $"Unknown A2UI catalog '{requestedCatalogId}'.";
+                return false;
+            }
+
+            if (supportedCatalogIds.Count > 0 && !supportedCatalogIds.Contains(requested.CatalogId, StringComparer.OrdinalIgnoreCase))
+            {
+                error = $"Canvas client does not support catalog '{requested.CatalogId}'.";
+                return false;
+            }
+
+            catalog = requested;
+            return true;
+        }
+
+        if (!A2UiCatalogRegistry.TryChooseCatalog(supportedCatalogIds, null, out var chosen))
+        {
+            error = "No compatible A2UI catalog is available.";
+            return false;
+        }
+
+        catalog = chosen;
+        return true;
+    }
+
+    public bool TryGetSurfaceCatalogId(string senderId, string sessionId, string surfaceId, out string? catalogId)
+        => _surfaceCatalogs.TryGetValue(new SurfaceCatalogKey(senderId, sessionId, surfaceId), out catalogId);
 
     public async Task<CanvasCommandResult> SendCommandAsync(
         Session session,
@@ -62,12 +108,26 @@ internal sealed class CanvasCommandBroker
             ? $"canvas_{Guid.NewGuid():N}"[..24]
             : command.RequestId!;
 
+        var surfaceId = string.IsNullOrWhiteSpace(command.SurfaceId) ? "main" : command.SurfaceId!;
         var outbound = command with
         {
             RequestId = requestId,
             SessionId = session.Id,
-            SurfaceId = string.IsNullOrWhiteSpace(command.SurfaceId) ? "main" : command.SurfaceId
+            SurfaceId = surfaceId
         };
+
+        string? lockedCatalogId = null;
+        if (IsCatalogLockedUpdate(outbound.Type) &&
+            _surfaceCatalogs.TryGetValue(new SurfaceCatalogKey(session.SenderId, session.Id, surfaceId), out lockedCatalogId) &&
+            !string.IsNullOrWhiteSpace(outbound.CatalogId) &&
+            !string.Equals(lockedCatalogId, outbound.CatalogId, StringComparison.OrdinalIgnoreCase))
+        {
+            return Fail(requestId, $"Canvas surface '{surfaceId}' is locked to catalog '{lockedCatalogId}' and cannot use catalog '{outbound.CatalogId}'.");
+        }
+
+        var negotiationCatalogId = string.IsNullOrWhiteSpace(outbound.CatalogId) ? lockedCatalogId : outbound.CatalogId;
+        if (IsCatalogAwareCommand(outbound.Type) && !TryChooseCatalog(session.SenderId, negotiationCatalogId, out _, out var catalogError))
+            return Fail(requestId, catalogError ?? "Canvas client does not support the requested catalog.");
 
         var bytes = JsonSerializer.SerializeToUtf8Bytes(outbound, CoreJsonContext.Default.WsServerEnvelope);
         if (bytes.Length > Math.Max(1, _config.Canvas.MaxCommandBytes))
@@ -103,6 +163,8 @@ internal sealed class CanvasCommandBroker
                 return Fail(requestId, error);
             }
 
+            UpdateSurfaceCatalogLockAfterSuccess(session, outbound);
+
             AppendRuntimeEvent(session, outbound.Type, requestId, "completed", "info", $"Canvas command '{outbound.Type}' completed.");
             return new CanvasCommandResult(true, requestId, SnapshotJson: response.SnapshotJson, ValueJson: response.ValueJson);
         }
@@ -121,12 +183,29 @@ internal sealed class CanvasCommandBroker
     {
         if (string.Equals(envelope.Type, "canvas_ready", StringComparison.Ordinal))
         {
-            _clientCapabilities[clientId] = NormalizeCapabilities(envelope.Capabilities);
+            _clientProfiles[clientId] = new ClientCanvasProfile(
+                NormalizeCapabilities(envelope.Capabilities),
+                NormalizeCatalogIds(envelope.SupportedCatalogIds));
             return ValueTask.CompletedTask;
         }
 
-        if (envelope.Capabilities is { Length: > 0 })
-            _clientCapabilities[clientId] = NormalizeCapabilities(envelope.Capabilities);
+        if (envelope.Capabilities is { Length: > 0 } || envelope.SupportedCatalogIds is { Length: > 0 })
+        {
+            _clientProfiles.AddOrUpdate(
+                clientId,
+                _ => new ClientCanvasProfile(
+                    NormalizeCapabilities(envelope.Capabilities),
+                    NormalizeCatalogIds(envelope.SupportedCatalogIds)),
+                (_, existing) => existing with
+                {
+                    Capabilities = envelope.Capabilities is { Length: > 0 }
+                        ? NormalizeCapabilities(envelope.Capabilities)
+                        : existing.Capabilities,
+                    SupportedCatalogIds = envelope.SupportedCatalogIds is { Length: > 0 }
+                        ? NormalizeCatalogIds(envelope.SupportedCatalogIds)
+                        : existing.SupportedCatalogIds
+                });
+        }
 
         if (!string.IsNullOrWhiteSpace(envelope.RequestId) &&
             _pending.TryGetValue(envelope.RequestId, out var pending) &&
@@ -150,17 +229,54 @@ internal sealed class CanvasCommandBroker
     }
 
     private bool HasCapability(string senderId, string capability)
-        => _clientCapabilities.TryGetValue(senderId, out var capabilities) &&
-           capabilities.Contains(capability, StringComparer.OrdinalIgnoreCase);
+        => _clientProfiles.TryGetValue(senderId, out var profile) &&
+           profile.Capabilities.Contains(capability, StringComparer.OrdinalIgnoreCase);
 
     private static string[] NormalizeCapabilities(string[]? capabilities)
-        => capabilities is null
+        => NormalizeStrings(capabilities);
+
+    private static string[] NormalizeCatalogIds(string[]? catalogIds)
+        => NormalizeStrings(catalogIds);
+
+    private static string[] NormalizeStrings(string[]? values)
+        => values is null
             ? []
-            : capabilities
+            : values
                 .Where(static item => !string.IsNullOrWhiteSpace(item))
                 .Select(static item => item.Trim())
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
+
+    private static bool IsCatalogAwareCommand(string commandType)
+        => string.Equals(commandType, "a2ui_create_surface", StringComparison.Ordinal) ||
+           string.Equals(commandType, "a2ui_update_components", StringComparison.Ordinal) ||
+           string.Equals(commandType, "a2ui_update_data_model", StringComparison.Ordinal) ||
+           string.Equals(commandType, "a2ui_delete_surface", StringComparison.Ordinal) ||
+           string.Equals(commandType, "a2ui_sync_ui_to_data", StringComparison.Ordinal);
+
+    private static bool IsCatalogLockedUpdate(string commandType)
+        => string.Equals(commandType, "a2ui_update_components", StringComparison.Ordinal) ||
+           string.Equals(commandType, "a2ui_update_data_model", StringComparison.Ordinal);
+
+    private void UpdateSurfaceCatalogLockAfterSuccess(Session session, WsServerEnvelope outbound)
+    {
+        var surfaceId = string.IsNullOrWhiteSpace(outbound.SurfaceId) ? "main" : outbound.SurfaceId!;
+        var key = new SurfaceCatalogKey(session.SenderId, session.Id, surfaceId);
+
+        if (string.Equals(outbound.Type, "a2ui_delete_surface", StringComparison.Ordinal))
+        {
+            _surfaceCatalogs.TryRemove(key, out _);
+            return;
+        }
+
+        if (!string.Equals(outbound.Type, "a2ui_create_surface", StringComparison.Ordinal))
+            return;
+
+        if (!TryChooseCatalog(session.SenderId, outbound.CatalogId, out var catalog, out _) || catalog is null)
+            return;
+
+        _surfaceCatalogs[key] = catalog.CatalogId;
+    }
 
     private void AppendRuntimeEvent(Session session, string action, string requestId, string state, string severity, string summary)
     {
@@ -184,6 +300,10 @@ internal sealed class CanvasCommandBroker
 
     private static CanvasCommandResult Fail(string? requestId, string error)
         => new(false, string.IsNullOrWhiteSpace(requestId) ? "" : requestId!, error);
+
+    private sealed record ClientCanvasProfile(string[] Capabilities, string[] SupportedCatalogIds);
+
+    private sealed record SurfaceCatalogKey(string SenderId, string SessionId, string SurfaceId);
 
     private sealed class PendingCommand
     {

--- a/src/OpenClaw.Gateway/CanvasCommandBroker.cs
+++ b/src/OpenClaw.Gateway/CanvasCommandBroker.cs
@@ -21,7 +21,7 @@ internal sealed class CanvasCommandBroker
     private readonly RuntimeEventStore _runtimeEvents;
     private readonly ConcurrentDictionary<string, PendingCommand> _pending = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, ClientCanvasProfile> _clientProfiles = new(StringComparer.Ordinal);
-    private readonly ConcurrentDictionary<SurfaceCatalogKey, string> _surfaceCatalogs = new();
+    private readonly ConcurrentDictionary<SurfaceCatalogKey, string> _surfaceCatalogs = new(SurfaceCatalogKeyComparer.Instance);
 
     public CanvasCommandBroker(GatewayConfig config, WebSocketChannel webSocketChannel, RuntimeEventStore runtimeEvents)
     {
@@ -256,7 +256,8 @@ internal sealed class CanvasCommandBroker
 
     private static bool IsCatalogLockedUpdate(string commandType)
         => string.Equals(commandType, "a2ui_update_components", StringComparison.Ordinal) ||
-           string.Equals(commandType, "a2ui_update_data_model", StringComparison.Ordinal);
+           string.Equals(commandType, "a2ui_update_data_model", StringComparison.Ordinal) ||
+           string.Equals(commandType, "a2ui_sync_ui_to_data", StringComparison.Ordinal);
 
     private void UpdateSurfaceCatalogLockAfterSuccess(Session session, WsServerEnvelope outbound)
     {
@@ -269,7 +270,7 @@ internal sealed class CanvasCommandBroker
             return;
         }
 
-        if (!string.Equals(outbound.Type, "a2ui_create_surface", StringComparison.Ordinal))
+        if (!IsCatalogAwareCommand(outbound.Type) || string.IsNullOrWhiteSpace(outbound.CatalogId))
             return;
 
         if (!TryChooseCatalog(session.SenderId, outbound.CatalogId, out var catalog, out _) || catalog is null)
@@ -304,6 +305,23 @@ internal sealed class CanvasCommandBroker
     private sealed record ClientCanvasProfile(string[] Capabilities, string[] SupportedCatalogIds);
 
     private sealed record SurfaceCatalogKey(string SenderId, string SessionId, string SurfaceId);
+
+    private sealed class SurfaceCatalogKeyComparer : IEqualityComparer<SurfaceCatalogKey>
+    {
+        public static readonly SurfaceCatalogKeyComparer Instance = new();
+
+        public bool Equals(SurfaceCatalogKey? x, SurfaceCatalogKey? y)
+            => x is not null && y is not null &&
+               string.Equals(x.SenderId, y.SenderId, StringComparison.Ordinal) &&
+               string.Equals(x.SessionId, y.SessionId, StringComparison.Ordinal) &&
+               string.Equals(x.SurfaceId, y.SurfaceId, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode(SurfaceCatalogKey obj)
+            => HashCode.Combine(
+                StringComparer.Ordinal.GetHashCode(obj.SenderId),
+                StringComparer.Ordinal.GetHashCode(obj.SessionId),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(obj.SurfaceId));
+    }
 
     private sealed class PendingCommand
     {

--- a/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.RuntimeFactories.cs
+++ b/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.RuntimeFactories.cs
@@ -134,6 +134,11 @@ internal static partial class RuntimeInitializationExtensions
             new A2UiPushTool(services.CanvasBroker, config),
             new A2UiResetTool(services.CanvasBroker, config),
             new A2UiEvalTool(services.CanvasBroker, config),
+            new A2UiCreateSurfaceTool(services.CanvasBroker, config),
+            new A2UiUpdateComponentsTool(services.CanvasBroker, config),
+            new A2UiUpdateDataModelTool(services.CanvasBroker, config),
+            new A2UiDeleteSurfaceTool(services.CanvasBroker, config),
+            new A2UiSyncUiToDataTool(services.CanvasBroker, config),
 
             new EditFileTool(config.Tooling),
             new ApplyPatchTool(config.Tooling),

--- a/src/OpenClaw.Gateway/Tools/CanvasTools.cs
+++ b/src/OpenClaw.Gateway/Tools/CanvasTools.cs
@@ -77,6 +77,106 @@ internal abstract class CanvasToolBase : IToolWithContext
         return false;
     }
 
+    protected static bool TryGetOptionalStringArray(JsonElement root, string propertyName, out string[]? values, out string error)
+    {
+        values = null;
+        error = "";
+        if (!root.TryGetProperty(propertyName, out var prop) || prop.ValueKind == JsonValueKind.Null)
+            return true;
+
+        if (prop.ValueKind != JsonValueKind.Array)
+        {
+            error = $"Error: '{propertyName}' must be a JSON string array.";
+            return false;
+        }
+
+        var items = new List<string>();
+        foreach (var item in prop.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.String)
+            {
+                error = $"Error: '{propertyName}' must be a JSON string array.";
+                return false;
+            }
+
+            items.Add(item.GetString() ?? "");
+        }
+
+        values = items.ToArray();
+        return true;
+    }
+
+    protected static bool TryGetRequiredStringArray(JsonElement root, string propertyName, out string[] values, out string error)
+    {
+        values = [];
+        if (!TryGetOptionalStringArray(root, propertyName, out var found, out error))
+            return false;
+
+        if (found is { Length: > 0 })
+        {
+            values = found;
+            return true;
+        }
+
+        error = $"Error: '{propertyName}' is required as a non-empty JSON string array.";
+        return false;
+    }
+
+    protected static string? ValidateOptionalJsonObject(string? json, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                ? null
+                : $"Error: '{propertyName}' must be a JSON object.";
+        }
+        catch (JsonException ex)
+        {
+            return $"Error: '{propertyName}' is not valid JSON: {ex.Message}";
+        }
+    }
+
+    protected string? ValidateEnvelopePayloadSize(WsServerEnvelope envelope)
+    {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(envelope, CoreJsonContext.Default.WsServerEnvelope);
+        var maxBytes = MaxPayloadBytesWithEnvelopeReserve();
+        return bytes.Length <= maxBytes
+            ? null
+            : $"Error: payload exceeds {maxBytes} bytes.";
+    }
+
+    protected static string? ValidateA2UiV09Envelope(WsServerEnvelope envelope)
+    {
+        var validation = A2UiV09MessageValidator.Validate(envelope);
+        return validation.IsValid ? null : $"Error: {validation.Error}";
+    }
+
+    protected bool TryResolveCatalog(string senderId, string? requestedCatalogId, out A2UiCatalogDescriptor catalog, out string error)
+    {
+        if (Broker.TryChooseCatalog(senderId, requestedCatalogId, out var chosen, out var brokerError) && chosen is not null)
+        {
+            catalog = chosen;
+            error = "";
+            return true;
+        }
+
+        catalog = null!;
+        error = $"Error: {brokerError ?? "Canvas client does not support the requested catalog."}";
+        return false;
+    }
+
+    protected bool TryGetLockedOrResolveCatalog(ToolExecutionContext context, string surfaceId, out A2UiCatalogDescriptor catalog, out string error)
+    {
+        var requestedCatalogId = Broker.TryGetSurfaceCatalogId(context.Session.SenderId, context.Session.Id, surfaceId, out var lockedCatalogId)
+            ? lockedCatalogId
+            : null;
+        return TryResolveCatalog(context.Session.SenderId, requestedCatalogId, out catalog, out error);
+    }
+
     protected int MaxPayloadBytesWithEnvelopeReserve()
         => Math.Max(1, Config.Canvas.MaxCommandBytes - 4096);
 }
@@ -247,5 +347,163 @@ internal sealed class A2UiEvalTool : CanvasToolBase
             SurfaceId = SurfaceId(args.RootElement),
             Script = script
         }, "canvas_eval_result", "a2ui.eval", ct);
+    }
+}
+
+internal sealed class A2UiCreateSurfaceTool : CanvasToolBase
+{
+    public A2UiCreateSurfaceTool(CanvasCommandBroker broker, GatewayConfig config) : base(broker, config) { }
+    public override string Name => "a2ui_create_surface";
+    public override string Description => "Create an A2UI v0.9 surface in the current session Canvas.";
+    public override string ParameterSchema => """
+        {"type":"object","properties":{"surfaceId":{"type":"string"},"catalogId":{"type":"string"},"title":{"type":"string"},"metadata":{"type":"string","description":"JSON object metadata"},"components":{"type":"array","items":{"type":"string"}},"dataModelJson":{"type":"string"}},"required":["surfaceId"]}
+        """;
+
+    public override async ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct)
+    {
+        using var args = ParseArgs(argumentsJson);
+        var root = args.RootElement;
+        if (!TryGetRequiredString(root, "surfaceId", out var surfaceId, out var error)) return error;
+        var catalogId = TryGetString(root, "catalogId");
+        var title = TryGetString(root, "title");
+        var metadata = TryGetString(root, "metadata");
+        if ((error = ValidateOptionalJsonObject(metadata, "metadata")) is not null) return error;
+        if (!TryGetOptionalStringArray(root, "components", out var components, out error)) return error;
+        var dataModelJson = TryGetString(root, "dataModelJson");
+
+        if (!TryResolveCatalog(context.Session.SenderId, catalogId, out var catalog, out error)) return error;
+
+        var envelope = new WsServerEnvelope
+        {
+            Type = "a2ui_create_surface",
+            Operation = "createSurface",
+            SurfaceId = surfaceId,
+            CatalogId = catalog.CatalogId,
+            SurfaceTitle = title,
+            ParametersJson = metadata,
+            Components = components,
+            DataModelJson = dataModelJson
+        };
+
+        if ((error = ValidateA2UiV09Envelope(envelope)) is not null) return error;
+        if ((error = ValidateEnvelopePayloadSize(envelope)) is not null) return error;
+        return await SendAsync(argumentsJson, context, envelope, "canvas_ack", "a2ui.v0_9", ct);
+    }
+}
+
+internal sealed class A2UiUpdateComponentsTool : CanvasToolBase
+{
+    public A2UiUpdateComponentsTool(CanvasCommandBroker broker, GatewayConfig config) : base(broker, config) { }
+    public override string Name => "a2ui_update_components";
+    public override string Description => "Update A2UI v0.9 surface components using a JSON string array.";
+    public override string ParameterSchema => """
+        {"type":"object","properties":{"surfaceId":{"type":"string"},"components":{"type":"array","items":{"type":"string"}}},"required":["surfaceId","components"]}
+        """;
+
+    public override async ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct)
+    {
+        using var args = ParseArgs(argumentsJson);
+        if (!TryGetRequiredString(args.RootElement, "surfaceId", out var surfaceId, out var error)) return error;
+        if (!TryGetRequiredStringArray(args.RootElement, "components", out var components, out error)) return error;
+
+        if (!TryGetLockedOrResolveCatalog(context, surfaceId, out var catalog, out error)) return error;
+
+        var envelope = new WsServerEnvelope
+        {
+            Type = "a2ui_update_components",
+            Operation = "updateComponents",
+            SurfaceId = surfaceId,
+            CatalogId = catalog.CatalogId,
+            Components = components
+        };
+
+        if ((error = ValidateA2UiV09Envelope(envelope)) is not null) return error;
+        if ((error = ValidateEnvelopePayloadSize(envelope)) is not null) return error;
+        return await SendAsync(argumentsJson, context, envelope, "canvas_ack", "a2ui.v0_9", ct);
+    }
+}
+
+internal sealed class A2UiUpdateDataModelTool : CanvasToolBase
+{
+    public A2UiUpdateDataModelTool(CanvasCommandBroker broker, GatewayConfig config) : base(broker, config) { }
+    public override string Name => "a2ui_update_data_model";
+    public override string Description => "Update an A2UI v0.9 surface data model.";
+    public override string ParameterSchema => """
+        {"type":"object","properties":{"surfaceId":{"type":"string"},"dataModelJson":{"type":"string"}},"required":["surfaceId","dataModelJson"]}
+        """;
+
+    public override async ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct)
+    {
+        using var args = ParseArgs(argumentsJson);
+        if (!TryGetRequiredString(args.RootElement, "surfaceId", out var surfaceId, out var error)) return error;
+        if (!TryGetRequiredString(args.RootElement, "dataModelJson", out var dataModelJson, out error)) return error;
+
+        if (!TryGetLockedOrResolveCatalog(context, surfaceId, out var catalog, out error)) return error;
+
+        var envelope = new WsServerEnvelope
+        {
+            Type = "a2ui_update_data_model",
+            Operation = "updateDataModel",
+            SurfaceId = surfaceId,
+            CatalogId = catalog.CatalogId,
+            DataModelJson = dataModelJson
+        };
+
+        if ((error = ValidateA2UiV09Envelope(envelope)) is not null) return error;
+        if ((error = ValidateEnvelopePayloadSize(envelope)) is not null) return error;
+        return await SendAsync(argumentsJson, context, envelope, "canvas_ack", "a2ui.v0_9", ct);
+    }
+}
+
+internal sealed class A2UiDeleteSurfaceTool : CanvasToolBase
+{
+    public A2UiDeleteSurfaceTool(CanvasCommandBroker broker, GatewayConfig config) : base(broker, config) { }
+    public override string Name => "a2ui_delete_surface";
+    public override string Description => "Delete an A2UI v0.9 surface.";
+    public override string ParameterSchema => """{"type":"object","properties":{"surfaceId":{"type":"string"}},"required":["surfaceId"]}""";
+
+    public override async ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct)
+    {
+        using var args = ParseArgs(argumentsJson);
+        if (!TryGetRequiredString(args.RootElement, "surfaceId", out var surfaceId, out var error)) return error;
+        var envelope = new WsServerEnvelope
+        {
+            Type = "a2ui_delete_surface",
+            Operation = "deleteSurface",
+            SurfaceId = surfaceId
+        };
+
+        if ((error = ValidateA2UiV09Envelope(envelope)) is not null) return error;
+        if ((error = ValidateEnvelopePayloadSize(envelope)) is not null) return error;
+        return await SendAsync(argumentsJson, context, envelope, "canvas_ack", "a2ui.v0_9", ct);
+    }
+}
+
+internal sealed class A2UiSyncUiToDataTool : CanvasToolBase
+{
+    public A2UiSyncUiToDataTool(CanvasCommandBroker broker, GatewayConfig config) : base(broker, config) { }
+    public override string Name => "a2ui_sync_ui_to_data";
+    public override string Description => "Synchronize A2UI v0.9 UI state into a data model.";
+    public override string ParameterSchema => """
+        {"type":"object","properties":{"surfaceId":{"type":"string"},"componentId":{"type":"string"},"syncMode":{"type":"string"}},"required":["surfaceId"]}
+        """;
+
+    public override async ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct)
+    {
+        using var args = ParseArgs(argumentsJson);
+        var root = args.RootElement;
+        if (!TryGetRequiredString(root, "surfaceId", out var surfaceId, out var error)) return error;
+        var envelope = new WsServerEnvelope
+        {
+            Type = "a2ui_sync_ui_to_data",
+            Operation = "syncUIToData",
+            SurfaceId = surfaceId,
+            ComponentId = TryGetString(root, "componentId"),
+            SyncMode = TryGetString(root, "syncMode")
+        };
+
+        if ((error = ValidateA2UiV09Envelope(envelope)) is not null) return error;
+        if ((error = ValidateEnvelopePayloadSize(envelope)) is not null) return error;
+        return await SendAsync(argumentsJson, context, envelope, "a2ui_sync_result", "a2ui.v0_9", ct);
     }
 }

--- a/src/OpenClaw.Gateway/wwwroot/webchat.html
+++ b/src/OpenClaw.Gateway/wwwroot/webchat.html
@@ -319,7 +319,34 @@
             background: white;
         }
 
-        #a2ui-root {
+        #a2ui-surfaces {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        #a2ui-tabs {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+
+        .a2ui-tab {
+            border: 1px solid var(--separator-strong);
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--text-secondary);
+            padding: 0.35rem 0.75rem;
+            cursor: pointer;
+        }
+
+        .a2ui-tab.active {
+            background: var(--accent);
+            border-color: var(--accent);
+            color: white;
+        }
+
+        #a2ui-surface-host {
             display: flex;
             flex-direction: column;
             gap: 0.75rem;
@@ -900,7 +927,10 @@
             </div>
             <div id="canvas-surface">
                 <iframe id="canvas-html-frame" title="Canvas HTML" sandbox="allow-scripts" hidden></iframe>
-                <div id="a2ui-root"></div>
+                <div id="a2ui-surfaces">
+                    <div id="a2ui-tabs" aria-label="A2UI surfaces"></div>
+                    <div id="a2ui-surface-host"></div>
+                </div>
             </div>
         </section>
 
@@ -989,7 +1019,9 @@
         const canvasPanel = document.getElementById('canvas-panel');
         const canvasStatus = document.getElementById('canvas-status');
         const canvasHtmlFrame = document.getElementById('canvas-html-frame');
-        const a2uiRoot = document.getElementById('a2ui-root');
+        const a2uiSurfaces = document.getElementById('a2ui-surfaces');
+        const a2uiTabs = document.getElementById('a2ui-tabs');
+        const a2uiSurfaceHost = document.getElementById('a2ui-surface-host');
         const TOKEN_KEY_PERSIST = 'openclaw_token';
         const TOKEN_KEY_SESSION = 'openclaw_token_session';
 
@@ -1009,9 +1041,8 @@
         let liveAudioProcessor = null;
         let canvasSessionId = null;
         let canvasEventSequence = 0;
-        let canvasFrames = [];
-        let canvasValues = {};
-        let canvasDiagnostics = [];
+        const canvasSurfaces = new Map();
+        let activeCanvasSurfaceId = 'main';
 
         const WEBCHAT_CONFIG = {
             streamRenderDebounceMs: Math.max(20, Number(window.OPENCLAW_WEBCHAT_CONFIG?.streamRenderDebounceMs ?? 120)),
@@ -1654,12 +1685,26 @@
             if (!ws || ws.readyState !== WebSocket.OPEN) return;
             ws.send(JSON.stringify({
                 type: 'canvas_ready',
-                capabilities: ['a2ui.v0_8', 'canvas.present', 'canvas.hide', 'canvas.local_html', 'snapshot.state']
+                capabilities: ['a2ui.v0_8', 'a2ui.v0_9', 'canvas.present', 'canvas.hide', 'canvas.local_html', 'snapshot.state'],
+                supportedCatalogIds: ['urn:a2ui:catalog:openclaw_v0_8', 'urn:a2ui:catalog:agenui_catalog']
             }));
         }
 
         function isCanvasEnvelopeType(type) {
-            return ['canvas_present', 'canvas_hide', 'canvas_navigate', 'canvas_snapshot', 'a2ui_push', 'a2ui_reset', 'a2ui_eval'].includes(type);
+            return [
+                'canvas_present',
+                'canvas_hide',
+                'canvas_navigate',
+                'canvas_snapshot',
+                'a2ui_push',
+                'a2ui_reset',
+                'a2ui_eval',
+                'a2ui_create_surface',
+                'a2ui_update_components',
+                'a2ui_update_data_model',
+                'a2ui_delete_surface',
+                'a2ui_sync_ui_to_data'
+            ].includes(type);
         }
 
         function sendCanvasAck(env, success = true, error = null) {
@@ -1684,14 +1729,72 @@
             canvasStatus.textContent = 'Hidden';
         }
 
-        function resetA2ui() {
-            canvasFrames = [];
-            canvasValues = {};
-            canvasDiagnostics = [];
-            a2uiRoot.innerHTML = '';
-            a2uiRoot.hidden = false;
+        function getCanvasSurface(surfaceId = 'main') {
+            const id = surfaceId || 'main';
+            let surface = canvasSurfaces.get(id);
+            if (!surface) {
+                surface = {
+                    surfaceId: id,
+                    catalogId: 'urn:a2ui:catalog:openclaw_v0_8',
+                    protocolVersion: 'v0_8',
+                    title: id === 'main' ? 'Main' : id,
+                    components: [],
+                    dataModelJson: null,
+                    dataModel: null,
+                    values: {},
+                    diagnostics: [],
+                    createdAt: new Date().toISOString(),
+                    updatedAt: new Date().toISOString(),
+                    deleted: false
+                };
+                canvasSurfaces.set(id, surface);
+            }
+            return surface;
+        }
+
+        function setActiveCanvasSurface(surfaceId) {
+            if (!canvasSurfaces.has(surfaceId)) return;
+            activeCanvasSurfaceId = surfaceId;
+            renderCanvasSurfaces();
+        }
+
+        function renderCanvasSurfaces() {
+            a2uiTabs.innerHTML = '';
+            for (const surface of canvasSurfaces.values()) {
+                if (surface.deleted) continue;
+                const tab = document.createElement('button');
+                tab.type = 'button';
+                tab.className = `a2ui-tab${surface.surfaceId === activeCanvasSurfaceId ? ' active' : ''}`;
+                tab.textContent = surface.title || surface.surfaceId;
+                tab.addEventListener('click', () => setActiveCanvasSurface(surface.surfaceId));
+                a2uiTabs.appendChild(tab);
+            }
+
+            a2uiSurfaceHost.innerHTML = '';
+            const surface = activeCanvasSurfaceId ? canvasSurfaces.get(activeCanvasSurfaceId) : null;
+            if (!surface || surface.deleted) return;
+            for (const component of surface.components) {
+                renderA2uiFrame(component, surface.surfaceId, surface);
+            }
+        }
+
+        function parseA2UiComponent(component) {
+            return typeof component === 'string' ? JSON.parse(component) : component;
+        }
+
+        function resetA2ui(surfaceId = 'main') {
+            const surface = getCanvasSurface(surfaceId);
+            surface.components = [];
+            surface.values = {};
+            surface.diagnostics = [];
+            surface.dataModelJson = null;
+            surface.dataModel = null;
+            surface.updatedAt = new Date().toISOString();
+            activeCanvasSurfaceId = surface.surfaceId;
+            a2uiSurfaces.hidden = false;
             canvasHtmlFrame.hidden = true;
             canvasHtmlFrame.removeAttribute('srcdoc');
+            renderCanvasSurfaces();
             canvasStatus.textContent = 'Reset';
         }
 
@@ -1711,11 +1814,26 @@
                         handleCanvasNavigate(env);
                         break;
                     case 'a2ui_reset':
-                        resetA2ui();
+                        resetA2ui(env.surfaceId || 'main');
                         sendCanvasAck(env);
                         break;
                     case 'a2ui_push':
                         handleA2uiPush(env);
+                        break;
+                    case 'a2ui_create_surface':
+                        handleA2uiCreateSurface(env);
+                        break;
+                    case 'a2ui_update_components':
+                        handleA2uiUpdateComponents(env);
+                        break;
+                    case 'a2ui_update_data_model':
+                        handleA2uiUpdateDataModel(env);
+                        break;
+                    case 'a2ui_delete_surface':
+                        handleA2uiDeleteSurface(env);
+                        break;
+                    case 'a2ui_sync_ui_to_data':
+                        handleA2uiSyncUiToData(env);
                         break;
                     case 'canvas_snapshot':
                         sendCanvasSnapshot(env);
@@ -1726,7 +1844,7 @@
                 }
             } catch (error) {
                 const message = String(error?.message || error);
-                canvasDiagnostics.push(message);
+                getCanvasSurface(env.surfaceId || activeCanvasSurfaceId || 'main').diagnostics.push(message);
                 sendCanvasAck(env, false, message);
             }
         }
@@ -1735,7 +1853,7 @@
             showCanvas();
             if (env.html) {
                 canvasHtmlFrame.hidden = false;
-                a2uiRoot.hidden = true;
+                a2uiSurfaces.hidden = true;
                 canvasHtmlFrame.srcdoc = env.html;
                 canvasStatus.textContent = 'Local HTML';
                 sendCanvasAck(env);
@@ -1757,67 +1875,219 @@
         function handleA2uiPush(env) {
             showCanvas();
             canvasHtmlFrame.hidden = true;
-            a2uiRoot.hidden = false;
+            a2uiSurfaces.hidden = false;
+            const surface = getCanvasSurface(env.surfaceId || 'main');
+            surface.catalogId = surface.catalogId || 'urn:a2ui:catalog:openclaw_v0_8';
+            surface.protocolVersion = 'v0_8';
+            surface.deleted = false;
             const lines = String(env.frames || '').split(/\r?\n/).map(line => line.trim()).filter(Boolean);
             for (const line of lines) {
-                const frame = JSON.parse(line);
-                canvasFrames.push(frame);
-                renderA2uiFrame(frame, env.surfaceId || 'main');
+                surface.components.push(JSON.parse(line));
             }
-            canvasStatus.textContent = `${lines.length} frame${lines.length === 1 ? '' : 's'}`;
+            surface.updatedAt = new Date().toISOString();
+            activeCanvasSurfaceId = surface.surfaceId;
+            renderCanvasSurfaces();
+            canvasStatus.textContent = `${surface.title || surface.surfaceId}: ${lines.length} frame${lines.length === 1 ? '' : 's'}`;
             sendCanvasAck(env);
         }
 
-        function renderA2uiFrame(frame, surfaceId) {
+        function handleA2uiCreateSurface(env) {
+            showCanvas();
+            canvasHtmlFrame.hidden = true;
+            a2uiSurfaces.hidden = false;
+            const surface = getCanvasSurface(env.surfaceId || 'main');
+            surface.catalogId = env.catalogId || surface.catalogId || 'urn:a2ui:catalog:agenui_catalog';
+            surface.protocolVersion = 'v0_9';
+            surface.title = env.surfaceTitle || surface.title || surface.surfaceId;
+            surface.components = Array.isArray(env.components) ? env.components.map(parseA2UiComponent) : [];
+            surface.dataModelJson = env.dataModelJson || null;
+            surface.dataModel = surface.dataModelJson ? JSON.parse(surface.dataModelJson) : null;
+            surface.values = {};
+            surface.diagnostics = [];
+            surface.deleted = false;
+            surface.updatedAt = new Date().toISOString();
+            activeCanvasSurfaceId = surface.surfaceId;
+            renderCanvasSurfaces();
+            canvasStatus.textContent = `Surface ${surface.title || surface.surfaceId} created`;
+            sendCanvasAck(env);
+        }
+
+        function handleA2uiUpdateComponents(env) {
+            showCanvas();
+            canvasHtmlFrame.hidden = true;
+            a2uiSurfaces.hidden = false;
+            const surface = getCanvasSurface(env.surfaceId || 'main');
+            if (env.catalogId) surface.catalogId = env.catalogId;
+            surface.protocolVersion = 'v0_9';
+            surface.components = Array.isArray(env.components) ? env.components.map(parseA2UiComponent) : [];
+            surface.deleted = false;
+            surface.updatedAt = new Date().toISOString();
+            activeCanvasSurfaceId = surface.surfaceId;
+            renderCanvasSurfaces();
+            canvasStatus.textContent = `${surface.title || surface.surfaceId}: ${surface.components.length} component${surface.components.length === 1 ? '' : 's'}`;
+            sendCanvasAck(env);
+        }
+
+        function handleA2uiUpdateDataModel(env) {
+            const surface = getCanvasSurface(env.surfaceId || 'main');
+            surface.dataModelJson = env.dataModelJson || '{}';
+            surface.dataModel = JSON.parse(surface.dataModelJson);
+            surface.updatedAt = new Date().toISOString();
+            renderCanvasSurfaces();
+            canvasStatus.textContent = `${surface.title || surface.surfaceId}: data updated`;
+            sendCanvasAck(env);
+        }
+
+        function handleA2uiDeleteSurface(env) {
+            const id = env.surfaceId || 'main';
+            const surface = canvasSurfaces.get(id);
+            if (surface) surface.deleted = true;
+            canvasSurfaces.delete(id);
+            if (activeCanvasSurfaceId === id) {
+                activeCanvasSurfaceId = canvasSurfaces.keys().next().value || null;
+            }
+            renderCanvasSurfaces();
+            canvasStatus.textContent = `Surface ${id} deleted`;
+            sendCanvasAck(env);
+        }
+
+        function handleA2uiSyncUiToData(env) {
+            const surface = getCanvasSurface(env.surfaceId || 'main');
+            const dataModelJson = syncedDataModelJson(surface);
+            ws.send(JSON.stringify({
+                type: 'a2ui_sync_result',
+                requestId: env.requestId,
+                sessionId: canvasSessionId,
+                surfaceId: surface.surfaceId,
+                componentId: env.componentId || null,
+                syncMode: env.syncMode || null,
+                success: true,
+                dataModelJson,
+                valueJson: dataModelJson
+            }));
+            sendCanvasAck(env);
+        }
+
+        const A2UI_TYPE_ALIASES = {
+            text: 'Text',
+            markdown: 'Markdown',
+            card: 'Card',
+            button: 'Button',
+            input: 'TextField',
+            select: 'ChoicePicker',
+            checklist: 'CheckBox',
+            table: 'Table',
+            image: 'Image',
+            progress: 'Slider',
+            chart: 'Chart'
+        };
+
+        const A2UI_RENDERERS = {
+            Text: renderA2uiText,
+            Markdown: renderA2uiMarkdown,
+            RichText: renderA2uiMarkdown,
+            Button: renderA2uiButton,
+            TextField: renderA2uiInput,
+            CheckBox: renderA2uiCheckBox,
+            Slider: renderA2uiProgress,
+            ChoicePicker: renderA2uiSelect,
+            DateTimeInput: renderA2uiDateTimeInput,
+            Row: renderA2uiContainer,
+            Column: renderA2uiContainer,
+            Card: renderA2uiCard,
+            List: renderA2uiList,
+            Tabs: renderA2uiTabs,
+            Modal: renderA2uiCard,
+            Table: renderA2uiTable,
+            Image: renderA2uiImage,
+            Divider: renderA2uiDivider,
+            AudioPlayer: renderA2uiMediaPlaceholder,
+            Video: renderA2uiMediaPlaceholder,
+            Icon: renderA2uiIcon,
+            Carousel: renderA2uiCarousel,
+            Web: renderA2uiWebFallback,
+            Chart: renderA2uiChart
+        };
+
+        function renderA2uiFrame(frame, surfaceId, surface = getCanvasSurface(surfaceId), parent = a2uiSurfaceHost) {
+            const type = canonicalA2uiType(frame.type);
             const wrap = document.createElement('div');
-            wrap.className = frame.type === 'card' ? 'a2ui-card' : 'a2ui-frame';
+            wrap.className = type === 'Card' ? 'a2ui-card' : 'a2ui-frame';
             wrap.dataset.frameId = frame.id || '';
-            wrap.dataset.type = frame.type || '';
-            const title = frame.title || frame.label;
-            if (title && frame.type !== 'button') {
+            wrap.dataset.type = type;
+            if (frame.visibleBinding && !asBoolean(readDataModelPath(surface, frame.visibleBinding))) {
+                wrap.hidden = true;
+            }
+            const title = resolveBoundText(surface, frame.title || frame.label || '', frame.titleBinding || frame.labelBinding);
+            if (title && type !== 'Button') {
                 const titleEl = document.createElement('div');
                 titleEl.className = 'a2ui-title';
                 titleEl.textContent = title;
                 wrap.appendChild(titleEl);
             }
-            switch (frame.type) {
-                case 'text':
-                case 'markdown':
-                    appendMarkdownOrText(wrap, frame.text || '', frame.type === 'markdown');
-                    break;
-                case 'card':
-                    appendMarkdownOrText(wrap, frame.body || frame.text || '', true);
-                    break;
-                case 'button':
-                    renderA2uiButton(wrap, frame, surfaceId);
-                    break;
-                case 'input':
-                    renderA2uiInput(wrap, frame, surfaceId);
-                    break;
-                case 'select':
-                    renderA2uiSelect(wrap, frame, surfaceId);
-                    break;
-                case 'checklist':
-                    renderA2uiChecklist(wrap, frame, surfaceId);
-                    break;
-                case 'table':
-                    renderA2uiTable(wrap, frame);
-                    break;
-                case 'image':
-                    renderA2uiImage(wrap, frame);
-                    break;
-                case 'progress':
-                    renderA2uiProgress(wrap, frame);
-                    break;
-                case 'chart':
-                    renderA2uiChart(wrap, frame);
-                    break;
-                default:
-                    wrap.textContent = `Unsupported A2UI frame: ${frame.type}`;
-                    canvasDiagnostics.push(`Unsupported A2UI frame: ${frame.type}`);
-                    break;
+            const renderer = A2UI_RENDERERS[type] || renderA2uiFallback;
+            renderer(wrap, frame, surfaceId, surface, type);
+            parent.appendChild(wrap);
+        }
+
+        function canonicalA2uiType(type) {
+            const raw = String(type || 'Text');
+            return A2UI_TYPE_ALIASES[raw] || A2UI_TYPE_ALIASES[raw.toLowerCase()] || raw;
+        }
+
+        function readDataModelPath(surface, path) {
+            if (!path) return undefined;
+            return String(path).split('.').filter(Boolean).reduce((value, segment) => value?.[segment], surface.dataModel);
+        }
+
+        function asBoolean(value) {
+            return value === undefined || value === null ? true : Boolean(value);
+        }
+
+        function boundValue(surface, frame, fallback, bindingName = 'valueBinding') {
+            const bound = readDataModelPath(surface, frame[bindingName]);
+            return bound === undefined ? fallback : bound;
+        }
+
+        function setDataModelPath(surface, path, value) {
+            if (!path) return;
+            if (!surface.dataModel || typeof surface.dataModel !== 'object' || Array.isArray(surface.dataModel)) {
+                surface.dataModel = {};
             }
-            a2uiRoot.appendChild(wrap);
+            const segments = String(path).split('.').filter(Boolean);
+            let current = surface.dataModel;
+            for (let i = 0; i < segments.length - 1; i++) {
+                const segment = segments[i];
+                if (!current[segment] || typeof current[segment] !== 'object' || Array.isArray(current[segment])) {
+                    current[segment] = {};
+                }
+                current = current[segment];
+            }
+            if (segments.length) {
+                current[segments[segments.length - 1]] = value;
+                surface.dataModelJson = JSON.stringify(surface.dataModel);
+            }
+        }
+
+        function setSurfaceValue(surface, frame, value) {
+            if (frame.id) surface.values[frame.id] = value;
+            setDataModelPath(surface, frame.valueBinding, value);
+        }
+
+        function syncedDataModelJson(surface) {
+            if (surface.dataModel && typeof surface.dataModel === 'object' && !Array.isArray(surface.dataModel)) {
+                return JSON.stringify(surface.dataModel);
+            }
+            return JSON.stringify(surface.values || {});
+        }
+
+        function resolveBoundText(surface, value, binding) {
+            const bound = readDataModelPath(surface, binding);
+            if (bound !== undefined) return String(bound ?? '');
+            return String(value ?? '').replace(/\{([A-Za-z0-9_.-]+)\}/g, (_, path) => {
+                const resolved = readDataModelPath(surface, path);
+                return resolved === undefined || resolved === null ? '' : String(resolved);
+            });
         }
 
         function appendMarkdownOrText(parent, value, markdown) {
@@ -1830,30 +2100,46 @@
             parent.appendChild(div);
         }
 
-        function renderA2uiButton(parent, frame, surfaceId) {
+        function renderA2uiText(parent, frame, _surfaceId, surface) {
+            appendMarkdownOrText(parent, resolveBoundText(surface, frame.text ?? frame.value ?? frame.label ?? '', frame.textBinding), false);
+        }
+
+        function renderA2uiMarkdown(parent, frame, _surfaceId, surface) {
+            appendMarkdownOrText(parent, resolveBoundText(surface, frame.markdown ?? frame.text ?? frame.value ?? '', frame.textBinding), true);
+        }
+
+        function renderA2uiCard(parent, frame, surfaceId, surface) {
+            appendMarkdownOrText(parent, resolveBoundText(surface, frame.body || frame.text || '', frame.textBinding), true);
+            renderChildComponents(parent, frame, surfaceId, surface);
+        }
+
+        function renderA2uiButton(parent, frame, surfaceId, surface) {
             const button = document.createElement('button');
             button.className = 'a2ui-button';
             button.type = 'button';
-            button.textContent = frame.label || frame.text || 'Button';
-            button.addEventListener('click', () => sendA2uiEvent(surfaceId, frame.id, 'click', true));
+            button.textContent = resolveBoundText(surface, frame.label || frame.text || 'Button', frame.textBinding);
+            button.disabled = Boolean(readDataModelPath(surface, frame.disabledBinding));
+            button.addEventListener('click', () => sendA2uiInteraction(surface, surfaceId, frame.id, 'click', true));
             parent.appendChild(button);
         }
 
-        function renderA2uiInput(parent, frame, surfaceId) {
+        function renderA2uiInput(parent, frame, surfaceId, surface) {
             const input = document.createElement('input');
             input.className = 'a2ui-control';
             input.placeholder = frame.placeholder || frame.label || '';
-            input.value = frame.value || '';
-            canvasValues[frame.id] = input.value;
+            input.value = String(boundValue(surface, frame, frame.value || '') ?? '');
+            input.disabled = Boolean(readDataModelPath(surface, frame.disabledBinding));
+            setSurfaceValue(surface, frame, input.value);
             input.addEventListener('change', () => {
-                canvasValues[frame.id] = input.value;
-                sendA2uiEvent(surfaceId, frame.id, 'change', input.value);
+                setSurfaceValue(surface, frame, input.value);
+                sendA2uiInteraction(surface, surfaceId, frame.id, 'change', input.value);
             });
             parent.appendChild(input);
         }
 
-        function normalizeOptions(frame) {
-            return Array.isArray(frame.options) ? frame.options.map(option => {
+        function normalizeOptions(frame, surface) {
+            const source = boundValue(surface, frame, frame.options, 'itemsBinding');
+            return Array.isArray(source) ? source.map(option => {
                 if (typeof option === 'string') return { label: option, value: option };
                 return {
                     label: option.label ?? option.text ?? option.value ?? 'option',
@@ -1863,62 +2149,163 @@
             }) : [];
         }
 
-        function renderA2uiSelect(parent, frame, surfaceId) {
+        function renderA2uiSelect(parent, frame, surfaceId, surface) {
             const select = document.createElement('select');
             select.className = 'a2ui-control';
-            for (const option of normalizeOptions(frame)) {
+            const current = boundValue(surface, frame, frame.value);
+            for (const option of normalizeOptions(frame, surface)) {
                 const el = document.createElement('option');
                 el.value = option.value;
                 el.textContent = option.label;
-                el.selected = option.selected;
+                el.selected = current !== undefined ? option.value === current : option.selected;
                 select.appendChild(el);
             }
-            canvasValues[frame.id] = select.value;
+            select.disabled = Boolean(readDataModelPath(surface, frame.disabledBinding));
+            setSurfaceValue(surface, frame, select.value);
             select.addEventListener('change', () => {
-                canvasValues[frame.id] = select.value;
-                sendA2uiEvent(surfaceId, frame.id, 'change', select.value);
+                setSurfaceValue(surface, frame, select.value);
+                sendA2uiInteraction(surface, surfaceId, frame.id, 'change', select.value);
             });
             parent.appendChild(select);
         }
 
-        function renderA2uiChecklist(parent, frame, surfaceId) {
+        function renderA2uiCheckBox(parent, frame, surfaceId, surface) {
+            const options = normalizeOptions(frame, surface);
+            if (!options.length) {
+                const label = document.createElement('label');
+                label.className = 'a2ui-muted';
+                const checkbox = document.createElement('input');
+                checkbox.type = 'checkbox';
+                checkbox.checked = Boolean(boundValue(surface, frame, frame.checked ?? frame.value ?? false));
+                checkbox.disabled = Boolean(readDataModelPath(surface, frame.disabledBinding));
+                setSurfaceValue(surface, frame, checkbox.checked);
+                checkbox.addEventListener('change', () => {
+                    setSurfaceValue(surface, frame, checkbox.checked);
+                    sendA2uiInteraction(surface, surfaceId, frame.id, 'change', checkbox.checked);
+                });
+                label.appendChild(checkbox);
+                label.append(` ${frame.label || frame.text || ''}`);
+                parent.appendChild(label);
+                return;
+            }
             const group = document.createElement('div');
-            for (const option of normalizeOptions(frame)) {
+            const disabled = Boolean(readDataModelPath(surface, frame.disabledBinding));
+            const checkboxItems = [];
+            const updateGroupState = () => {
+                const selected = checkboxItems.filter(item => item.checkbox.checked).map(item => item.value);
+                if (frame.id) surface.values[frame.id] = selected;
+                setDataModelPath(surface, frame.valueBinding, selected);
+                return selected;
+            };
+            for (const option of options) {
                 const label = document.createElement('label');
                 label.className = 'a2ui-muted';
                 const checkbox = document.createElement('input');
                 checkbox.type = 'checkbox';
                 checkbox.checked = Boolean(option.selected);
+                checkbox.disabled = disabled;
+                checkboxItems.push({ checkbox, value: option.value });
                 checkbox.addEventListener('change', () => {
-                    canvasValues[`${frame.id}:${option.value}`] = checkbox.checked;
-                    sendA2uiEvent(surfaceId, frame.id, 'change', { value: option.value, selected: checkbox.checked });
+                    const selected = updateGroupState();
+                    sendA2uiInteraction(surface, surfaceId, frame.id, 'change', selected);
                 });
                 label.appendChild(checkbox);
                 label.append(` ${option.label}`);
                 group.appendChild(label);
                 group.appendChild(document.createElement('br'));
             }
+            updateGroupState();
             parent.appendChild(group);
         }
 
-        function renderA2uiTable(parent, frame) {
+        function renderA2uiDateTimeInput(parent, frame, surfaceId, surface) {
+            const input = document.createElement('input');
+            input.className = 'a2ui-control';
+            input.type = frame.inputType || (frame.mode === 'date' ? 'date' : 'datetime-local');
+            input.value = String(boundValue(surface, frame, frame.value || '') ?? '');
+            input.disabled = Boolean(readDataModelPath(surface, frame.disabledBinding));
+            setSurfaceValue(surface, frame, input.value);
+            input.addEventListener('change', () => {
+                setSurfaceValue(surface, frame, input.value);
+                sendA2uiInteraction(surface, surfaceId, frame.id, 'change', input.value);
+            });
+            parent.appendChild(input);
+        }
+
+        function renderA2uiContainer(parent, frame, surfaceId, surface, type) {
+            const container = document.createElement('div');
+            container.style.display = 'flex';
+            container.style.flexDirection = type === 'Row' ? 'row' : 'column';
+            container.style.gap = '0.75rem';
+            renderChildComponents(container, frame, surfaceId, surface);
+            parent.appendChild(container);
+        }
+
+        function renderChildComponents(parent, frame, surfaceId, surface) {
+            const children = frame.components || frame.children || frame.items || [];
+            if (!Array.isArray(children)) return;
+            for (const child of children) {
+                renderA2uiFrame(child, surfaceId, surface, parent);
+            }
+        }
+
+        function renderA2uiList(parent, frame, surfaceId, surface) {
+            const items = boundValue(surface, frame, frame.items || [], 'itemsBinding');
+            const list = document.createElement(frame.ordered ? 'ol' : 'ul');
+            for (const item of Array.isArray(items) ? items : []) {
+                const li = document.createElement('li');
+                if (typeof item === 'object' && item !== null) {
+                    renderA2uiFrame(item, surfaceId, surface, li);
+                } else {
+                    li.textContent = String(item ?? '');
+                }
+                list.appendChild(li);
+            }
+            parent.appendChild(list);
+        }
+
+        function renderA2uiTabs(parent, frame, surfaceId, surface) {
+            const tabs = frame.tabs || frame.items || [];
+            const list = document.createElement('div');
+            list.style.display = 'flex';
+            list.style.gap = '0.5rem';
+            const panel = document.createElement('div');
+            panel.className = 'a2ui-frame';
+            tabs.forEach((tab, index) => {
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.className = 'a2ui-tab';
+                button.textContent = tab.title || tab.label || `Tab ${index + 1}`;
+                button.addEventListener('click', () => {
+                    panel.innerHTML = '';
+                    for (const child of tab.components || tab.children || []) renderA2uiFrame(child, surfaceId, surface, panel);
+                });
+                list.appendChild(button);
+            });
+            parent.appendChild(list);
+            parent.appendChild(panel);
+            list.querySelector('button')?.click();
+        }
+
+        function renderA2uiTable(parent, frame, _surfaceId, surface) {
             const table = document.createElement('table');
             table.className = 'a2ui-table';
+            const rows = boundValue(surface, frame, frame.rows || [], 'itemsBinding');
             if (Array.isArray(frame.columns)) {
                 const thead = document.createElement('thead');
                 const tr = document.createElement('tr');
                 for (const column of frame.columns) {
                     const th = document.createElement('th');
-                    th.textContent = String(column);
+                    th.textContent = String(column.label ?? column.key ?? column);
                     tr.appendChild(th);
                 }
                 thead.appendChild(tr);
                 table.appendChild(thead);
             }
             const tbody = document.createElement('tbody');
-            for (const row of Array.isArray(frame.rows) ? frame.rows : []) {
+            for (const row of Array.isArray(rows) ? rows : []) {
                 const tr = document.createElement('tr');
-                const cells = Array.isArray(row) ? row : Object.values(row || {});
+                const cells = Array.isArray(row) ? row : frame.columns?.map(column => row?.[column.key ?? column]) ?? Object.values(row || {});
                 for (const cell of cells) {
                     const td = document.createElement('td');
                     td.textContent = String(cell ?? '');
@@ -1933,23 +2320,41 @@
         function renderA2uiImage(parent, frame) {
             const note = document.createElement('div');
             note.className = 'a2ui-muted';
-            note.textContent = frame.alt || frame.label || 'Image URL omitted by Canvas security policy.';
+            note.textContent = frame.alt || frame.label || frame.url || 'Image URL omitted by Canvas security policy.';
             parent.appendChild(note);
         }
 
-        function renderA2uiProgress(parent, frame) {
+        function renderA2uiDivider(parent) {
+            parent.appendChild(document.createElement('hr'));
+        }
+
+        function renderA2uiProgress(parent, frame, surfaceId, surface) {
             const progress = document.createElement('progress');
             progress.className = 'a2ui-progress';
             progress.max = Number(frame.max ?? 100);
-            const raw = Number(frame.value ?? 0);
+            const raw = Number(boundValue(surface, frame, frame.value ?? 0));
             progress.value = raw <= 1 && progress.max === 100 ? raw * 100 : raw;
             parent.appendChild(progress);
+            if (canonicalA2uiType(frame.type) === 'Slider') {
+                const range = document.createElement('input');
+                range.type = 'range';
+                range.className = 'a2ui-control';
+                range.min = Number(frame.min ?? 0);
+                range.max = Number(frame.max ?? 100);
+                range.value = String(progress.value);
+                range.disabled = Boolean(readDataModelPath(surface, frame.disabledBinding));
+                range.addEventListener('change', () => {
+                    setSurfaceValue(surface, frame, Number(range.value));
+                    sendA2uiInteraction(surface, surfaceId, frame.id, 'change', Number(range.value));
+                });
+                parent.appendChild(range);
+            }
         }
 
-        function renderA2uiChart(parent, frame) {
-            const data = Array.isArray(frame.data) ? frame.data : [];
-            if (!data.length) {
-                appendMarkdownOrText(parent, JSON.stringify(frame.data ?? {}, null, 2), false);
+        function renderA2uiChart(parent, frame, _surfaceId, surface) {
+            const data = boundValue(surface, frame, frame.data || [], 'itemsBinding');
+            if (!Array.isArray(data) || !data.length) {
+                appendMarkdownOrText(parent, JSON.stringify(data ?? {}, null, 2), false);
                 return;
             }
             const max = Math.max(...data.map(item => Number(item.value ?? item.y ?? 0)), 1);
@@ -1965,6 +2370,44 @@
             }
         }
 
+        function renderA2uiIcon(parent, frame) {
+            const span = document.createElement('span');
+            span.className = 'a2ui-muted';
+            span.textContent = frame.label || frame.name || 'Icon';
+            parent.appendChild(span);
+        }
+
+        function renderA2uiCarousel(parent, frame, surfaceId, surface) {
+            renderA2uiList(parent, { ...frame, items: frame.items || frame.slides || [] }, surfaceId, surface);
+        }
+
+        function renderA2uiMediaPlaceholder(parent, frame, _surfaceId, _surface, type) {
+            const note = document.createElement('div');
+            note.className = 'a2ui-muted';
+            note.textContent = `${type} source omitted by Canvas security policy.`;
+            parent.appendChild(note);
+        }
+
+        function renderA2uiWebFallback(parent, frame) {
+            const note = document.createElement('div');
+            note.className = 'a2ui-muted';
+            note.textContent = frame.url ? `Web component blocked: ${frame.url}` : 'Web component blocked by Canvas security policy.';
+            parent.appendChild(note);
+        }
+
+        function renderA2uiFallback(parent, frame, _surfaceId, surface, type) {
+            parent.textContent = `Unsupported A2UI component: ${type}`;
+            surface.diagnostics.push(`Unsupported A2UI component: ${type}`);
+        }
+
+        function sendA2uiInteraction(surface, surfaceId, componentId, eventName, value) {
+            if (surface.protocolVersion === 'v0_9') {
+                sendA2uiAction(surfaceId, componentId, eventName, value, syncedDataModelJson(surface));
+                return;
+            }
+            sendA2uiEvent(surfaceId, componentId, eventName, value);
+        }
+
         function sendA2uiEvent(surfaceId, componentId, eventName, value) {
             if (!ws || ws.readyState !== WebSocket.OPEN) return;
             ws.send(JSON.stringify({
@@ -1978,28 +2421,50 @@
             }));
         }
 
+        function sendA2uiAction(surfaceId, componentId, action, value, dataModelJson) {
+            if (!ws || ws.readyState !== WebSocket.OPEN) return;
+            ws.send(JSON.stringify({
+                type: 'a2ui_action',
+                operation: 'action',
+                sessionId: canvasSessionId,
+                surfaceId: surfaceId || 'main',
+                componentId,
+                action,
+                valueJson: JSON.stringify(value ?? null),
+                dataModelJson: dataModelJson || null,
+                sequence: ++canvasEventSequence
+            }));
+        }
+
         function sendCanvasSnapshot(env) {
+            const requestedSurfaceId = env.surfaceId || activeCanvasSurfaceId || 'main';
+            const surface = canvasSurfaces.get(requestedSurfaceId) || null;
+            const components = surface?.components || [];
             const snapshot = {
                 type: 'canvas_snapshot',
-                surfaceId: env.surfaceId || 'main',
+                surfaceId: surface?.surfaceId || requestedSurfaceId,
+                catalogId: surface?.catalogId || null,
+                title: surface?.title || null,
                 visible: !canvasPanel.hidden,
-                frameCount: canvasFrames.length,
-                frames: canvasFrames.map(frame => ({
+                frameCount: components.length,
+                components,
+                frames: components.map(frame => ({
                     id: frame.id,
                     type: frame.type,
                     title: frame.title,
                     label: frame.label,
                     text: frame.text
                 })),
-                values: canvasValues,
-                diagnostics: canvasDiagnostics,
+                dataModelJson: surface?.dataModelJson || null,
+                values: surface?.values || {},
+                diagnostics: surface?.diagnostics || [],
                 localHtmlText: canvasHtmlFrame.hidden ? null : canvasHtmlFrame.srcdoc
             };
             ws.send(JSON.stringify({
                 type: 'canvas_snapshot_result',
                 requestId: env.requestId,
                 sessionId: canvasSessionId,
-                surfaceId: env.surfaceId || 'main',
+                surfaceId: snapshot.surfaceId,
                 snapshotMode: env.snapshotMode || 'state',
                 success: true,
                 snapshotJson: JSON.stringify(snapshot)

--- a/src/OpenClaw.Gateway/wwwroot/webchat.html
+++ b/src/OpenClaw.Gateway/wwwroot/webchat.html
@@ -1782,15 +1782,9 @@
             return typeof component === 'string' ? JSON.parse(component) : component;
         }
 
-        function resetA2ui(surfaceId = 'main') {
-            const surface = getCanvasSurface(surfaceId);
-            surface.components = [];
-            surface.values = {};
-            surface.diagnostics = [];
-            surface.dataModelJson = null;
-            surface.dataModel = null;
-            surface.updatedAt = new Date().toISOString();
-            activeCanvasSurfaceId = surface.surfaceId;
+        function resetA2ui() {
+            canvasSurfaces.clear();
+            activeCanvasSurfaceId = null;
             a2uiSurfaces.hidden = false;
             canvasHtmlFrame.hidden = true;
             canvasHtmlFrame.removeAttribute('srcdoc');
@@ -1814,7 +1808,7 @@
                         handleCanvasNavigate(env);
                         break;
                     case 'a2ui_reset':
-                        resetA2ui(env.surfaceId || 'main');
+                        resetA2ui();
                         sendCanvasAck(env);
                         break;
                     case 'a2ui_push':

--- a/src/OpenClaw.Gateway/wwwroot/webchat.html
+++ b/src/OpenClaw.Gateway/wwwroot/webchat.html
@@ -1870,7 +1870,7 @@
             showCanvas();
             canvasHtmlFrame.hidden = true;
             a2uiSurfaces.hidden = false;
-            const surface = getCanvasSurface(env.surfaceId || 'main');
+            const surface = getCanvasSurface('main');
             surface.catalogId = surface.catalogId || 'urn:a2ui:catalog:openclaw_v0_8';
             surface.protocolVersion = 'v0_8';
             surface.deleted = false;
@@ -1972,7 +1972,7 @@
             checklist: 'CheckBox',
             table: 'Table',
             image: 'Image',
-            progress: 'Slider',
+            progress: 'Progress',
             chart: 'Chart'
         };
 
@@ -1983,6 +1983,7 @@
             Button: renderA2uiButton,
             TextField: renderA2uiInput,
             CheckBox: renderA2uiCheckBox,
+            Progress: renderA2uiProgress,
             Slider: renderA2uiProgress,
             ChoicePicker: renderA2uiSelect,
             DateTimeInput: renderA2uiDateTimeInput,
@@ -2185,6 +2186,8 @@
             const group = document.createElement('div');
             const disabled = Boolean(readDataModelPath(surface, frame.disabledBinding));
             const checkboxItems = [];
+            const current = boundValue(surface, frame, surface.values?.[frame.id]);
+            const currentValues = Array.isArray(current) ? current.map(value => String(value)) : null;
             const updateGroupState = () => {
                 const selected = checkboxItems.filter(item => item.checkbox.checked).map(item => item.value);
                 if (frame.id) surface.values[frame.id] = selected;
@@ -2196,7 +2199,7 @@
                 label.className = 'a2ui-muted';
                 const checkbox = document.createElement('input');
                 checkbox.type = 'checkbox';
-                checkbox.checked = Boolean(option.selected);
+                checkbox.checked = currentValues ? currentValues.includes(String(option.value)) : Boolean(option.selected);
                 checkbox.disabled = disabled;
                 checkboxItems.push({ checkbox, value: option.value });
                 checkbox.addEventListener('change', () => {
@@ -2208,7 +2211,11 @@
                 group.appendChild(label);
                 group.appendChild(document.createElement('br'));
             }
-            updateGroupState();
+            if (currentValues) {
+                if (frame.id) surface.values[frame.id] = currentValues;
+            } else {
+                updateGroupState();
+            }
             parent.appendChild(group);
         }
 

--- a/src/OpenClaw.Tests/A2UiFrameValidatorTests.cs
+++ b/src/OpenClaw.Tests/A2UiFrameValidatorTests.cs
@@ -1,4 +1,5 @@
 using OpenClaw.Core.Canvas;
+using OpenClaw.Core.Models;
 using Xunit;
 
 namespace OpenClaw.Tests;
@@ -64,5 +65,366 @@ public sealed class A2UiFrameValidatorTests
 
         Assert.False(result.IsValid);
         Assert.Contains("options", result.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateJsonl_PreservesV08ComponentAliases()
+    {
+        var frames = string.Join('\n',
+            """{"type":"markdown","id":"md","text":"**Hello**"}""",
+            """{"type":"input","id":"name"}""",
+            """{"type":"select","id":"choice","options":["A"]}""",
+            """{"type":"checklist","id":"checks","options":["A"]}""",
+            """{"type":"image","id":"img","url":"https://example.test/a.png"}""",
+            """{"type":"chart","id":"chart","data":{}}""");
+
+        var result = A2UiFrameValidator.ValidateJsonl(frames, maxFrames: 10, maxBytes: 4096);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(6, result.FrameCount);
+    }
+
+    [Fact]
+    public void ValidateV09_AcceptsValidCreateSurface()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "createSurface",
+            SurfaceId = "surface-1",
+            SupportedCatalogIds = [A2UiCatalogRegistry.AGenUiCatalogId]
+        });
+
+        Assert.True(result.IsValid, result.Error);
+    }
+
+    [Fact]
+    public void ValidateV09_AcceptsValidUpdateComponentsJsonStringArray()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "updateComponents",
+            SurfaceId = "surface-1",
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            Components = ["""{"type":"Text","id":"t1","text":"Hello"}""", """{"type":"Button","id":"b1","label":"OK"}"""]
+        });
+
+        Assert.True(result.IsValid, result.Error);
+    }
+
+    [Fact]
+    public void ValidateV09_RejectsMalformedComponentString()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "updateComponents",
+            SurfaceId = "surface-1",
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            Components = ["{\"type\":\"Text\""]
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("not valid JSON", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateV09_UpdateDataModelAcceptsJsonObject()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "updateDataModel",
+            SurfaceId = "surface-1",
+            DataModelJson = """{"count":1}"""
+        });
+
+        Assert.True(result.IsValid, result.Error);
+    }
+
+    [Fact]
+    public void ValidateV09_UpdateDataModelRejectsMissingSurfaceId()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "updateDataModel",
+            DataModelJson = """{"count":1}"""
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("surfaceId", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateV09_UpdateDataModelRejectsMalformedJson()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "updateDataModel",
+            SurfaceId = "surface-1",
+            DataModelJson = "{\"count\":"
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("not valid JSON", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateV09_UpdateDataModelRejectsNonObjectJson()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "updateDataModel",
+            SurfaceId = "surface-1",
+            DataModelJson = """["count"]"""
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("JSON object", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateV09_DeleteSurfaceAcceptsSurfaceId()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "deleteSurface",
+            SurfaceId = "surface-1"
+        });
+
+        Assert.True(result.IsValid, result.Error);
+    }
+
+    [Fact]
+    public void ValidateV09_DeleteSurfaceRejectsMissingSurfaceId()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "deleteSurface"
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("surfaceId", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateV09_SyncUIToDataAcceptsSurfaceIdWithoutDataModelJson()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "syncUIToData",
+            SurfaceId = "surface-1"
+        });
+
+        Assert.True(result.IsValid, result.Error);
+    }
+
+    [Fact]
+    public void ValidateV09_SyncUIToDataAcceptsOptionalDataModelJsonObject()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "syncUIToData",
+            SurfaceId = "surface-1",
+            DataModelJson = """{"enabled":true}"""
+        });
+
+        Assert.True(result.IsValid, result.Error);
+    }
+
+    [Fact]
+    public void ValidateV09_SyncUIToDataRejectsInvalidOptionalDataModelJson()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "syncUIToData",
+            SurfaceId = "surface-1",
+            DataModelJson = "{\"enabled\":"
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("not valid JSON", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateV09_SyncUIToDataRejectsNonObjectOptionalDataModelJson()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "syncUIToData",
+            SurfaceId = "surface-1",
+            DataModelJson = "true"
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("JSON object", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateV09_ActionAcceptsSurfaceIdAndAction()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "action",
+            SurfaceId = "surface-1",
+            Action = "submit"
+        });
+
+        Assert.True(result.IsValid, result.Error);
+    }
+
+    [Fact]
+    public void ValidateV09_ActionRejectsMissingAction()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "action",
+            SurfaceId = "surface-1"
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("action", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateV09_ActionRejectsMissingSurfaceId()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "action",
+            Action = "submit"
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("surfaceId", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateV09_ActionRejectsNonObjectParametersJson()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "action",
+            SurfaceId = "surface-1",
+            Action = "submit",
+            ParametersJson = "[]"
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("JSON object", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("error", null)]
+    [InlineData(null, "E_A2UI")]
+    public void ValidateV09_ErrorAcceptsErrorOrDiagnosticCode(string? error, string? diagnosticCode)
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "error",
+            Error = error,
+            DiagnosticCode = diagnosticCode
+        });
+
+        Assert.True(result.IsValid, result.Error);
+    }
+
+    [Fact]
+    public void ValidateV09_ErrorRejectsWhenErrorAndDiagnosticCodeAreAbsent()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "error"
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("error", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("diagnosticCode", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateV09_RejectsUnsupportedCatalogIds()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "createSurface",
+            SurfaceId = "surface-1",
+            CatalogId = "urn:a2ui:catalog:unknown"
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("catalog", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateV09_RejectsUnsupportedComponentTypes()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "updateComponents",
+            SurfaceId = "surface-1",
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            Components = ["""{"type":"UnsupportedWidget","id":"bad"}"""]
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("UnsupportedWidget", result.Error, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("Text")]
+    [InlineData("Image")]
+    [InlineData("Icon")]
+    [InlineData("Divider")]
+    [InlineData("Video")]
+    [InlineData("AudioPlayer")]
+    [InlineData("Markdown")]
+    [InlineData("Button")]
+    [InlineData("TextField")]
+    [InlineData("CheckBox")]
+    [InlineData("Slider")]
+    [InlineData("ChoicePicker")]
+    [InlineData("DateTimeInput")]
+    [InlineData("Row")]
+    [InlineData("Column")]
+    [InlineData("Card")]
+    [InlineData("List")]
+    [InlineData("Tabs")]
+    [InlineData("Modal")]
+    [InlineData("Table")]
+    [InlineData("Carousel")]
+    [InlineData("Web")]
+    [InlineData("RichText")]
+    [InlineData("Chart")]
+    public void ValidateV09_AcceptsEveryTargetAGenUiComponentType(string componentType)
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "updateComponents",
+            SurfaceId = "surface-1",
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            Components = [$$"""{"type":"{{componentType}}","id":"component-1"}"""]
+        });
+
+        Assert.True(result.IsValid, result.Error);
     }
 }

--- a/src/OpenClaw.Tests/A2UiFrameValidatorTests.cs
+++ b/src/OpenClaw.Tests/A2UiFrameValidatorTests.cs
@@ -130,6 +130,22 @@ public sealed class A2UiFrameValidatorTests
     }
 
     [Fact]
+    public void ValidateV09_RejectsComponentWithoutId()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "updateComponents",
+            SurfaceId = "surface-1",
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            Components = ["""{"type":"Text","text":"Hello"}"""]
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("id", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void ValidateV09_UpdateDataModelAcceptsJsonObject()
     {
         var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
@@ -367,6 +383,37 @@ public sealed class A2UiFrameValidatorTests
             Operation = "createSurface",
             SurfaceId = "surface-1",
             CatalogId = "urn:a2ui:catalog:unknown"
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("catalog", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateV09_RejectsUnsupportedAdvertisedCatalogIds()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "createSurface",
+            SurfaceId = "surface-1",
+            SupportedCatalogIds = ["urn:a2ui:catalog:unknown"]
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("catalog", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateV09_RejectsRequestedCatalogWhenNotAdvertised()
+    {
+        var result = A2UiV09MessageValidator.Validate(new WsServerEnvelope
+        {
+            Type = "canvas",
+            Operation = "createSurface",
+            SurfaceId = "surface-1",
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            SupportedCatalogIds = [A2UiCatalogRegistry.OpenClawV08CatalogId]
         });
 
         Assert.False(result.IsValid);

--- a/src/OpenClaw.Tests/CanvasCommandBrokerTests.cs
+++ b/src/OpenClaw.Tests/CanvasCommandBrokerTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenClaw.Channels;
+using OpenClaw.Core.Canvas;
 using OpenClaw.Core.Models;
 using OpenClaw.Gateway;
 using Xunit;
@@ -170,6 +171,256 @@ public sealed class CanvasCommandBrokerTests
         Assert.Contains("snapshot exceeds", result.Error, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task HandleClientEnvelopeAsync_StoresSupportedCatalogIdsFromReadyAndLaterEnvelopes()
+    {
+        var broker = CreateBroker(new WebSocketChannel(new WebSocketConfig()));
+
+        await broker.HandleClientEnvelopeAsync("client", ReadyWithCatalogs(
+        [
+            " canvas.present ",
+            "CANVAS.PRESENT"
+        ],
+        [
+            " urn:a2ui:catalog:agenui_catalog ",
+            "URN:A2UI:CATALOG:AGenUI_CATALOG",
+            "urn:a2ui:catalog:openclaw_v0_8"
+        ]), CancellationToken.None);
+
+        Assert.Equal(["canvas.present"], broker.GetClientCapabilities("client"));
+        Assert.Equal([
+            A2UiCatalogRegistry.AGenUiCatalogId,
+            A2UiCatalogRegistry.OpenClawV08CatalogId
+        ], broker.GetClientSupportedCatalogIds("client"));
+
+        await broker.HandleClientEnvelopeAsync("client", new WsClientEnvelope
+        {
+            Type = "canvas_ack",
+            SupportedCatalogIds = ["urn:a2ui:catalog:openclaw_v0_8"]
+        }, CancellationToken.None);
+
+        Assert.Equal([A2UiCatalogRegistry.OpenClawV08CatalogId], broker.GetClientSupportedCatalogIds("client"));
+    }
+
+    [Fact]
+    public async Task TryChooseCatalog_ChoosesCompatibleCatalogAndRejectsUnsupportedRequestedCatalog()
+    {
+        var broker = CreateBroker(new WebSocketChannel(new WebSocketConfig()));
+        await broker.HandleClientEnvelopeAsync("client", ReadyWithCatalogs(
+            ["canvas.a2ui"],
+            [A2UiCatalogRegistry.OpenClawV08CatalogId]), CancellationToken.None);
+
+        Assert.True(broker.TryChooseCatalog("client", null, out var chosen, out var error));
+        Assert.Equal(A2UiCatalogRegistry.OpenClawV08CatalogId, chosen?.CatalogId);
+        Assert.Null(error);
+
+        Assert.False(broker.TryChooseCatalog("client", A2UiCatalogRegistry.AGenUiCatalogId, out chosen, out error));
+        Assert.Null(chosen);
+        Assert.Contains("does not support catalog", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task TryChooseCatalog_PrefersAGenUiWhenBothFirstPartyCatalogsAreSupported()
+    {
+        var broker = CreateBroker(new WebSocketChannel(new WebSocketConfig()));
+        await broker.HandleClientEnvelopeAsync("client", ReadyWithCatalogs(
+            ["canvas.a2ui"],
+            [A2UiCatalogRegistry.OpenClawV08CatalogId, A2UiCatalogRegistry.AGenUiCatalogId]), CancellationToken.None);
+
+        Assert.True(broker.TryChooseCatalog("client", null, out var chosen, out var error));
+        Assert.Equal(A2UiCatalogRegistry.AGenUiCatalogId, chosen?.CatalogId);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_LegacyA2UiPushSendsWithoutCatalogNegotiation()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel);
+        await broker.HandleClientEnvelopeAsync("client", Ready("a2ui.v0_8"), CancellationToken.None);
+
+        var task = broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope { Type = "a2ui_push" },
+            "canvas_ack",
+            "a2ui.v0_8",
+            CancellationToken.None);
+
+        var sent = await WaitForSentEnvelopeAsync(ws);
+        await AckAsync(broker, "client", sent, "sess");
+        var result = await task;
+
+        Assert.True(result.Success);
+        Assert.Equal("a2ui_push", sent.Type);
+        Assert.Empty(broker.GetClientSupportedCatalogIds("client"));
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_LegacyA2UiPushSendsWhenRequestedCatalogIsUnsupported()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel);
+        await broker.HandleClientEnvelopeAsync("client", ReadyWithCatalogs(
+            ["a2ui.v0_8"],
+            [A2UiCatalogRegistry.OpenClawV08CatalogId]), CancellationToken.None);
+
+        var task = broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope
+            {
+                Type = "a2ui_push",
+                CatalogId = A2UiCatalogRegistry.AGenUiCatalogId
+            },
+            "canvas_ack",
+            "a2ui.v0_8",
+            CancellationToken.None);
+
+        var sent = await WaitForSentEnvelopeAsync(ws);
+        await AckAsync(broker, "client", sent, "sess");
+        var result = await task;
+
+        Assert.True(result.Success);
+        Assert.Equal("a2ui_push", sent.Type);
+        Assert.Equal(A2UiCatalogRegistry.AGenUiCatalogId, sent.CatalogId);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_SuccessfulCreateSurfaceLocksCatalogForSurface()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel);
+        await broker.HandleClientEnvelopeAsync("client", ReadyWithCatalogs(
+            ["canvas.a2ui"],
+            [A2UiCatalogRegistry.OpenClawV08CatalogId]), CancellationToken.None);
+
+        var task = broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope
+            {
+                Type = "a2ui_create_surface",
+                SurfaceId = "surface-1",
+                CatalogId = A2UiCatalogRegistry.OpenClawV08CatalogId
+            },
+            "canvas_ack",
+            "canvas.a2ui",
+            CancellationToken.None);
+
+        var sent = await WaitForSentEnvelopeAsync(ws);
+        await AckAsync(broker, "client", sent, "sess");
+        var result = await task;
+
+        Assert.True(result.Success);
+        Assert.True(broker.TryGetSurfaceCatalogId("client", "sess", "surface-1", out var catalogId));
+        Assert.Equal(A2UiCatalogRegistry.OpenClawV08CatalogId, catalogId);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_RejectsConflictingCatalogUpdateBeforeSending()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel);
+        await broker.HandleClientEnvelopeAsync("client", ReadyWithCatalogs(
+            ["canvas.a2ui"],
+            [A2UiCatalogRegistry.OpenClawV08CatalogId, A2UiCatalogRegistry.AGenUiCatalogId]), CancellationToken.None);
+        await LockSurfaceCatalogThroughCreateAsync(broker, ws, "client", "sess", "surface-1", A2UiCatalogRegistry.OpenClawV08CatalogId);
+
+        var result = await broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope
+            {
+                Type = "a2ui_update_components",
+                SurfaceId = "surface-1",
+                CatalogId = A2UiCatalogRegistry.AGenUiCatalogId
+            },
+            "canvas_ack",
+            "canvas.a2ui",
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("catalog", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Single(ws.Sent);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_AllowsLockedCatalogUpdateWithoutCatalogId()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel);
+        await broker.HandleClientEnvelopeAsync("client", ReadyWithCatalogs(
+            ["canvas.a2ui"],
+            [A2UiCatalogRegistry.OpenClawV08CatalogId]), CancellationToken.None);
+        await LockSurfaceCatalogThroughCreateAsync(broker, ws, "client", "sess", "surface-1", A2UiCatalogRegistry.OpenClawV08CatalogId);
+
+        var task = broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope
+            {
+                Type = "a2ui_update_components",
+                SurfaceId = "surface-1"
+            },
+            "canvas_ack",
+            "canvas.a2ui",
+            CancellationToken.None);
+
+        var sent = await WaitForSentEnvelopeAsync(ws, skip: 1);
+        await AckAsync(broker, "client", sent, "sess");
+        var result = await task;
+
+        Assert.True(result.Success);
+        Assert.Null(sent.CatalogId);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_SuccessfulDeleteSurfaceClearsCatalogLockAndAllowsNewCatalog()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel);
+        await broker.HandleClientEnvelopeAsync("client", ReadyWithCatalogs(
+            ["canvas.a2ui"],
+            [A2UiCatalogRegistry.OpenClawV08CatalogId, A2UiCatalogRegistry.AGenUiCatalogId]), CancellationToken.None);
+        await LockSurfaceCatalogThroughCreateAsync(broker, ws, "client", "sess", "surface-1", A2UiCatalogRegistry.OpenClawV08CatalogId);
+
+        var deleteTask = broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope { Type = "a2ui_delete_surface", SurfaceId = "surface-1" },
+            "canvas_ack",
+            "canvas.a2ui",
+            CancellationToken.None);
+        var deleteSent = await WaitForSentEnvelopeAsync(ws, skip: 1);
+        await AckAsync(broker, "client", deleteSent, "sess");
+        Assert.True((await deleteTask).Success);
+        Assert.False(broker.TryGetSurfaceCatalogId("client", "sess", "surface-1", out _));
+
+        var createTask = broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope
+            {
+                Type = "a2ui_create_surface",
+                SurfaceId = "surface-1",
+                CatalogId = A2UiCatalogRegistry.AGenUiCatalogId
+            },
+            "canvas_ack",
+            "canvas.a2ui",
+            CancellationToken.None);
+        var createSent = await WaitForSentEnvelopeAsync(ws, skip: 2);
+        await AckAsync(broker, "client", createSent, "sess");
+        Assert.True((await createTask).Success);
+        Assert.True(broker.TryGetSurfaceCatalogId("client", "sess", "surface-1", out var catalogId));
+        Assert.Equal(A2UiCatalogRegistry.AGenUiCatalogId, catalogId);
+    }
+
     private static CanvasCommandBroker CreateBroker(WebSocketChannel channel, GatewayConfig? config = null)
         => new(
             config ?? new GatewayConfig(),
@@ -185,6 +436,47 @@ public sealed class CanvasCommandBrokerTests
             Capabilities = capabilities
         };
 
+    private static WsClientEnvelope ReadyWithCatalogs(string[] capabilities, string[] supportedCatalogIds)
+        => new()
+        {
+            Type = "canvas_ready",
+            Capabilities = capabilities,
+            SupportedCatalogIds = supportedCatalogIds
+        };
+
+    private static async Task LockSurfaceCatalogThroughCreateAsync(
+        CanvasCommandBroker broker,
+        TestWebSocket ws,
+        string clientId,
+        string sessionId,
+        string surfaceId,
+        string catalogId)
+    {
+        var createTask = broker.SendCommandAsync(
+            Session(sessionId, clientId),
+            new WsServerEnvelope
+            {
+                Type = "a2ui_create_surface",
+                SurfaceId = surfaceId,
+                CatalogId = catalogId
+            },
+            "canvas_ack",
+            "canvas.a2ui",
+            CancellationToken.None);
+        var createSent = await WaitForSentEnvelopeAsync(ws);
+        await AckAsync(broker, clientId, createSent, sessionId);
+        Assert.True((await createTask).Success);
+    }
+
+    private static async Task AckAsync(CanvasCommandBroker broker, string clientId, WsServerEnvelope sent, string sessionId)
+        => await broker.HandleClientEnvelopeAsync(clientId, new WsClientEnvelope
+        {
+            Type = "canvas_ack",
+            RequestId = sent.RequestId,
+            SessionId = sessionId,
+            Success = true
+        }, CancellationToken.None);
+
     private static Session Session(string id, string senderId)
         => new()
         {
@@ -193,13 +485,13 @@ public sealed class CanvasCommandBrokerTests
             SenderId = senderId
         };
 
-    private static async Task<WsServerEnvelope> WaitForSentEnvelopeAsync(TestWebSocket ws)
+    private static async Task<WsServerEnvelope> WaitForSentEnvelopeAsync(TestWebSocket ws, int skip = 0)
     {
         for (var attempt = 0; attempt < 100; attempt++)
         {
-            if (ws.Sent.Count > 0)
+            if (ws.Sent.Count > skip)
             {
-                var payload = Encoding.UTF8.GetString(ws.Sent.Last());
+                var payload = Encoding.UTF8.GetString(ws.Sent.Skip(skip).Last());
                 return JsonSerializer.Deserialize(payload, CoreJsonContext.Default.WsServerEnvelope)
                     ?? throw new InvalidOperationException("Sent payload was not a websocket envelope.");
             }

--- a/src/OpenClaw.Tests/CanvasCommandBrokerTests.cs
+++ b/src/OpenClaw.Tests/CanvasCommandBrokerTests.cs
@@ -321,6 +321,38 @@ public sealed class CanvasCommandBrokerTests
     }
 
     [Fact]
+    public async Task SendCommandAsync_SuccessfulUpdateComponentsLocksCatalogForSurface()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel);
+        await broker.HandleClientEnvelopeAsync("client", ReadyWithCatalogs(
+            ["canvas.a2ui"],
+            [A2UiCatalogRegistry.OpenClawV08CatalogId, A2UiCatalogRegistry.AGenUiCatalogId]), CancellationToken.None);
+
+        var task = broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope
+            {
+                Type = "a2ui_update_components",
+                SurfaceId = "surface-1",
+                CatalogId = A2UiCatalogRegistry.OpenClawV08CatalogId
+            },
+            "canvas_ack",
+            "canvas.a2ui",
+            CancellationToken.None);
+
+        var sent = await WaitForSentEnvelopeAsync(ws);
+        await AckAsync(broker, "client", sent, "sess");
+        var result = await task;
+
+        Assert.True(result.Success);
+        Assert.True(broker.TryGetSurfaceCatalogId("client", "sess", "surface-1", out var catalogId));
+        Assert.Equal(A2UiCatalogRegistry.OpenClawV08CatalogId, catalogId);
+    }
+
+    [Fact]
     public async Task SendCommandAsync_RejectsConflictingCatalogUpdateBeforeSending()
     {
         var channel = new WebSocketChannel(new WebSocketConfig());
@@ -344,6 +376,78 @@ public sealed class CanvasCommandBrokerTests
             "canvas.a2ui",
             CancellationToken.None);
 
+        Assert.False(result.Success);
+        Assert.Contains("catalog", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Single(ws.Sent);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_RejectsConflictingCatalogUpdateWithMixedCaseSurfaceIdBeforeSending()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel);
+        await broker.HandleClientEnvelopeAsync("client", ReadyWithCatalogs(
+            ["canvas.a2ui"],
+            [A2UiCatalogRegistry.OpenClawV08CatalogId, A2UiCatalogRegistry.AGenUiCatalogId]), CancellationToken.None);
+        await LockSurfaceCatalogThroughCreateAsync(broker, ws, "client", "sess", "Main", A2UiCatalogRegistry.OpenClawV08CatalogId);
+
+        var task = broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope
+            {
+                Type = "a2ui_update_components",
+                SurfaceId = "main",
+                CatalogId = A2UiCatalogRegistry.AGenUiCatalogId
+            },
+            "canvas_ack",
+            "canvas.a2ui",
+            CancellationToken.None);
+
+        if (await Task.WhenAny(task, Task.Delay(200)) != task)
+        {
+            var sent = await WaitForSentEnvelopeAsync(ws, skip: 1);
+            await AckAsync(broker, "client", sent, "sess");
+        }
+
+        var result = await task;
+        Assert.False(result.Success);
+        Assert.Contains("catalog", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Single(ws.Sent);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_RejectsConflictingSyncCatalogBeforeSending()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = CreateBroker(channel);
+        await broker.HandleClientEnvelopeAsync("client", ReadyWithCatalogs(
+            ["canvas.a2ui"],
+            [A2UiCatalogRegistry.OpenClawV08CatalogId, A2UiCatalogRegistry.AGenUiCatalogId]), CancellationToken.None);
+        await LockSurfaceCatalogThroughCreateAsync(broker, ws, "client", "sess", "surface-1", A2UiCatalogRegistry.OpenClawV08CatalogId);
+
+        var task = broker.SendCommandAsync(
+            Session("sess", "client"),
+            new WsServerEnvelope
+            {
+                Type = "a2ui_sync_ui_to_data",
+                SurfaceId = "surface-1",
+                CatalogId = A2UiCatalogRegistry.AGenUiCatalogId
+            },
+            "canvas_ack",
+            "canvas.a2ui",
+            CancellationToken.None);
+
+        if (await Task.WhenAny(task, Task.Delay(200)) != task)
+        {
+            var sent = await WaitForSentEnvelopeAsync(ws, skip: 1);
+            await AckAsync(broker, "client", sent, "sess");
+        }
+
+        var result = await task;
         Assert.False(result.Success);
         Assert.Contains("catalog", result.Error, StringComparison.OrdinalIgnoreCase);
         Assert.Single(ws.Sent);

--- a/src/OpenClaw.Tests/CanvasSnapshotAssertions.cs
+++ b/src/OpenClaw.Tests/CanvasSnapshotAssertions.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+internal static class CanvasSnapshotAssertions
+{
+    public static void AssertV09Snapshot(
+        string snapshotJson,
+        int expectedFrameCount,
+        int expectedComponentCount,
+        string expectedDataModelFragment,
+        string? expectedDiagnosticContains = null)
+    {
+        using var doc = JsonDocument.Parse(snapshotJson);
+        var root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("dataModelJson", out var dataModelJson));
+        Assert.Equal(JsonValueKind.String, dataModelJson.ValueKind);
+        Assert.Contains(expectedDataModelFragment, dataModelJson.GetString() ?? string.Empty, StringComparison.Ordinal);
+
+        Assert.True(root.TryGetProperty("components", out var components));
+        Assert.Equal(JsonValueKind.Array, components.ValueKind);
+        Assert.Equal(expectedComponentCount, components.GetArrayLength());
+
+        Assert.True(root.TryGetProperty("frameCount", out var frameCount));
+        Assert.Equal(expectedFrameCount, frameCount.GetInt32());
+
+        Assert.True(root.TryGetProperty("diagnostics", out var diagnostics));
+        Assert.Equal(JsonValueKind.Array, diagnostics.ValueKind);
+
+        if (!string.IsNullOrWhiteSpace(expectedDiagnosticContains))
+        {
+            var values = diagnostics.EnumerateArray()
+                .Where(static item => item.ValueKind == JsonValueKind.String)
+                .Select(static item => item.GetString() ?? string.Empty)
+                .ToArray();
+            Assert.Contains(values, value => value.Contains(expectedDiagnosticContains, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/OpenClaw.Tests/CanvasToolTests.cs
+++ b/src/OpenClaw.Tests/CanvasToolTests.cs
@@ -1,7 +1,10 @@
+using System.Net;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenClaw.Channels;
 using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Canvas;
 using OpenClaw.Core.Models;
 using OpenClaw.Core.Observability;
 using OpenClaw.Gateway;
@@ -92,6 +95,287 @@ public sealed class CanvasToolTests
         Assert.Contains("eval is disabled", result, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task A2UiCreateSurface_MinimalSurfaceIdSendsV09Envelope()
+    {
+        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
+
+        var executeTask = tool.ExecuteAsync(
+            JsonSerializer.Serialize(new { surfaceId = "surface-1" }),
+            Context(senderId: "client"),
+            CancellationToken.None);
+        var sent = await WaitForSentEnvelopeAsync(ws);
+        await AckAsync(broker, "client", sent, "sess");
+        var result = await executeTask;
+
+        Assert.Contains("Canvas command accepted", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("a2ui_create_surface", sent.Type);
+        Assert.Equal("createSurface", sent.Operation);
+        Assert.Equal("surface-1", sent.SurfaceId);
+        Assert.Equal(A2UiCatalogRegistry.AGenUiCatalogId, sent.CatalogId);
+        Assert.Null(sent.SurfaceTitle);
+        Assert.Null(sent.ParametersJson);
+        Assert.Null(sent.Components);
+        Assert.Null(sent.DataModelJson);
+    }
+
+    [Fact]
+    public async Task A2UiCreateSurface_OmittedCatalogRejectsUnsupportedComponentBeforeSend()
+    {
+        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.OpenClawV08CatalogId]);
+        var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
+        var component = """{"type":"Icon","name":"home"}""";
+
+        var result = await tool.ExecuteAsync(
+            JsonSerializer.Serialize(new { surfaceId = "surface-1", components = new[] { component } }),
+            Context(senderId: "client"),
+            CancellationToken.None);
+
+        Assert.Contains("unsupported component type 'Icon'", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(ws.Sent);
+    }
+
+    [Fact]
+    public async Task A2UiCreateSurface_RejectsMalformedOptionalComponentString()
+    {
+        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
+
+        var result = await tool.ExecuteAsync(
+            JsonSerializer.Serialize(new { surfaceId = "surface-1", components = new[] { "not-json" } }),
+            Context(senderId: "client"),
+            CancellationToken.None);
+
+        Assert.Contains("not valid JSON", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(ws.Sent);
+    }
+
+    [Theory]
+    [InlineData("not-json", "not valid JSON")]
+    [InlineData("[]", "must be a JSON object")]
+    public async Task A2UiCreateSurface_RejectsInvalidOrNonObjectOptionalDataModelJson(string dataModelJson, string expectedError)
+    {
+        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
+
+        var result = await tool.ExecuteAsync(
+            JsonSerializer.Serialize(new { surfaceId = "surface-1", dataModelJson }),
+            Context(senderId: "client"),
+            CancellationToken.None);
+
+        Assert.Contains(expectedError, result, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(ws.Sent);
+    }
+
+    [Fact]
+    public async Task A2UiCreateSurface_SendsV09EnvelopeWithOptionalCatalogTitleMetadataComponentsAndDataModel()
+    {
+        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
+        var metadata = """{"theme":"dark"}""";
+        var dataModelJson = """{"count":1}""";
+        var component = """{"type":"Text","text":"Hello"}""";
+        var argumentsJson = JsonSerializer.Serialize(new
+        {
+            surfaceId = "surface-1",
+            catalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            title = "Dashboard",
+            metadata,
+            components = new[] { component },
+            dataModelJson
+        });
+
+        var executeTask = tool.ExecuteAsync(argumentsJson, Context(senderId: "client"), CancellationToken.None);
+        var sent = await WaitForSentEnvelopeAsync(ws);
+        await AckAsync(broker, "client", sent, "sess");
+        var result = await executeTask;
+
+        Assert.Contains("Canvas command accepted", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("a2ui_create_surface", sent.Type);
+        Assert.Equal("createSurface", sent.Operation);
+        Assert.Equal("surface-1", sent.SurfaceId);
+        Assert.Equal(A2UiCatalogRegistry.AGenUiCatalogId, sent.CatalogId);
+        Assert.Equal("Dashboard", sent.SurfaceTitle);
+        Assert.Equal(metadata, sent.ParametersJson);
+        Assert.NotNull(sent.Components);
+        Assert.Equal([component], sent.Components);
+        Assert.Equal(dataModelJson, sent.DataModelJson);
+    }
+
+    [Fact]
+    public async Task A2UiV09Tools_MissingRequiredFieldsReturnToolErrors()
+    {
+        var broker = CreateBroker();
+        var config = new GatewayConfig();
+        var context = Context(senderId: "client");
+
+        Assert.Contains("'surfaceId' is required", await new A2UiCreateSurfaceTool(broker, config).ExecuteAsync("{}", context, CancellationToken.None), StringComparison.Ordinal);
+        Assert.Contains("'surfaceId' is required", await new A2UiUpdateComponentsTool(broker, config).ExecuteAsync("{}", context, CancellationToken.None), StringComparison.Ordinal);
+        Assert.Contains("'components' is required", await new A2UiUpdateComponentsTool(broker, config).ExecuteAsync("""{"surfaceId":"surface-1"}""", context, CancellationToken.None), StringComparison.Ordinal);
+        Assert.Contains("'surfaceId' is required", await new A2UiUpdateDataModelTool(broker, config).ExecuteAsync("{}", context, CancellationToken.None), StringComparison.Ordinal);
+        Assert.Contains("'dataModelJson' is required", await new A2UiUpdateDataModelTool(broker, config).ExecuteAsync("""{"surfaceId":"surface-1"}""", context, CancellationToken.None), StringComparison.Ordinal);
+        Assert.Contains("'surfaceId' is required", await new A2UiDeleteSurfaceTool(broker, config).ExecuteAsync("{}", context, CancellationToken.None), StringComparison.Ordinal);
+        Assert.Contains("'surfaceId' is required", await new A2UiSyncUiToDataTool(broker, config).ExecuteAsync("{}", context, CancellationToken.None), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A2UiCreateSurface_MissingV09CapabilityReturnsError()
+    {
+        var (broker, _) = CreateConnectedBroker(["a2ui.v0_8"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
+
+        var result = await tool.ExecuteAsync(
+            JsonSerializer.Serialize(new
+            {
+                surfaceId = "surface-1",
+                catalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+                title = "Dashboard",
+                metadata = "{}"
+            }),
+            Context(senderId: "client"),
+            CancellationToken.None);
+
+        Assert.Contains("a2ui.v0_9", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task A2UiV09UpdateDeleteAndSyncTools_MissingV09CapabilityReturnsError()
+    {
+        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_8"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var config = new GatewayConfig();
+        var context = Context(senderId: "client");
+        var component = """{"type":"Text","text":"Hello"}""";
+
+        Assert.Contains("a2ui.v0_9", await new A2UiUpdateComponentsTool(broker, config).ExecuteAsync(JsonSerializer.Serialize(new { surfaceId = "surface-1", components = new[] { component } }), context, CancellationToken.None), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("a2ui.v0_9", await new A2UiUpdateDataModelTool(broker, config).ExecuteAsync(JsonSerializer.Serialize(new { surfaceId = "surface-1", dataModelJson = "{}" }), context, CancellationToken.None), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("a2ui.v0_9", await new A2UiDeleteSurfaceTool(broker, config).ExecuteAsync("""{"surfaceId":"surface-1"}""", context, CancellationToken.None), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("a2ui.v0_9", await new A2UiSyncUiToDataTool(broker, config).ExecuteAsync("""{"surfaceId":"surface-1"}""", context, CancellationToken.None), StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(ws.Sent);
+    }
+
+    [Fact]
+    public async Task A2UiUpdateComponents_RejectsInvalidComponentJsonAndAcceptsValidStringArray()
+    {
+        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var tool = new A2UiUpdateComponentsTool(broker, new GatewayConfig());
+
+        var invalidResult = await tool.ExecuteAsync(
+            JsonSerializer.Serialize(new { surfaceId = "surface-1", components = new[] { "not-json" } }),
+            Context(senderId: "client"),
+            CancellationToken.None);
+
+        Assert.Contains("not valid JSON", invalidResult, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(ws.Sent);
+
+        var component = """{"type":"Text","text":"Hello"}""";
+        var executeTask = tool.ExecuteAsync(
+            JsonSerializer.Serialize(new { surfaceId = "surface-1", components = new[] { component } }),
+            Context(senderId: "client"),
+            CancellationToken.None);
+        var sent = await WaitForSentEnvelopeAsync(ws);
+        await AckAsync(broker, "client", sent, "sess");
+        var result = await executeTask;
+
+        Assert.Contains("Canvas command accepted", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("a2ui_update_components", sent.Type);
+        Assert.Equal("updateComponents", sent.Operation);
+        Assert.Equal("surface-1", sent.SurfaceId);
+        Assert.NotNull(sent.Components);
+        Assert.Equal([component], sent.Components);
+    }
+
+    [Theory]
+    [InlineData("not-json", "not valid JSON")]
+    [InlineData("[]", "must be a JSON object")]
+    public async Task A2UiUpdateDataModel_RejectsInvalidOrNonObjectJson(string dataModelJson, string expectedError)
+    {
+        var (broker, _) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var tool = new A2UiUpdateDataModelTool(broker, new GatewayConfig());
+
+        var result = await tool.ExecuteAsync(
+            JsonSerializer.Serialize(new { surfaceId = "surface-1", dataModelJson }),
+            Context(senderId: "client"),
+            CancellationToken.None);
+
+        Assert.Contains(expectedError, result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task A2UiUpdateDataModel_SendsV09Envelope()
+    {
+        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var tool = new A2UiUpdateDataModelTool(broker, new GatewayConfig());
+        var dataModelJson = """{"count":2}""";
+
+        var executeTask = tool.ExecuteAsync(
+            JsonSerializer.Serialize(new { surfaceId = "surface-1", dataModelJson }),
+            Context(senderId: "client"),
+            CancellationToken.None);
+        var sent = await WaitForSentEnvelopeAsync(ws);
+        await AckAsync(broker, "client", sent, "sess");
+        var result = await executeTask;
+
+        Assert.Contains("Canvas command accepted", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("a2ui_update_data_model", sent.Type);
+        Assert.Equal("updateDataModel", sent.Operation);
+        Assert.Equal("surface-1", sent.SurfaceId);
+        Assert.Equal(dataModelJson, sent.DataModelJson);
+    }
+
+    [Fact]
+    public async Task A2UiDeleteSurface_SendsV09Envelope()
+    {
+        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var tool = new A2UiDeleteSurfaceTool(broker, new GatewayConfig());
+
+        var executeTask = tool.ExecuteAsync("""{"surfaceId":"surface-1"}""", Context(senderId: "client"), CancellationToken.None);
+        var sent = await WaitForSentEnvelopeAsync(ws);
+        await AckAsync(broker, "client", sent, "sess");
+        var result = await executeTask;
+
+        Assert.Contains("Canvas command accepted", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("a2ui_delete_surface", sent.Type);
+        Assert.Equal("deleteSurface", sent.Operation);
+        Assert.Equal("surface-1", sent.SurfaceId);
+    }
+
+    [Fact]
+    public async Task A2UiSyncUiToData_SendsV09EnvelopeWithOptionalFields()
+    {
+        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var tool = new A2UiSyncUiToDataTool(broker, new GatewayConfig());
+
+        var executeTask = tool.ExecuteAsync(
+            JsonSerializer.Serialize(new
+            {
+                surfaceId = "surface-1",
+                componentId = "component-1",
+                syncMode = "merge"
+            }),
+            Context(senderId: "client"),
+            CancellationToken.None);
+        var sent = await WaitForSentEnvelopeAsync(ws);
+        await broker.HandleClientEnvelopeAsync("client", new WsClientEnvelope
+        {
+            Type = "a2ui_sync_result",
+            RequestId = sent.RequestId,
+            SessionId = "sess",
+            SurfaceId = "surface-1",
+            Success = true,
+            ValueJson = "{\"value\":\"updated\"}"
+        }, CancellationToken.None);
+        var result = await executeTask;
+
+        Assert.Equal("{\"value\":\"updated\"}", result);
+        Assert.Equal("a2ui_sync_ui_to_data", sent.Type);
+        Assert.Equal("syncUIToData", sent.Operation);
+        Assert.Equal("surface-1", sent.SurfaceId);
+        Assert.Equal("component-1", sent.ComponentId);
+        Assert.Equal("merge", sent.SyncMode);
+        Assert.Null(sent.DataModelJson);
+    }
+
     private static CanvasCommandBroker CreateBroker(GatewayConfig? config = null)
         => new(
             config ?? new GatewayConfig(),
@@ -100,14 +384,63 @@ public sealed class CanvasToolTests
                 Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N")),
                 NullLogger<RuntimeEventStore>.Instance));
 
-    private static ToolExecutionContext Context(string channelId = "websocket")
+    private static async Task AckAsync(CanvasCommandBroker broker, string clientId, WsServerEnvelope sent, string sessionId)
+        => await broker.HandleClientEnvelopeAsync(clientId, new WsClientEnvelope
+        {
+            Type = "canvas_ack",
+            RequestId = sent.RequestId,
+            SessionId = sessionId,
+            Success = true
+        }, CancellationToken.None);
+
+    private static (CanvasCommandBroker Broker, TestWebSocket WebSocket) CreateConnectedBroker(
+        string[] capabilities,
+        string[] supportedCatalogIds,
+        GatewayConfig? config = null)
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig());
+        var ws = new TestWebSocket();
+        Assert.True(channel.TryAddConnectionForTest("client", ws, IPAddress.Loopback, useJsonEnvelope: true));
+        var broker = new CanvasCommandBroker(
+            config ?? new GatewayConfig(),
+            channel,
+            new RuntimeEventStore(
+                Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N")),
+                NullLogger<RuntimeEventStore>.Instance));
+        broker.HandleClientEnvelopeAsync("client", new WsClientEnvelope
+        {
+            Type = "canvas_ready",
+            Capabilities = capabilities,
+            SupportedCatalogIds = supportedCatalogIds
+        }, CancellationToken.None).AsTask().GetAwaiter().GetResult();
+        return (broker, ws);
+    }
+
+    private static async Task<WsServerEnvelope> WaitForSentEnvelopeAsync(TestWebSocket ws, int skip = 0)
+    {
+        for (var attempt = 0; attempt < 100; attempt++)
+        {
+            if (ws.Sent.Count > skip)
+            {
+                var payload = Encoding.UTF8.GetString(ws.Sent.Skip(skip).Last());
+                return JsonSerializer.Deserialize(payload, CoreJsonContext.Default.WsServerEnvelope)
+                    ?? throw new InvalidOperationException("Sent payload was not a websocket envelope.");
+            }
+
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException("Timed out waiting for websocket send.");
+    }
+
+    private static ToolExecutionContext Context(string channelId = "websocket", string senderId = "client")
         => new()
         {
             Session = new Session
             {
                 Id = "sess",
                 ChannelId = channelId,
-                SenderId = "client"
+                SenderId = senderId
             },
             TurnContext = new TurnContext
             {

--- a/src/OpenClaw.Tests/CanvasToolTests.cs
+++ b/src/OpenClaw.Tests/CanvasToolTests.cs
@@ -151,6 +151,21 @@ public sealed class CanvasToolTests
         Assert.Empty(ws.Sent);
     }
 
+    [Fact]
+    public async Task A2UiCreateSurface_RejectsNonStringComponentArray()
+    {
+        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
+
+        var result = await tool.ExecuteAsync(
+            """{"surfaceId":"surface-1","components":[123]}""",
+            Context(senderId: "client"),
+            CancellationToken.None);
+
+        Assert.Contains("must be a JSON string array", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(ws.Sent);
+    }
+
     [Theory]
     [InlineData("not-json", "not valid JSON")]
     [InlineData("[]", "must be a JSON object")]
@@ -285,6 +300,21 @@ public sealed class CanvasToolTests
         Assert.Equal([component], sent.Components);
     }
 
+    [Fact]
+    public async Task A2UiUpdateComponents_RejectsNonStringComponentArray()
+    {
+        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var tool = new A2UiUpdateComponentsTool(broker, new GatewayConfig());
+
+        var result = await tool.ExecuteAsync(
+            """{"surfaceId":"surface-1","components":[true]}""",
+            Context(senderId: "client"),
+            CancellationToken.None);
+
+        Assert.Contains("must be a JSON string array", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(ws.Sent);
+    }
+
     [Theory]
     [InlineData("not-json", "not valid JSON")]
     [InlineData("[]", "must be a JSON object")]
@@ -376,6 +406,117 @@ public sealed class CanvasToolTests
         Assert.Null(sent.DataModelJson);
     }
 
+    [Fact]
+    public async Task A2UiV09Lifecycle_WebSocketRoundTrip_CoversCreateUpdateSnapshotSyncAndDelete()
+    {
+        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9", "snapshot.state"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var config = new GatewayConfig();
+        var context = Context(senderId: "client");
+
+        var createTool = new A2UiCreateSurfaceTool(broker, config);
+        var updateModelTool = new A2UiUpdateDataModelTool(broker, config);
+        var updateComponentsTool = new A2UiUpdateComponentsTool(broker, config);
+        var snapshotTool = new CanvasSnapshotTool(broker, config);
+        var syncTool = new A2UiSyncUiToDataTool(broker, config);
+        var deleteTool = new A2UiDeleteSurfaceTool(broker, config);
+
+        var createTask = createTool.ExecuteAsync(
+            """{"surfaceId":"details","components":["{\"type\":\"Text\",\"id\":\"title\",\"text\":\"ok\"}"],"dataModelJson":"{\"status\":\"draft\"}"}""",
+            context,
+            CancellationToken.None);
+        var createSent = await WaitForSentEnvelopeAsync(ws);
+        await AckAsync(broker, "client", createSent, "sess");
+        var createResult = await createTask;
+
+        Assert.Contains("Canvas command accepted", createResult, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("a2ui_create_surface", createSent.Type);
+        Assert.Equal("createSurface", createSent.Operation);
+        Assert.Equal("details", createSent.SurfaceId);
+
+        var snapshotTask1 = snapshotTool.ExecuteAsync("""{"surfaceId":"details"}""", context, CancellationToken.None);
+        var snapshotSent1 = await WaitForSentEnvelopeAsync(ws, skip: 1);
+        await RespondWithSnapshotAsync(
+            broker,
+            requestId: snapshotSent1.RequestId!,
+            surfaceId: "details",
+            snapshotJson: """{"dataModelJson":"{\"status\":\"draft\"}","components":[{"type":"Text","id":"title","text":"ok"}],"frameCount":1,"diagnostics":[]}""");
+        var snapshotResult1 = await snapshotTask1;
+
+        CanvasSnapshotAssertions.AssertV09Snapshot(
+            snapshotResult1,
+            expectedFrameCount: 1,
+            expectedComponentCount: 1,
+            expectedDataModelFragment: "status",
+            expectedDiagnosticContains: null);
+
+        var updateModelTask = updateModelTool.ExecuteAsync(
+            """{"surfaceId":"details","dataModelJson":"{\"status\":\"approved\"}"}""",
+            context,
+            CancellationToken.None);
+        var updateModelSent = await WaitForSentEnvelopeAsync(ws, skip: 2);
+        await AckAsync(broker, "client", updateModelSent, "sess");
+        var updateModelResult = await updateModelTask;
+
+        Assert.Contains("Canvas command accepted", updateModelResult, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("a2ui_update_data_model", updateModelSent.Type);
+
+        var updateComponentsTask = updateComponentsTool.ExecuteAsync(
+            """{"surfaceId":"details","components":["{\"type\":\"Text\",\"id\":\"title\",\"text\":\"updated\"}"]}""",
+            context,
+            CancellationToken.None);
+        var updateComponentsSent = await WaitForSentEnvelopeAsync(ws, skip: 3);
+        await AckAsync(broker, "client", updateComponentsSent, "sess");
+        var updateComponentsResult = await updateComponentsTask;
+
+        Assert.Contains("Canvas command accepted", updateComponentsResult, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("a2ui_update_components", updateComponentsSent.Type);
+        Assert.Equal("updateComponents", updateComponentsSent.Operation);
+
+        var snapshotTask2 = snapshotTool.ExecuteAsync("""{"surfaceId":"details"}""", context, CancellationToken.None);
+        var snapshotSent2 = await WaitForSentEnvelopeAsync(ws, skip: 4);
+        await RespondWithSnapshotAsync(
+            broker,
+            requestId: snapshotSent2.RequestId!,
+            surfaceId: "details",
+            snapshotJson: """{"dataModelJson":"{\"status\":\"approved\"}","components":[{"type":"Text","id":"title","text":"updated"}],"frameCount":1,"diagnostics":["surface validated"]}""");
+        var snapshotResult2 = await snapshotTask2;
+
+        CanvasSnapshotAssertions.AssertV09Snapshot(
+            snapshotResult2,
+            expectedFrameCount: 1,
+            expectedComponentCount: 1,
+            expectedDataModelFragment: "approved",
+            expectedDiagnosticContains: "validated");
+
+        var syncTask = syncTool.ExecuteAsync(
+            """{"surfaceId":"details","syncMode":"full"}""",
+            context,
+            CancellationToken.None);
+        var syncSent = await WaitForSentEnvelopeAsync(ws, skip: 5);
+        await broker.HandleClientEnvelopeAsync("client", new WsClientEnvelope
+        {
+            Type = "a2ui_sync_result",
+            RequestId = syncSent.RequestId,
+            SessionId = "sess",
+            SurfaceId = "details",
+            Success = true,
+            ValueJson = "{\"status\":\"approved\"}"
+        }, CancellationToken.None);
+        var syncResult = await syncTask;
+
+        Assert.Equal("{\"status\":\"approved\"}", syncResult);
+        Assert.Equal("a2ui_sync_ui_to_data", syncSent.Type);
+
+        var deleteTask = deleteTool.ExecuteAsync("""{"surfaceId":"details"}""", context, CancellationToken.None);
+        var deleteSent = await WaitForSentEnvelopeAsync(ws, skip: 6);
+        await AckAsync(broker, "client", deleteSent, "sess");
+        var deleteResult = await deleteTask;
+
+        Assert.Contains("Canvas command accepted", deleteResult, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("a2ui_delete_surface", deleteSent.Type);
+        Assert.Equal("deleteSurface", deleteSent.Operation);
+    }
+
     private static CanvasCommandBroker CreateBroker(GatewayConfig? config = null)
         => new(
             config ?? new GatewayConfig(),
@@ -391,6 +532,21 @@ public sealed class CanvasToolTests
             RequestId = sent.RequestId,
             SessionId = sessionId,
             Success = true
+        }, CancellationToken.None);
+
+    private static async Task RespondWithSnapshotAsync(
+        CanvasCommandBroker broker,
+        string requestId,
+        string surfaceId,
+        string snapshotJson)
+        => await broker.HandleClientEnvelopeAsync("client", new WsClientEnvelope
+        {
+            Type = "canvas_snapshot_result",
+            RequestId = requestId,
+            SessionId = "sess",
+            SurfaceId = surfaceId,
+            Success = true,
+            SnapshotJson = snapshotJson
         }, CancellationToken.None);
 
     private static (CanvasCommandBroker Broker, TestWebSocket WebSocket) CreateConnectedBroker(

--- a/src/OpenClaw.Tests/CanvasToolTests.cs
+++ b/src/OpenClaw.Tests/CanvasToolTests.cs
@@ -98,7 +98,7 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task A2UiCreateSurface_MinimalSurfaceIdSendsV09Envelope()
     {
-        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, ws) = await CreateConnectedBrokerAsync(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
 
         var executeTask = tool.ExecuteAsync(
@@ -123,9 +123,9 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task A2UiCreateSurface_OmittedCatalogRejectsUnsupportedComponentBeforeSend()
     {
-        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.OpenClawV08CatalogId]);
+        var (broker, ws) = await CreateConnectedBrokerAsync(["a2ui.v0_9"], [A2UiCatalogRegistry.OpenClawV08CatalogId]);
         var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
-        var component = """{"type":"Icon","name":"home"}""";
+        var component = """{"type":"Icon","id":"home","name":"home"}""";
 
         var result = await tool.ExecuteAsync(
             JsonSerializer.Serialize(new { surfaceId = "surface-1", components = new[] { component } }),
@@ -139,7 +139,7 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task A2UiCreateSurface_RejectsMalformedOptionalComponentString()
     {
-        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, ws) = await CreateConnectedBrokerAsync(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
 
         var result = await tool.ExecuteAsync(
@@ -154,7 +154,7 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task A2UiCreateSurface_RejectsNonStringComponentArray()
     {
-        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, ws) = await CreateConnectedBrokerAsync(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
 
         var result = await tool.ExecuteAsync(
@@ -171,7 +171,7 @@ public sealed class CanvasToolTests
     [InlineData("[]", "must be a JSON object")]
     public async Task A2UiCreateSurface_RejectsInvalidOrNonObjectOptionalDataModelJson(string dataModelJson, string expectedError)
     {
-        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, ws) = await CreateConnectedBrokerAsync(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
 
         var result = await tool.ExecuteAsync(
@@ -186,11 +186,11 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task A2UiCreateSurface_SendsV09EnvelopeWithOptionalCatalogTitleMetadataComponentsAndDataModel()
     {
-        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, ws) = await CreateConnectedBrokerAsync(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
         var metadata = """{"theme":"dark"}""";
         var dataModelJson = """{"count":1}""";
-        var component = """{"type":"Text","text":"Hello"}""";
+        var component = """{"type":"Text","id":"hello","text":"Hello"}""";
         var argumentsJson = JsonSerializer.Serialize(new
         {
             surfaceId = "surface-1",
@@ -237,7 +237,7 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task A2UiCreateSurface_MissingV09CapabilityReturnsError()
     {
-        var (broker, _) = CreateConnectedBroker(["a2ui.v0_8"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, _) = await CreateConnectedBrokerAsync(["a2ui.v0_8"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var tool = new A2UiCreateSurfaceTool(broker, new GatewayConfig());
 
         var result = await tool.ExecuteAsync(
@@ -257,10 +257,10 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task A2UiV09UpdateDeleteAndSyncTools_MissingV09CapabilityReturnsError()
     {
-        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_8"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, ws) = await CreateConnectedBrokerAsync(["a2ui.v0_8"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var config = new GatewayConfig();
         var context = Context(senderId: "client");
-        var component = """{"type":"Text","text":"Hello"}""";
+        var component = """{"type":"Text","id":"hello","text":"Hello"}""";
 
         Assert.Contains("a2ui.v0_9", await new A2UiUpdateComponentsTool(broker, config).ExecuteAsync(JsonSerializer.Serialize(new { surfaceId = "surface-1", components = new[] { component } }), context, CancellationToken.None), StringComparison.OrdinalIgnoreCase);
         Assert.Contains("a2ui.v0_9", await new A2UiUpdateDataModelTool(broker, config).ExecuteAsync(JsonSerializer.Serialize(new { surfaceId = "surface-1", dataModelJson = "{}" }), context, CancellationToken.None), StringComparison.OrdinalIgnoreCase);
@@ -272,7 +272,7 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task A2UiUpdateComponents_RejectsInvalidComponentJsonAndAcceptsValidStringArray()
     {
-        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, ws) = await CreateConnectedBrokerAsync(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var tool = new A2UiUpdateComponentsTool(broker, new GatewayConfig());
 
         var invalidResult = await tool.ExecuteAsync(
@@ -283,7 +283,7 @@ public sealed class CanvasToolTests
         Assert.Contains("not valid JSON", invalidResult, StringComparison.OrdinalIgnoreCase);
         Assert.Empty(ws.Sent);
 
-        var component = """{"type":"Text","text":"Hello"}""";
+        var component = """{"type":"Text","id":"hello","text":"Hello"}""";
         var executeTask = tool.ExecuteAsync(
             JsonSerializer.Serialize(new { surfaceId = "surface-1", components = new[] { component } }),
             Context(senderId: "client"),
@@ -303,7 +303,7 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task A2UiUpdateComponents_RejectsNonStringComponentArray()
     {
-        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, ws) = await CreateConnectedBrokerAsync(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var tool = new A2UiUpdateComponentsTool(broker, new GatewayConfig());
 
         var result = await tool.ExecuteAsync(
@@ -320,7 +320,7 @@ public sealed class CanvasToolTests
     [InlineData("[]", "must be a JSON object")]
     public async Task A2UiUpdateDataModel_RejectsInvalidOrNonObjectJson(string dataModelJson, string expectedError)
     {
-        var (broker, _) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, _) = await CreateConnectedBrokerAsync(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var tool = new A2UiUpdateDataModelTool(broker, new GatewayConfig());
 
         var result = await tool.ExecuteAsync(
@@ -334,7 +334,7 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task A2UiUpdateDataModel_SendsV09Envelope()
     {
-        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, ws) = await CreateConnectedBrokerAsync(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var tool = new A2UiUpdateDataModelTool(broker, new GatewayConfig());
         var dataModelJson = """{"count":2}""";
 
@@ -356,7 +356,7 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task A2UiDeleteSurface_SendsV09Envelope()
     {
-        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, ws) = await CreateConnectedBrokerAsync(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var tool = new A2UiDeleteSurfaceTool(broker, new GatewayConfig());
 
         var executeTask = tool.ExecuteAsync("""{"surfaceId":"surface-1"}""", Context(senderId: "client"), CancellationToken.None);
@@ -373,7 +373,7 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task A2UiSyncUiToData_SendsV09EnvelopeWithOptionalFields()
     {
-        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, ws) = await CreateConnectedBrokerAsync(["a2ui.v0_9"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var tool = new A2UiSyncUiToDataTool(broker, new GatewayConfig());
 
         var executeTask = tool.ExecuteAsync(
@@ -409,7 +409,7 @@ public sealed class CanvasToolTests
     [Fact]
     public async Task A2UiV09Lifecycle_WebSocketRoundTrip_CoversCreateUpdateSnapshotSyncAndDelete()
     {
-        var (broker, ws) = CreateConnectedBroker(["a2ui.v0_9", "snapshot.state"], [A2UiCatalogRegistry.AGenUiCatalogId]);
+        var (broker, ws) = await CreateConnectedBrokerAsync(["a2ui.v0_9", "snapshot.state"], [A2UiCatalogRegistry.AGenUiCatalogId]);
         var config = new GatewayConfig();
         var context = Context(senderId: "client");
 
@@ -549,7 +549,7 @@ public sealed class CanvasToolTests
             SnapshotJson = snapshotJson
         }, CancellationToken.None);
 
-    private static (CanvasCommandBroker Broker, TestWebSocket WebSocket) CreateConnectedBroker(
+    private static async Task<(CanvasCommandBroker Broker, TestWebSocket WebSocket)> CreateConnectedBrokerAsync(
         string[] capabilities,
         string[] supportedCatalogIds,
         GatewayConfig? config = null)
@@ -563,12 +563,12 @@ public sealed class CanvasToolTests
             new RuntimeEventStore(
                 Path.Combine(Path.GetTempPath(), "openclaw-tests", Guid.NewGuid().ToString("N")),
                 NullLogger<RuntimeEventStore>.Instance));
-        broker.HandleClientEnvelopeAsync("client", new WsClientEnvelope
+        await broker.HandleClientEnvelopeAsync("client", new WsClientEnvelope
         {
             Type = "canvas_ready",
             Capabilities = capabilities,
             SupportedCatalogIds = supportedCatalogIds
-        }, CancellationToken.None).AsTask().GetAwaiter().GetResult();
+        }, CancellationToken.None);
         return (broker, ws);
     }
 

--- a/src/OpenClaw.Tests/CompanionCanvasTests.cs
+++ b/src/OpenClaw.Tests/CompanionCanvasTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using OpenClaw.Companion.Services;
 using OpenClaw.Companion.ViewModels;
+using OpenClaw.Core.Canvas;
 using OpenClaw.Core.Models;
 using Xunit;
 
@@ -19,6 +20,20 @@ public sealed class CompanionCanvasTests : IDisposable
             try { Directory.Delete(dir, recursive: true); }
             catch { }
         }
+    }
+
+    [Fact]
+    public async Task SendCanvasReady_AdvertisesV09AndSupportedCatalogs()
+    {
+        var (viewModel, ws) = CreateViewModel();
+
+        await SendCanvasReadyAsync(viewModel);
+
+        var ready = LastSentEnvelope(ws);
+        Assert.Equal("canvas_ready", ready.Type);
+        Assert.Contains("a2ui.v0_9", ready.Capabilities ?? []);
+        Assert.Contains(A2UiCatalogRegistry.OpenClawV08CatalogId, ready.SupportedCatalogIds ?? []);
+        Assert.Contains(A2UiCatalogRegistry.AGenUiCatalogId, ready.SupportedCatalogIds ?? []);
     }
 
     [Fact]
@@ -145,6 +160,304 @@ public sealed class CompanionCanvasTests : IDisposable
         Assert.True(snapshot.SnapshotJson!.Length <= 128 * 1024);
     }
 
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V09CreateUpdateDeleteMaintainsIndependentSurfaces()
+    {
+        var (viewModel, ws) = CreateViewModel();
+
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", [TextComponent("alpha-text", "Alpha 1")]));
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("beta", "Beta", [TextComponent("beta-text", "Beta 1")]));
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_update_components",
+            Operation = "updateComponents",
+            RequestId = "update-alpha",
+            SessionId = "sess",
+            SurfaceId = "alpha",
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            Components = [TextComponent("alpha-text", "Alpha 2")]
+        });
+
+        Assert.Equal(2, viewModel.CanvasSurfaces.Count);
+        Assert.Equal("alpha", viewModel.ActiveCanvasSurface?.SurfaceId);
+        Assert.Equal("Alpha 2", viewModel.CanvasSurfaces.Single(surface => surface.SurfaceId == "alpha").Components.Single().Text);
+        Assert.Equal("Beta 1", viewModel.CanvasSurfaces.Single(surface => surface.SurfaceId == "beta").Components.Single().Text);
+        Assert.Equal("alpha-text", viewModel.CanvasFrames.Single().Id);
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_delete_surface",
+            Operation = "deleteSurface",
+            RequestId = "delete-alpha",
+            SessionId = "sess",
+            SurfaceId = "alpha"
+        });
+
+        Assert.Single(viewModel.CanvasSurfaces);
+        Assert.Equal("beta", viewModel.ActiveCanvasSurface?.SurfaceId);
+        Assert.Equal("beta-text", viewModel.CanvasFrames.Single().Id);
+        Assert.Equal("delete-alpha", LastSentEnvelope(ws).RequestId);
+        Assert.True(LastSentEnvelope(ws).Success);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V09SnapshotIsSurfaceSpecific()
+    {
+        var (viewModel, ws) = CreateViewModel();
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", [TextComponent("alpha-text", "Alpha")], "{\"alpha\":1}"));
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("beta", "Beta", [TextComponent("beta-text", "Beta")], "{\"beta\":2}"));
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "canvas_snapshot",
+            RequestId = "snap-alpha",
+            SessionId = "sess",
+            SurfaceId = "alpha"
+        });
+
+        var snapshot = LastSentEnvelope(ws);
+        using var doc = JsonDocument.Parse(snapshot.SnapshotJson!);
+        Assert.Equal("alpha", doc.RootElement.GetProperty("surfaceId").GetString());
+        Assert.Equal(1, doc.RootElement.GetProperty("frameCount").GetInt32());
+        Assert.Equal("alpha-text", doc.RootElement.GetProperty("frames")[0].GetProperty("Id").GetString());
+        Assert.Equal(1, doc.RootElement.GetProperty("dataModel").GetProperty("alpha").GetInt32());
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V09DataModelUpdateKeepsExistingComponents()
+    {
+        var (viewModel, _) = CreateViewModel();
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", [TextComponent("alpha-text", "Alpha")], "{\"count\":1}"));
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_update_data_model",
+            Operation = "updateDataModel",
+            RequestId = "data-alpha",
+            SessionId = "sess",
+            SurfaceId = "alpha",
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            DataModelJson = "{\"count\":2}"
+        });
+
+        var surface = Assert.Single(viewModel.CanvasSurfaces);
+        Assert.Equal("alpha-text", surface.Components.Single().Id);
+        Assert.Equal("{\"count\":2}", surface.DataModelJson);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V09ComponentActionSendsA2UiAction()
+    {
+        var (viewModel, ws) = CreateViewModel();
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", [ButtonComponent("save", "Save")]));
+
+        await viewModel.ActiveCanvasSurface!.Components.Single().ActivateCommand.ExecuteAsync(null);
+
+        var action = LastSentEnvelope(ws);
+        Assert.Equal("a2ui_action", action.Type);
+        Assert.Equal("sess", action.SessionId);
+        Assert.Equal("alpha", action.SurfaceId);
+        Assert.Equal("save", action.ComponentId);
+        Assert.Equal("click", action.Action);
+        Assert.Equal("true", action.ValueJson);
+        Assert.Equal(1, action.Sequence);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V09SyncUiToDataReturnsDataModelValueJson()
+    {
+        var (viewModel, ws) = CreateViewModel();
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", [TextComponent("alpha-text", "Alpha")], "{\"count\":2}"));
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_sync_ui_to_data",
+            Operation = "syncUIToData",
+            RequestId = "sync-alpha",
+            SessionId = "sess",
+            SurfaceId = "alpha",
+            SyncMode = "pull"
+        });
+
+        var result = LastSentEnvelope(ws);
+        Assert.Equal("a2ui_sync_result", result.Type);
+        Assert.Equal("sync-alpha", result.RequestId);
+        Assert.Equal("alpha", result.SurfaceId);
+        Assert.Equal("pull", result.SyncMode);
+        Assert.Equal("{\"count\":2}", result.ValueJson);
+        Assert.Null(result.DataModelJson);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V09MalformedCreateKeepsPreviousSurfaceState()
+    {
+        var (viewModel, ws) = CreateViewModel();
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", [TextComponent("alpha-text", "Alpha")], "{\"count\":1}"));
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_create_surface",
+            Operation = "createSurface",
+            RequestId = "bad-create",
+            SessionId = "sess",
+            SurfaceId = "alpha",
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            SurfaceTitle = "Changed",
+            DataModelJson = "{\"count\":2}",
+            Components = [TextComponent("replacement", "Replacement"), "not-json"]
+        });
+
+        var surface = Assert.Single(viewModel.CanvasSurfaces);
+        Assert.Equal("Alpha", surface.Title);
+        Assert.Equal("alpha-text", surface.Components.Single().Id);
+        Assert.Equal("{\"count\":1}", surface.DataModelJson);
+
+        var ack = LastSentEnvelope(ws);
+        Assert.Equal("bad-create", ack.RequestId);
+        Assert.False(ack.Success);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V09MalformedComponentUpdateKeepsPreviousSurfaceState()
+    {
+        var (viewModel, ws) = CreateViewModel();
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", [TextComponent("alpha-text", "Alpha")], "{\"count\":1}"));
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_update_components",
+            Operation = "updateComponents",
+            RequestId = "bad-update",
+            SessionId = "sess",
+            SurfaceId = "alpha",
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            Components = [TextComponent("replacement", "Replacement"), "not-json"]
+        });
+
+        var surface = Assert.Single(viewModel.CanvasSurfaces);
+        Assert.Equal("alpha-text", surface.Components.Single().Id);
+        Assert.Equal("{\"count\":1}", surface.DataModelJson);
+
+        var ack = LastSentEnvelope(ws);
+        Assert.Equal("bad-update", ack.RequestId);
+        Assert.False(ack.Success);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V09MalformedComponentUpdateDoesNotCreateSurface()
+    {
+        var (viewModel, ws) = CreateViewModel();
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_update_components",
+            Operation = "updateComponents",
+            RequestId = "bad-update",
+            SessionId = "sess",
+            SurfaceId = "alpha",
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            Components = ["not-json"]
+        });
+
+        Assert.Empty(viewModel.CanvasSurfaces);
+        Assert.Null(viewModel.ActiveCanvasSurface);
+
+        var ack = LastSentEnvelope(ws);
+        Assert.Equal("bad-update", ack.RequestId);
+        Assert.False(ack.Success);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V09SnapshotWithMalformedDataModelReturnsDiagnosticSnapshot()
+    {
+        var (viewModel, ws) = CreateViewModel();
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", [TextComponent("alpha-text", "Alpha")]));
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_update_data_model",
+            Operation = "updateDataModel",
+            RequestId = "bad-data",
+            SessionId = "sess",
+            SurfaceId = "alpha",
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            DataModelJson = "not-json"
+        });
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "canvas_snapshot",
+            RequestId = "snap-alpha",
+            SessionId = "sess",
+            SurfaceId = "alpha"
+        });
+
+        var snapshot = LastSentEnvelope(ws);
+        Assert.Equal("canvas_snapshot_result", snapshot.Type);
+        Assert.True(snapshot.Success);
+        using var doc = JsonDocument.Parse(snapshot.SnapshotJson!);
+        Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("dataModel").ValueKind);
+        Assert.Contains(doc.RootElement.GetProperty("diagnostics").EnumerateArray(), diagnostic => diagnostic.GetString()!.Contains("dataModelJson", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V08PushRoutesIntoMainSurfaceAndKeepsA2UiEvent()
+    {
+        var (viewModel, ws) = CreateViewModel();
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_push",
+            RequestId = "req1",
+            SessionId = "sess",
+            SurfaceId = "legacy",
+            Frames = """{"type":"button","id":"save","label":"Save"}"""
+        });
+
+        var surface = Assert.Single(viewModel.CanvasSurfaces);
+        Assert.Equal("main", surface.SurfaceId);
+        Assert.Equal("main", viewModel.CanvasFrames.Single().SurfaceId);
+
+        await viewModel.CanvasFrames.Single().ActivateCommand.ExecuteAsync(null);
+
+        var evt = LastSentEnvelope(ws);
+        Assert.Equal("a2ui_event", evt.Type);
+        Assert.Equal("main", evt.SurfaceId);
+        Assert.Equal("save", evt.ComponentId);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V09UnsupportedAdvancedComponentRecordsDiagnosticAndRendersFallback()
+    {
+        var (viewModel, ws) = CreateViewModel();
+
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", ["""{"type":"Video","id":"demo","src":"demo.mp4"}"""]));
+
+        var surface = Assert.Single(viewModel.CanvasSurfaces);
+        Assert.Equal("demo", surface.Components.Single().Id);
+        Assert.Contains(surface.Diagnostics, diagnostic => diagnostic.Contains("Video", StringComparison.OrdinalIgnoreCase));
+        Assert.True(LastSentEnvelope(ws).Success);
+    }
+
+    private static WsServerEnvelope CreateSurfaceEnvelope(string surfaceId, string title, string[] components, string? dataModelJson = null)
+        => new()
+        {
+            Type = "a2ui_create_surface",
+            Operation = "createSurface",
+            RequestId = "create-" + surfaceId,
+            SessionId = "sess",
+            SurfaceId = surfaceId,
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            SurfaceTitle = title,
+            Components = components,
+            DataModelJson = dataModelJson
+        };
+
+    private static string TextComponent(string id, string text)
+        => $$"""{"type":"Text","id":"{{id}}","text":"{{text}}"}""";
+
+    private static string ButtonComponent(string id, string label)
+        => $$"""{"type":"Button","id":"{{id}}","label":"{{label}}"}""";
+
     private (MainWindowViewModel ViewModel, TestWebSocket Socket) CreateViewModel()
     {
         var dir = Path.Combine(Path.GetTempPath(), "openclaw-companion-canvas-tests", Guid.NewGuid().ToString("N"));
@@ -165,6 +478,18 @@ public sealed class CompanionCanvasTests : IDisposable
         Assert.NotNull(method);
 
         var task = (Task?)method!.Invoke(viewModel, [envelope]);
+        Assert.NotNull(task);
+        await task!;
+    }
+
+    private static async Task SendCanvasReadyAsync(MainWindowViewModel viewModel)
+    {
+        var method = typeof(MainWindowViewModel).GetMethod(
+            "SendCanvasReadyAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var task = (Task?)method!.Invoke(viewModel, []);
         Assert.NotNull(task);
         await task!;
     }

--- a/src/OpenClaw.Tests/CompanionCanvasTests.cs
+++ b/src/OpenClaw.Tests/CompanionCanvasTests.cs
@@ -224,6 +224,25 @@ public sealed class CompanionCanvasTests : IDisposable
     }
 
     [Fact]
+    public async Task ApplyCanvasEnvelope_V09SnapshotOmitsNonObjectDataModel()
+    {
+        var (viewModel, ws) = CreateViewModel();
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", [TextComponent("alpha-text", "Alpha")], "[1,2]"));
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "canvas_snapshot",
+            RequestId = "snap-alpha",
+            SessionId = "sess",
+            SurfaceId = "alpha"
+        });
+
+        var snapshot = LastSentEnvelope(ws);
+        using var doc = JsonDocument.Parse(snapshot.SnapshotJson!);
+        Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("dataModel").ValueKind);
+    }
+
+    [Fact]
     public async Task ApplyCanvasEnvelope_V09DataModelUpdateKeepsExistingComponents()
     {
         var (viewModel, _) = CreateViewModel();
@@ -286,6 +305,30 @@ public sealed class CompanionCanvasTests : IDisposable
         Assert.Equal("pull", result.SyncMode);
         Assert.Equal("{\"count\":2}", result.ValueJson);
         Assert.Null(result.DataModelJson);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V09SyncUiToDataIncludesSelectedChecklistOptions()
+    {
+        var (viewModel, ws) = CreateViewModel();
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", [
+            """{"type":"CheckBox","id":"checks","options":[{"label":"One","value":"one","selected":true},{"label":"Two","value":"two"},{"label":"Three","value":"three","selected":true}]}"""
+        ]));
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_sync_ui_to_data",
+            Operation = "syncUIToData",
+            RequestId = "sync-alpha",
+            SessionId = "sess",
+            SurfaceId = "alpha",
+            SyncMode = "pull"
+        });
+
+        var result = LastSentEnvelope(ws);
+        using var doc = JsonDocument.Parse(result.ValueJson!);
+        var values = doc.RootElement.GetProperty("checks").EnumerateArray().Select(static item => item.GetString()!).ToArray();
+        Assert.Equal(["one", "three"], values);
     }
 
     [Fact]

--- a/src/OpenClaw.Tests/CompanionCanvasTests.cs
+++ b/src/OpenClaw.Tests/CompanionCanvasTests.cs
@@ -286,7 +286,8 @@ public sealed class CompanionCanvasTests : IDisposable
     public async Task ApplyCanvasEnvelope_V09SyncUiToDataReturnsDataModelValueJson()
     {
         var (viewModel, ws) = CreateViewModel();
-        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", [TextComponent("alpha-text", "Alpha")], "{\"count\":2}"));
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", ["""{"type":"TextField","id":"count","value":"2"}"""], "{\"count\":1}"));
+        viewModel.ActiveCanvasSurface!.Components.Single().ValueText = "3";
 
         await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
         {
@@ -303,7 +304,7 @@ public sealed class CompanionCanvasTests : IDisposable
         Assert.Equal("sync-alpha", result.RequestId);
         Assert.Equal("alpha", result.SurfaceId);
         Assert.Equal("pull", result.SyncMode);
-        Assert.Equal("{\"count\":2}", result.ValueJson);
+        Assert.Equal("{\"count\":\"3\"}", result.ValueJson);
         Assert.Null(result.DataModelJson);
     }
 
@@ -408,6 +409,67 @@ public sealed class CompanionCanvasTests : IDisposable
         var ack = LastSentEnvelope(ws);
         Assert.Equal("bad-update", ack.RequestId);
         Assert.False(ack.Success);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V09UpdateForUnknownSurfaceDoesNotCreateSurface()
+    {
+        var (viewModel, ws) = CreateViewModel();
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_update_components",
+            Operation = "updateComponents",
+            RequestId = "update-missing",
+            SessionId = "sess",
+            SurfaceId = "missing",
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            Components = [TextComponent("replacement", "Replacement")]
+        });
+
+        Assert.Empty(viewModel.CanvasSurfaces);
+        Assert.Null(viewModel.ActiveCanvasSurface);
+
+        var ack = LastSentEnvelope(ws);
+        Assert.Equal("update-missing", ack.RequestId);
+        Assert.False(ack.Success);
+        Assert.Contains("Unknown A2UI surface", ack.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ApplyCanvasEnvelope_V09SnapshotAndSyncForUnknownSurfaceDoNotUseActiveSurface()
+    {
+        var (viewModel, ws) = CreateViewModel();
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", [TextComponent("alpha-text", "Alpha")], "{\"alpha\":1}"));
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "canvas_snapshot",
+            RequestId = "snap-missing",
+            SessionId = "sess",
+            SurfaceId = "missing"
+        });
+
+        var snapshot = LastSentEnvelope(ws);
+        using (var doc = JsonDocument.Parse(snapshot.SnapshotJson!))
+        {
+            Assert.Equal("missing", doc.RootElement.GetProperty("surfaceId").GetString());
+            Assert.Equal(0, doc.RootElement.GetProperty("frameCount").GetInt32());
+            Assert.Empty(doc.RootElement.GetProperty("frames").EnumerateArray());
+        }
+
+        await ApplyCanvasEnvelopeAsync(viewModel, new WsServerEnvelope
+        {
+            Type = "a2ui_sync_ui_to_data",
+            Operation = "syncUIToData",
+            RequestId = "sync-missing",
+            SessionId = "sess",
+            SurfaceId = "missing"
+        });
+
+        var sync = LastSentEnvelope(ws);
+        Assert.Equal("sync-missing", sync.RequestId);
+        Assert.Equal("{}", sync.ValueJson);
     }
 
     [Fact]

--- a/src/OpenClaw.Tests/CompanionCanvasUiTests.cs
+++ b/src/OpenClaw.Tests/CompanionCanvasUiTests.cs
@@ -1,0 +1,121 @@
+using System.Reflection;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using OpenClaw.Companion;
+using OpenClaw.Companion.Services;
+using OpenClaw.Companion.ViewModels;
+using OpenClaw.Companion.Views;
+using OpenClaw.Core.Canvas;
+using OpenClaw.Core.Models;
+using Xunit;
+
+[assembly: AvaloniaTestApplication(typeof(OpenClaw.Tests.CompanionAvaloniaTestApp))]
+
+namespace OpenClaw.Tests;
+
+public sealed class CompanionAvaloniaTestApp
+{
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}
+
+public sealed class CompanionCanvasUiTests : IDisposable
+{
+    private readonly List<string> _tempDirs = [];
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            try { Directory.Delete(dir, recursive: true); }
+            catch { }
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task MainWindow_RendersSurfaceSelectorAndActiveSurfaceComponents()
+    {
+        var viewModel = CreateViewModel();
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("alpha", "Alpha", [TextComponent("alpha-text", "Alpha ready")]));
+        await ApplyCanvasEnvelopeAsync(viewModel, CreateSurfaceEnvelope("beta", "Beta", [ButtonComponent("beta-save", "Save beta")]));
+
+        var window = new MainWindow
+        {
+            Width = 900,
+            Height = 600,
+            DataContext = viewModel
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var tabControl = window.GetVisualDescendants().OfType<TabControl>().Single();
+        tabControl.SelectedIndex = 2;
+        Dispatcher.UIThread.RunJobs();
+
+        var selector = window.FindControl<ComboBox>("CanvasSurfaceSelector");
+        Assert.NotNull(selector);
+        Assert.True(selector!.IsVisible);
+        Assert.Equal(viewModel.CanvasSurfaces, selector.ItemsSource);
+        Assert.Equal(viewModel.ActiveCanvasSurface, selector.SelectedItem);
+        Assert.Contains(viewModel.CanvasSurfaces, surface => surface.Title == "Alpha");
+        Assert.Contains(viewModel.CanvasSurfaces, surface => surface.Title == "Beta");
+
+        var componentHost = window.FindControl<ItemsControl>("CanvasComponentHost");
+        Assert.NotNull(componentHost);
+        Assert.Equal(viewModel.ActiveCanvasSurface!.Components, componentHost!.ItemsSource);
+        Assert.Contains(window.GetVisualDescendants().OfType<Button>(), button => string.Equals(button.Content?.ToString(), "Save beta", StringComparison.Ordinal));
+
+        selector.SelectedItem = viewModel.CanvasSurfaces.Single(surface => surface.SurfaceId == "alpha");
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("alpha", viewModel.ActiveCanvasSurface?.SurfaceId);
+        Assert.Contains(window.GetVisualDescendants().OfType<TextBlock>(), text => string.Equals(text.Text, "Alpha ready", StringComparison.Ordinal));
+    }
+
+    private MainWindowViewModel CreateViewModel()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "openclaw-companion-canvas-ui-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        _tempDirs.Add(dir);
+
+        var client = new GatewayWebSocketClient();
+        client.SetConnectedSocketForTest(new TestWebSocket());
+        return new MainWindowViewModel(new SettingsStore(dir), client);
+    }
+
+    private static WsServerEnvelope CreateSurfaceEnvelope(string surfaceId, string title, string[] components)
+        => new()
+        {
+            Type = "a2ui_create_surface",
+            Operation = "createSurface",
+            RequestId = "create-" + surfaceId,
+            SessionId = "sess",
+            SurfaceId = surfaceId,
+            CatalogId = A2UiCatalogRegistry.AGenUiCatalogId,
+            SurfaceTitle = title,
+            Components = components
+        };
+
+    private static string TextComponent(string id, string text)
+        => $$"""{"type":"Text","id":"{{id}}","text":"{{text}}"}""";
+
+    private static string ButtonComponent(string id, string label)
+        => $$"""{"type":"Button","id":"{{id}}","label":"{{label}}"}""";
+
+    private static async Task ApplyCanvasEnvelopeAsync(MainWindowViewModel viewModel, WsServerEnvelope envelope)
+    {
+        var method = typeof(MainWindowViewModel).GetMethod(
+            "ApplyCanvasEnvelopeAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var task = (Task?)method!.Invoke(viewModel, [envelope]);
+        Assert.NotNull(task);
+        await task!;
+    }
+}

--- a/src/OpenClaw.Tests/CompanionCanvasUiTests.cs
+++ b/src/OpenClaw.Tests/CompanionCanvasUiTests.cs
@@ -50,31 +50,38 @@ public sealed class CompanionCanvasUiTests : IDisposable
             Height = 600,
             DataContext = viewModel
         };
-        window.Show();
-        Dispatcher.UIThread.RunJobs();
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
 
-        var tabControl = window.GetVisualDescendants().OfType<TabControl>().Single();
-        tabControl.SelectedIndex = 2;
-        Dispatcher.UIThread.RunJobs();
+            var tabControl = window.GetVisualDescendants().OfType<TabControl>().Single();
+            tabControl.SelectedIndex = 2;
+            Dispatcher.UIThread.RunJobs();
 
-        var selector = window.FindControl<ComboBox>("CanvasSurfaceSelector");
-        Assert.NotNull(selector);
-        Assert.True(selector!.IsVisible);
-        Assert.Equal(viewModel.CanvasSurfaces, selector.ItemsSource);
-        Assert.Equal(viewModel.ActiveCanvasSurface, selector.SelectedItem);
-        Assert.Contains(viewModel.CanvasSurfaces, surface => surface.Title == "Alpha");
-        Assert.Contains(viewModel.CanvasSurfaces, surface => surface.Title == "Beta");
+            var selector = window.FindControl<ComboBox>("CanvasSurfaceSelector");
+            Assert.NotNull(selector);
+            Assert.True(selector!.IsVisible);
+            Assert.Equal(viewModel.CanvasSurfaces, selector.ItemsSource);
+            Assert.Equal(viewModel.ActiveCanvasSurface, selector.SelectedItem);
+            Assert.Contains(viewModel.CanvasSurfaces, surface => surface.Title == "Alpha");
+            Assert.Contains(viewModel.CanvasSurfaces, surface => surface.Title == "Beta");
 
-        var componentHost = window.FindControl<ItemsControl>("CanvasComponentHost");
-        Assert.NotNull(componentHost);
-        Assert.Equal(viewModel.ActiveCanvasSurface!.Components, componentHost!.ItemsSource);
-        Assert.Contains(window.GetVisualDescendants().OfType<Button>(), button => string.Equals(button.Content?.ToString(), "Save beta", StringComparison.Ordinal));
+            var componentHost = window.FindControl<ItemsControl>("CanvasComponentHost");
+            Assert.NotNull(componentHost);
+            Assert.Equal(viewModel.ActiveCanvasSurface!.Components, componentHost!.ItemsSource);
+            Assert.Contains(window.GetVisualDescendants().OfType<Button>(), button => string.Equals(button.Content?.ToString(), "Save beta", StringComparison.Ordinal));
 
-        selector.SelectedItem = viewModel.CanvasSurfaces.Single(surface => surface.SurfaceId == "alpha");
-        Dispatcher.UIThread.RunJobs();
+            selector.SelectedItem = viewModel.CanvasSurfaces.Single(surface => surface.SurfaceId == "alpha");
+            Dispatcher.UIThread.RunJobs();
 
-        Assert.Equal("alpha", viewModel.ActiveCanvasSurface?.SurfaceId);
-        Assert.Contains(window.GetVisualDescendants().OfType<TextBlock>(), text => string.Equals(text.Text, "Alpha ready", StringComparison.Ordinal));
+            Assert.Equal("alpha", viewModel.ActiveCanvasSurface?.SurfaceId);
+            Assert.Contains(window.GetVisualDescendants().OfType<TextBlock>(), text => string.Equals(text.Text, "Alpha ready", StringComparison.Ordinal));
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     private MainWindowViewModel CreateViewModel()

--- a/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
+++ b/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
@@ -5134,6 +5134,20 @@ public sealed class GatewayAdminEndpointTests
     }
 
     [Fact]
+    public async Task WebChat_A2UiReset_ClearsAllSurfaces()
+    {
+        var webChatHtmlPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../src/OpenClaw.Gateway/wwwroot/webchat.html"));
+        var html = await File.ReadAllTextAsync(webChatHtmlPath);
+        var normalizedHtml = html.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        Assert.Contains("function resetA2ui()", html, StringComparison.Ordinal);
+        Assert.Contains("canvasSurfaces.clear();", html, StringComparison.Ordinal);
+        Assert.Contains("activeCanvasSurfaceId = null;", html, StringComparison.Ordinal);
+        Assert.Contains("case 'a2ui_reset':\n                        resetA2ui();", normalizedHtml, StringComparison.Ordinal);
+        Assert.DoesNotContain("resetA2ui(env.surfaceId || 'main')", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task AdminHtml_ExposesSetupVerifyAndFirstOperatorWizard()
     {
         var adminHtmlPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../src/OpenClaw.Gateway/wwwroot/admin.html"));

--- a/src/OpenClaw.Tests/OpenClaw.Tests.csproj
+++ b/src/OpenClaw.Tests/OpenClaw.Tests.csproj
@@ -54,6 +54,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.0-preview.3.25172.1" />
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.12" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/src/OpenClaw.Tests/ToolGovernanceTests.cs
+++ b/src/OpenClaw.Tests/ToolGovernanceTests.cs
@@ -207,7 +207,8 @@ public sealed class ToolGovernanceTests
             "shell", "read_file", "write_file", "process", "memory", "memory_search", "project_memory",
             "sessions", "session_search", "profile_read", "todo", "automation", "vision_analyze",
             "text_to_speech", "canvas_present", "canvas_hide", "canvas_navigate", "canvas_snapshot",
-            "a2ui_push", "a2ui_reset", "a2ui_eval", "edit_file", "apply_patch", "sessions_history",
+            "a2ui_push", "a2ui_reset", "a2ui_eval", "a2ui_create_surface", "a2ui_update_components",
+            "a2ui_update_data_model", "a2ui_delete_surface", "a2ui_sync_ui_to_data", "edit_file", "apply_patch", "sessions_history",
             "sessions_send", "sessions_spawn", "session_status", "agents_list", "cron", "gateway",
             "message", "x_search", "memory_get", "profile_write", "sessions_yield", "browser",
             "external_cli", "payment", "stream_echo", "web_search", "web_fetch", "git", "code_exec",
@@ -229,6 +230,22 @@ public sealed class ToolGovernanceTests
         Assert.False(todo.ReadOnly);
         Assert.False(sessions.ReadOnly);
         Assert.False(cron.ReadOnly);
+    }
+
+    [Theory]
+    [InlineData("a2ui_create_surface")]
+    [InlineData("a2ui_update_components")]
+    [InlineData("a2ui_update_data_model")]
+    [InlineData("a2ui_delete_surface")]
+    [InlineData("a2ui_sync_ui_to_data")]
+    public void DescriptorCatalog_A2UiV09ToolsAreUiWriteWithoutCodeExecution(string toolName)
+    {
+        var descriptor = ToolGovernanceDescriptorCatalog.Resolve(toolName, toolName, new ToolActionDescriptor());
+
+        Assert.False(descriptor.ReadOnly);
+        Assert.Contains("ui.write", descriptor.Capabilities);
+        Assert.False(descriptor.CanExecuteCode);
+        Assert.DoesNotContain("code.execute", descriptor.Capabilities);
     }
 
     private static OpenClawToolExecutor CreateExecutor(

--- a/src/OpenClaw.Tests/WebSocketChannelTests.cs
+++ b/src/OpenClaw.Tests/WebSocketChannelTests.cs
@@ -10,6 +10,86 @@ namespace OpenClaw.Tests;
 public sealed class WebSocketChannelTests
 {
     [Fact]
+    public void WsClientEnvelope_RoundTripsA2UiV09Fields()
+    {
+        var envelope = new WsClientEnvelope
+        {
+            Type = "a2ui_operation",
+            ProtocolVersion = "0.9",
+            Operation = "invoke",
+            CatalogId = "catalog-main",
+            SupportedCatalogIds = ["catalog-main", "catalog-fallback"],
+            Components = ["{\"type\":\"Text\",\"id\":\"button\"}"],
+            DataModelJson = "{\"count\":1}",
+            SurfaceTitle = "Main Surface",
+            SurfaceKind = "panel",
+            ParentSurfaceId = "root",
+            Action = "submit",
+            ParametersJson = "{\"value\":true}",
+            SyncMode = "delta",
+            DiagnosticCode = "diag.ok"
+        };
+
+        var json = JsonSerializer.Serialize(envelope, CoreJsonContext.Default.WsClientEnvelope);
+        var roundTripped = JsonSerializer.Deserialize(json, CoreJsonContext.Default.WsClientEnvelope);
+
+        Assert.NotNull(roundTripped);
+        Assert.Equal("0.9", roundTripped!.ProtocolVersion);
+        Assert.Equal("invoke", roundTripped.Operation);
+        Assert.Equal("catalog-main", roundTripped.CatalogId);
+        Assert.Equal(["catalog-main", "catalog-fallback"], roundTripped.SupportedCatalogIds ?? []);
+        Assert.Equal(["{\"type\":\"Text\",\"id\":\"button\"}"], roundTripped.Components ?? []);
+        Assert.Equal("{\"count\":1}", roundTripped.DataModelJson);
+        Assert.Equal("Main Surface", roundTripped.SurfaceTitle);
+        Assert.Equal("panel", roundTripped.SurfaceKind);
+        Assert.Equal("root", roundTripped.ParentSurfaceId);
+        Assert.Equal("submit", roundTripped.Action);
+        Assert.Equal("{\"value\":true}", roundTripped.ParametersJson);
+        Assert.Equal("delta", roundTripped.SyncMode);
+        Assert.Equal("diag.ok", roundTripped.DiagnosticCode);
+    }
+
+    [Fact]
+    public void WsServerEnvelope_RoundTripsA2UiV09Fields()
+    {
+        var envelope = new WsServerEnvelope
+        {
+            Type = "a2ui_operation_result",
+            ProtocolVersion = "0.9",
+            Operation = "render",
+            CatalogId = "catalog-main",
+            SupportedCatalogIds = ["catalog-main", "catalog-fallback"],
+            Components = ["{\"type\":\"Card\",\"id\":\"card\"}"],
+            DataModelJson = "{\"status\":\"ready\"}",
+            SurfaceTitle = "Details",
+            SurfaceKind = "modal",
+            ParentSurfaceId = "main",
+            Action = "refresh",
+            ParametersJson = "{\"force\":false}",
+            SyncMode = "full",
+            DiagnosticCode = "diag.warning"
+        };
+
+        var json = JsonSerializer.Serialize(envelope, CoreJsonContext.Default.WsServerEnvelope);
+        var roundTripped = JsonSerializer.Deserialize(json, CoreJsonContext.Default.WsServerEnvelope);
+
+        Assert.NotNull(roundTripped);
+        Assert.Equal("0.9", roundTripped!.ProtocolVersion);
+        Assert.Equal("render", roundTripped.Operation);
+        Assert.Equal("catalog-main", roundTripped.CatalogId);
+        Assert.Equal(["catalog-main", "catalog-fallback"], roundTripped.SupportedCatalogIds ?? []);
+        Assert.Equal(["{\"type\":\"Card\",\"id\":\"card\"}"], roundTripped.Components ?? []);
+        Assert.Equal("{\"status\":\"ready\"}", roundTripped.DataModelJson);
+        Assert.Equal("Details", roundTripped.SurfaceTitle);
+        Assert.Equal("modal", roundTripped.SurfaceKind);
+        Assert.Equal("main", roundTripped.ParentSurfaceId);
+        Assert.Equal("refresh", roundTripped.Action);
+        Assert.Equal("{\"force\":false}", roundTripped.ParametersJson);
+        Assert.Equal("full", roundTripped.SyncMode);
+        Assert.Equal("diag.warning", roundTripped.DiagnosticCode);
+    }
+
+    [Fact]
     public async Task SendAsync_RoutesOnlyToRecipient()
     {
         var channel = new WebSocketChannel(new WebSocketConfig());
@@ -140,6 +220,8 @@ public sealed class WebSocketChannelTests
         ws.QueueReceiveText("""{"type":"canvas_ack","requestId":"req1","success":true}""");
         ws.QueueReceiveText("""{"type":"canvas_snapshot_result","requestId":"req2","snapshotJson":"{}","success":true}""");
         ws.QueueReceiveText("""{"type":"canvas_eval_result","requestId":"req3","valueJson":"1","success":true}""");
+        ws.QueueReceiveText("""{"type":"a2ui_error","sessionId":"sess","surfaceId":"main","error":"failed"}""");
+        ws.QueueReceiveText("""{"type":"a2ui_sync_result","sessionId":"sess","surfaceId":"main","success":true}""");
         ws.QueueClose();
 
         var canvasTypes = new List<string>();
@@ -157,8 +239,31 @@ public sealed class WebSocketChannelTests
 
         await channel.HandleConnectionAsync(ws, "client", IPAddress.Loopback, CancellationToken.None);
 
-        Assert.Equal(["canvas_ack", "canvas_snapshot_result", "canvas_eval_result"], canvasTypes);
+        Assert.Equal(["canvas_ack", "canvas_snapshot_result", "canvas_eval_result", "a2ui_error", "a2ui_sync_result"], canvasTypes);
         Assert.False(messageObserved);
+    }
+
+    [Fact]
+    public async Task HandleConnectionAsync_A2UiEventDoesNotUseActionAsEventFallback()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig { MaxMessageBytes = 1024 });
+        var ws = new TestWebSocket();
+
+        ws.QueueReceiveText("""{"type":"a2ui_event","sessionId":"sess","surfaceId":"main","componentId":"btn","action":"click","valueJson":"true","sequence":7}""");
+        ws.QueueClose();
+
+        InboundMessage? received = null;
+        channel.OnMessageReceived += (msg, _) =>
+        {
+            received = msg;
+            return ValueTask.CompletedTask;
+        };
+
+        await channel.HandleConnectionAsync(ws, "client", IPAddress.Loopback, CancellationToken.None);
+
+        Assert.NotNull(received);
+        Assert.Null(received!.Event);
+        Assert.Contains("\"event\": \"\"", received.Text, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -194,6 +299,47 @@ public sealed class WebSocketChannelTests
         Assert.Equal("true", received.ValueJson);
         Assert.Equal(7, received.Sequence);
         Assert.Contains("\"componentId\": \"btn\"", received.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HandleConnectionAsync_ConvertsA2UiActionToSessionMessage()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig { MaxMessageBytes = 2048 });
+        var ws = new TestWebSocket();
+
+        ws.QueueReceiveText("""{"type":"a2ui_action","sessionId":"sess","surfaceId":"main","componentId":"submit-button","action":"submit","valueJson":"{\"accepted\":true}","dataModelJson":"{\"name\":\"Ada\"}","sequence":42}""");
+        ws.QueueClose();
+
+        WsClientEnvelope? canvasEnvelope = null;
+        InboundMessage? received = null;
+        channel.OnCanvasClientEnvelopeReceived += (_, envelope, _) =>
+        {
+            canvasEnvelope = envelope;
+            return ValueTask.CompletedTask;
+        };
+        channel.OnMessageReceived += (msg, _) =>
+        {
+            received = msg;
+            return ValueTask.CompletedTask;
+        };
+
+        await channel.HandleConnectionAsync(ws, "client", IPAddress.Loopback, CancellationToken.None);
+
+        Assert.NotNull(canvasEnvelope);
+        Assert.NotNull(received);
+        Assert.Equal("a2ui_action", received!.Type);
+        Assert.Equal("sess", received.SessionId);
+        Assert.Equal("main", received.SurfaceId);
+        Assert.Equal("submit-button", received.ComponentId);
+        Assert.Equal("submit", received.Event);
+        Assert.Equal("{\"accepted\":true}", received.ValueJson);
+        Assert.Equal(42, received.Sequence);
+        Assert.Contains("\"surfaceId\": \"main\"", received.Text, StringComparison.Ordinal);
+        Assert.Contains("\"componentId\": \"submit-button\"", received.Text, StringComparison.Ordinal);
+        Assert.Contains("\"action\": \"submit\"", received.Text, StringComparison.Ordinal);
+        Assert.Contains("\"value\": {\"accepted\":true}", received.Text, StringComparison.Ordinal);
+        Assert.Contains("\"dataModel\": {\"name\":\"Ada\"}", received.Text, StringComparison.Ordinal);
+        Assert.Contains("\"sequence\": 42", received.Text, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Description
This pull request significantly expands and updates the documentation for Canvas and A2UI support in OpenClaw.NET, reflecting the addition of A2UI v0.9 structured surfaces, catalog negotiation, new surface operations, and enhanced client capabilities. The docs now detail new websocket envelope types, per-surface state management, catalog selection/locking, and improved compatibility for advanced AGenUI components, while clarifying the security and capability model.

**Major Documentation Updates:**

**A2UI v0.9 Structured Surfaces and Operations**
- Added support and documentation for A2UI v0.9 structured surface operations (`a2ui_create_surface`, `a2ui_update_components`, `a2ui_update_data_model`, `a2ui_delete_surface`, `a2ui_sync_ui_to_data`), including per-surface state, lifecycle, and JSON examples for each operation. [[1]](diffhunk://#diff-63342e6f52c85f9b70f64fa610751240257db1be4748f199f20e8a1f68ab01b6L3-L30) [[2]](diffhunk://#diff-63342e6f52c85f9b70f64fa610751240257db1be4748f199f20e8a1f68ab01b6R65-R69) [[3]](diffhunk://#diff-63342e6f52c85f9b70f64fa610751240257db1be4748f199f20e8a1f68ab01b6L86-R190) [[4]](diffhunk://#diff-63342e6f52c85f9b70f64fa610751240257db1be4748f199f20e8a1f68ab01b6L114-R275)

**Catalog Negotiation and Component Compatibility**
- Introduced catalog negotiation with `supportedCatalogIds`, surface-specific catalog locking, and compatibility rules, including a list of built-in catalogs and mapping of v0.8 component names to AGenUI catalog types. [[1]](diffhunk://#diff-63342e6f52c85f9b70f64fa610751240257db1be4748f199f20e8a1f68ab01b6R78-R104) [[2]](diffhunk://#diff-63342e6f52c85f9b70f64fa610751240257db1be4748f199f20e8a1f68ab01b6L114-R275)

**Expanded Client and Broker Behavior**
- Updated client capability advertisement and rendering logic for v0.9, including per-surface tabs, component placeholders, and advanced component handling for both Webchat and Companion. Updated broker validation and catalog enforcement. [[1]](diffhunk://#diff-63342e6f52c85f9b70f64fa610751240257db1be4748f199f20e8a1f68ab01b6L114-R275) [[2]](diffhunk://#diff-63342e6f52c85f9b70f64fa610751240257db1be4748f199f20e8a1f68ab01b6R285)

**Tooling and Compatibility Table Updates**
- Expanded the list of native agent tools and updated the compatibility table to reflect support for v0.9 operations, catalog negotiation, and advanced components, with detailed notes on capability gating and diagnostics. [[1]](diffhunk://#diff-63342e6f52c85f9b70f64fa610751240257db1be4748f199f20e8a1f68ab01b6L3-L30) [[2]](diffhunk://#diff-0333285b158fbef700dbdf89f364f7edbada5846a67ab9d5888e056c8ea98a1dL63-R75) [[3]](diffhunk://#diff-a6fb0172d4905fb71089dbfae05e8c90a259b06bd31668d710f18a91dd721040L91-R103)

**Security and Safety Clarifications**
- Clarified security posture, including conservative rendering for remote media/web components, and explicit catalog/capability validation before command forwarding.

These changes collectively bring the documentation up to date with the latest Canvas/A2UI features and provide clear guidance for developers and integrators.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style implementation of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed locally (`dotnet test`)
- [ ] I have updated the documentation (README.md, comments) if required
- [ ] I have checked for security implications (input validation, authorization)

## Screenshots (if applicable)

[Add screenshots for UI/UX changes]

## Benchmarks (if applicable)

[Did this change affect performance? Provide benchmark results.]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-surface A2UI v0.9: independent surfaces with per-surface components, data models, tabs/selector UI, and a2ui_action interactions
  * New canvas tools for create/update/sync/delete surfaces and component/data-model updates
  * Snapshots and diagnostics are surface-specific and include data-model info when valid

* **Documentation**
  * Expanded Canvas/A2UI docs, compatibility guide, tools guide, and a new A2UI WebChat testing guide

* **Bug Fixes**
  * Stronger validation, clearer diagnostics, and more robust protocol handling

* **Tests**
  * Extensive new unit/integration/UI tests covering v0.9 lifecycle, catalog negotiation, and snapshots

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/clawdotnet/openclaw.net/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->