### PR TITLE
Add TweetClaw to the compatibility catalog

### DIFF
--- a/compat/public-smoke.json
+++ b/compat/public-smoke.json
@@ -35,6 +35,19 @@
       "expectedSkillNames": ["tavily-search"]
     },
     {
+      "id": "tweetclaw",
+      "category": "ts-jiti-plugin",
+      "kind": "npm-plugin",
+      "spec": "@xquik/tweetclaw@1.6.31",
+      "packageName": "@xquik/tweetclaw",
+      "pluginId": "tweetclaw",
+      "installExtraPackages": ["jiti"],
+      "expectedStatus": "compatible",
+      "configJson": "{}",
+      "expectedToolNames": ["explore", "tweetclaw"],
+      "expectedSkillNames": ["tweetclaw"]
+    },
+    {
       "id": "openclaw-tavily-invalid-config",
       "category": "config-schema-plugin",
       "kind": "npm-plugin",


### PR DESCRIPTION
## Summary
- Add @xquik/tweetclaw@1.6.31 to the public compatibility catalog as a TypeScript plus jiti npm plugin.
- Pin the expected OpenClaw.NET surfaces to the explore and tweetclaw tools plus bundled tweetclaw skill.
- Use empty config so smoke coverage verifies install and load without requiring live Xquik credentials.

## Validation
- jq . compat/public-smoke.json
- npm view @xquik/tweetclaw@1.6.31 version repository.url homepage
- npm install @xquik/tweetclaw@1.6.31 jiti with no package lock, no save, and ignored scripts
- inspected installed package metadata, plugin manifest, expected tool contracts, and skill frontmatter
- checked 22 README/docs/contributing public links; no failures
- git diff --check
- dotnet test not run because dotnet is not installed in this environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added compatibility testing support for a new plugin package with predefined configuration and expected capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/clawdotnet/openclaw.net/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->