### PR TITLE
Filter MAF tools by allowed tools

### DIFF
--- a/src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs
+++ b/src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs
@@ -46,6 +46,7 @@ public sealed class MafAgentRuntime : IAgentRuntime
     private readonly string? _memoryRecallPrefix;
     private readonly object _skillGate = new();
     private readonly IList<AITool> _mafTools;
+    private readonly IReadOnlyDictionary<string, AITool> _mafToolsByName;
     private string _systemPrompt = string.Empty;
     private string[] _loadedSkillNames = [];
     private int _systemPromptLength;
@@ -108,6 +109,7 @@ public sealed class MafAgentRuntime : IAgentRuntime
         _mafTools = context.Tools
             .Select(tool => (AITool)new MafToolAdapter(tool, _toolExecutor))
             .ToArray();
+        _mafToolsByName = _mafTools.ToDictionary(tool => tool.Name, StringComparer.Ordinal);
 
         ApplySkills(context.Skills);
     }
@@ -340,7 +342,10 @@ public sealed class MafAgentRuntime : IAgentRuntime
 
     private ChatClientAgent CreateAgent(Session session)
     {
-        return _agentFactory.Create(_chatClient, GetSystemPrompt(session), _mafTools);
+        var tools = _toolExecutor.GetToolDeclarations(session)
+            .Select(tool => _mafToolsByName[tool.Name])
+            .ToArray();
+        return _agentFactory.Create(_chatClient, GetSystemPrompt(session), tools);
     }
 
     private async Task ProduceStreamingRunAsync(

--- a/src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs
+++ b/src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs
@@ -71,6 +71,7 @@ public sealed class MafAgentRuntime : IAgentRuntime
             logger,
             config: context.Config,
             toolSandbox: context.ToolSandbox,
+            toolPresetResolver: context.Services.GetService(typeof(IToolPresetResolver)) as IToolPresetResolver,
             auditLog: context.ToolAuditLog,
             toolGovernance: context.ToolGovernance);
         _options = options;

--- a/src/OpenClaw.Tests/MafAdapterTests.cs
+++ b/src/OpenClaw.Tests/MafAdapterTests.cs
@@ -156,6 +156,85 @@ public sealed class MafAdapterTests
     }
 
     [Fact]
+    public async Task MafAgentRuntime_FiltersToolsByRouteAllowedTools()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        var executionService = new CapturingLlmExecutionService();
+        var storagePath = Path.Combine(Path.GetTempPath(), "openclaw-maf-tool-filter-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(storagePath);
+
+        try
+        {
+            var runtime = new MafAgentRuntime(
+                new AgentRuntimeFactoryContext
+                {
+                    Services = services,
+                    Config = new GatewayConfig
+                    {
+                        Memory = new MemoryConfig
+                        {
+                            StoragePath = storagePath
+                        },
+                        Llm = new LlmProviderConfig
+                        {
+                            Provider = "test-maf",
+                            Model = "maf-test-model"
+                        }
+                    },
+                    RuntimeState = new GatewayRuntimeState
+                    {
+                        RequestedMode = "jit",
+                        EffectiveMode = GatewayRuntimeMode.Jit,
+                        DynamicCodeSupported = true
+                    },
+                    ChatClient = new MafTestChatClient(),
+                    Tools = [new TestTool("echo_tool"), new TestTool("shell")],
+                    MemoryStore = new FileMemoryStore(storagePath, 4),
+                    RuntimeMetrics = new RuntimeMetrics(),
+                    ProviderUsage = new ProviderUsageTracker(),
+                    LlmExecutionService = executionService,
+                    Skills = [],
+                    SkillsConfig = new SkillsConfig(),
+                    WorkspacePath = null,
+                    PluginSkillDirs = [],
+                    Logger = NullLogger.Instance,
+                    Hooks = [],
+                    RequireToolApproval = false,
+                    ApprovalRequiredTools = [],
+                    IsContractTokenBudgetExceeded = null,
+                    IsContractRuntimeBudgetExceeded = null,
+                    RecordContractTurnUsage = null,
+                    AppendContractSnapshot = null
+                },
+                new MafOptions(),
+                new MafAgentFactory(Options.Create(new MafOptions()), NullLoggerFactory.Instance, services),
+                new MafSessionStateStore(
+                    new GatewayConfig
+                    {
+                        Memory = new MemoryConfig
+                        {
+                            StoragePath = storagePath
+                        }
+                    },
+                    Options.Create(new MafOptions()),
+                    NullLogger<MafSessionStateStore>.Instance),
+                new MafTelemetryAdapter(),
+                NullLogger<MafAgentRuntime>.Instance);
+            var session = CreateSession("maf-tool-filter");
+            session.RouteAllowedTools = ["echo_tool"];
+
+            await runtime.RunAsync(session, "use tools", CancellationToken.None);
+
+            var toolNames = executionService.LastToolNames;
+            Assert.Equal(["echo_tool"], toolNames);
+        }
+        finally
+        {
+            Directory.Delete(storagePath, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task MafSessionStateStore_HistoryHashMismatch_RebuildsFreshSession()
     {
         var storagePath = Path.Combine(Path.GetTempPath(), "openclaw-maf-sidecar-tests", Guid.NewGuid().ToString("N"));
@@ -364,9 +443,9 @@ public sealed class MafAdapterTests
     private static string NormalizeJson(JsonElement element)
         => JsonSerializer.Serialize(element, new JsonSerializerOptions { WriteIndented = false });
 
-    private sealed class TestTool : ITool
+    private sealed class TestTool(string name = "echo_tool") : ITool
     {
-        public string Name => "echo_tool";
+        public string Name => name;
 
         public string Description => "Echo test tool.";
 
@@ -377,6 +456,57 @@ public sealed class MafAdapterTests
             _ = argumentsJson;
             _ = ct;
             return ValueTask.FromResult("ok");
+        }
+    }
+
+    private sealed class CapturingLlmExecutionService : ILlmExecutionService
+    {
+        public IReadOnlyList<string> LastToolNames { get; private set; } = [];
+
+        public CircuitState DefaultCircuitState => CircuitState.Closed;
+
+        public Task<LlmExecutionResult> GetResponseAsync(
+            Session session,
+            IReadOnlyList<ChatMessage> messages,
+            ChatOptions options,
+            TurnContext turnContext,
+            LlmExecutionEstimate estimate,
+            CancellationToken ct)
+        {
+            _ = session;
+            _ = messages;
+            _ = turnContext;
+            _ = estimate;
+            _ = ct;
+            LastToolNames = options.Tools?.Select(tool => tool.Name).OrderBy(name => name, StringComparer.Ordinal).ToArray() ?? [];
+            return Task.FromResult(new LlmExecutionResult
+            {
+                ProviderId = "test-maf",
+                ModelId = "maf-test-model",
+                Response = new ChatResponse([new ChatMessage(ChatRole.Assistant, "ok")])
+            });
+        }
+
+        public Task<LlmStreamingExecutionResult> StartStreamingAsync(
+            Session session,
+            IReadOnlyList<ChatMessage> messages,
+            ChatOptions options,
+            TurnContext turnContext,
+            LlmExecutionEstimate estimate,
+            CancellationToken ct)
+        {
+            _ = session;
+            _ = messages;
+            _ = options;
+            _ = turnContext;
+            _ = estimate;
+            _ = ct;
+            return Task.FromResult(new LlmStreamingExecutionResult
+            {
+                ProviderId = "test-maf",
+                ModelId = "maf-test-model",
+                Updates = AsyncEnumerable.Empty<ChatResponseUpdate>()
+            });
         }
     }
 

--- a/src/OpenClaw.Tests/MafAdapterTests.cs
+++ b/src/OpenClaw.Tests/MafAdapterTests.cs
@@ -235,6 +235,87 @@ public sealed class MafAdapterTests
     }
 
     [Fact]
+    public async Task MafAgentRuntime_FiltersToolsByPresetResolver()
+    {
+        var services = new ServiceCollection()
+            .AddSingleton<IToolPresetResolver>(new TestToolPresetResolver(["echo_tool"]))
+            .BuildServiceProvider();
+        var executionService = new CapturingLlmExecutionService();
+        var storagePath = Path.Combine(Path.GetTempPath(), "openclaw-maf-preset-filter-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(storagePath);
+
+        try
+        {
+            var runtime = new MafAgentRuntime(
+                new AgentRuntimeFactoryContext
+                {
+                    Services = services,
+                    Config = new GatewayConfig
+                    {
+                        Memory = new MemoryConfig
+                        {
+                            StoragePath = storagePath
+                        },
+                        Llm = new LlmProviderConfig
+                        {
+                            Provider = "test-maf",
+                            Model = "maf-test-model"
+                        }
+                    },
+                    RuntimeState = new GatewayRuntimeState
+                    {
+                        RequestedMode = "jit",
+                        EffectiveMode = GatewayRuntimeMode.Jit,
+                        DynamicCodeSupported = true
+                    },
+                    ChatClient = new MafTestChatClient(),
+                    Tools = [new TestTool("echo_tool"), new TestTool("shell")],
+                    MemoryStore = new FileMemoryStore(storagePath, 4),
+                    RuntimeMetrics = new RuntimeMetrics(),
+                    ProviderUsage = new ProviderUsageTracker(),
+                    LlmExecutionService = executionService,
+                    Skills = [],
+                    SkillsConfig = new SkillsConfig(),
+                    WorkspacePath = null,
+                    PluginSkillDirs = [],
+                    Logger = NullLogger.Instance,
+                    Hooks = [],
+                    RequireToolApproval = false,
+                    ApprovalRequiredTools = [],
+                    IsContractTokenBudgetExceeded = null,
+                    IsContractRuntimeBudgetExceeded = null,
+                    RecordContractTurnUsage = null,
+                    AppendContractSnapshot = null
+                },
+                new MafOptions(),
+                new MafAgentFactory(Options.Create(new MafOptions()), NullLoggerFactory.Instance, services),
+                new MafSessionStateStore(
+                    new GatewayConfig
+                    {
+                        Memory = new MemoryConfig
+                        {
+                            StoragePath = storagePath
+                        }
+                    },
+                    Options.Create(new MafOptions()),
+                    NullLogger<MafSessionStateStore>.Instance),
+                new MafTelemetryAdapter(),
+                NullLogger<MafAgentRuntime>.Instance);
+            var session = CreateSession("maf-preset-filter");
+            session.RoutePresetId = "test-preset";
+
+            await runtime.RunAsync(session, "use tools", CancellationToken.None);
+
+            var toolNames = executionService.LastToolNames;
+            Assert.Equal(["echo_tool"], toolNames);
+        }
+        finally
+        {
+            Directory.Delete(storagePath, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task MafSessionStateStore_HistoryHashMismatch_RebuildsFreshSession()
     {
         var storagePath = Path.Combine(Path.GetTempPath(), "openclaw-maf-sidecar-tests", Guid.NewGuid().ToString("N"));
@@ -456,6 +537,28 @@ public sealed class MafAdapterTests
             _ = argumentsJson;
             _ = ct;
             return ValueTask.FromResult("ok");
+        }
+    }
+
+    private sealed class TestToolPresetResolver(IEnumerable<string> allowedTools) : IToolPresetResolver
+    {
+        private readonly ResolvedToolPreset _preset = new()
+        {
+            PresetId = "test-preset",
+            AllowedTools = allowedTools.ToHashSet(StringComparer.OrdinalIgnoreCase)
+        };
+
+        public ResolvedToolPreset Resolve(Session session, IEnumerable<string> availableToolNames)
+        {
+            _ = session;
+            _ = availableToolNames;
+            return _preset;
+        }
+
+        public IReadOnlyList<ResolvedToolPreset> ListPresets(IEnumerable<string> availableToolNames)
+        {
+            _ = availableToolNames;
+            return [_preset];
         }
     }
 


### PR DESCRIPTION
Root Cause of MAF Tool List Not Filtered by Session:
During construction, MafAgentRuntime caches all tools into _mafTools. The CreateAgent() method always passes the complete list of tools directly. In contrast, AgentRuntime filters tools via OpenClawToolExecutor.GetToolDeclarations(session), which applies filtering based on session.RouteAllowedTools / preset.
Fix:
MafAgentRuntime.CreateAgent(session) now first calls _toolExecutor.GetToolDeclarations(session), then maps the result to the corresponding MAF AITool objects. Only the tool declarations allowed for the current session are passed to the MAF agent.
Regression Test:
A new test MafAgentRuntime_FiltersToolsByRouteAllowedTools has been added. It verifies that when RouteAllowedTools = ["echo_tool"], the shell tool declaration is not provided to the model.

Add a name->AITool lookup and use it to supply only route-allowed tools to the agent. MafAgentRuntime now builds _mafToolsByName in the constructor and CreateAgent maps tool declarations from _toolExecutor.GetToolDeclarations(session) to the corresponding AITool instances before creating the agent. Add a unit test (MafAgentRuntime_FiltersToolsByRouteAllowedTools) plus a CapturingLlmExecutionService helper and make TestTool accept a name to verify that only the permitted tool is passed to the LLM execution service.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agents now honor session-specific tool restrictions and preset-based tool allowances instead of exposing all available tools.

* **Tests**
  * Added tests verifying tool filtering by session route and by preset resolver.
  * Added test helpers that capture and assert which tools are passed to the execution service.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/clawdotnet/openclaw.net/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->