### PR TITLE
[codex] Add Tailscale and Aperture integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,20 @@ Embedded video support is frame-based: OpenClaw samples local `video/*` inputs i
 
 > **Breaking change**: browser admin usage is account/session-first. Use named operator accounts for `/admin`, and use operator account tokens for Companion, CLI, API, and websocket clients.
 
+## Tailscale And Aperture Integration
+
+OpenClaw.NET can integrate with Tailscale for secure private runtime access and with Aperture by Tailscale for upstream model routing.
+
+In this setup:
+
+- OpenClaw.NET remains the self-hosted agent runtime and gateway.
+- Tailscale provides private networking and identity-aware access.
+- Aperture optionally manages upstream provider routing, model access, telemetry, and spend controls.
+
+OpenClaw.NET still manages agents, tools, sessions, approvals, memory, channels, runtime governance, MCP, and OpenAI-compatible surfaces. Tailscale/Aperture support is optional and does not change the default local-first OpenClaw.NET experience.
+
+See [docs/deployment/TAILSCALE.md](docs/deployment/TAILSCALE.md) for Serve/Funnel deployment patterns, Aperture profile examples, and security notes.
+
 ## Security
 
 When binding to a non-loopback address, the gateway **refuses to start** unless dangerous settings are explicitly hardened (auth token required, tooling roots restricted, signature validation enforced, `raw:` secret refs rejected). See [SECURITY.md](SECURITY.md) before exposing the gateway publicly.
@@ -184,6 +198,7 @@ The public documentation site is **[AgentQi.dev](https://agentqi.dev)**. The sou
 | [docs/mempalace-memory.md](docs/mempalace-memory.md) | Optional MemPalace.NET memory provider and temporal knowledge graph |
 | [docs/CANVAS_A2UI.md](docs/CANVAS_A2UI.md) | Supported Canvas and A2UI visual workspace behavior |
 | [docs/MODEL_PROFILES.md](docs/MODEL_PROFILES.md) | Provider-agnostic named model profiles (including Gemma) |
+| [docs/deployment/TAILSCALE.md](docs/deployment/TAILSCALE.md) | Optional Tailscale private access and Aperture provider routing |
 | [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md) | Supported upstream skill, plugin, and channel surface |
 | [SECURITY.md](SECURITY.md) | Hardening guidance for public deployments |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ Use this page as the map. If you are unsure where to go next, the groups below a
 | [PULSE.md](PULSE.md) | Runtime Pulse scheduled heartbeat turns, `HEARTBEAT.md`, alert suppression, and operator controls. |
 | [governance/sidecar-pattern.md](governance/sidecar-pattern.md) | Optional central tool-governance middleware, sidecar flow, decisions, and audit fields. |
 | [governance/microsoft-agent-governance.md](governance/microsoft-agent-governance.md) | Microsoft Agent Governance sidecar integration notes and deployment cautions. |
+| [deployment/TAILSCALE.md](deployment/TAILSCALE.md) | Optional Tailscale private access and Aperture upstream provider routing guidance. |
 
 ## Testing and Evaluation
 
@@ -64,6 +65,7 @@ Use this page as the map. If you are unsure where to go next, the groups below a
 | [COMPATIBILITY.md](COMPATIBILITY.md) | Supported upstream skill, plugin, and channel surface. |
 | [sandboxing.md](sandboxing.md) | Optional sandbox execution backends. |
 | [DOCKERHUB.md](DOCKERHUB.md) | Official container image reference. |
+| [deployment/TAILSCALE.md](deployment/TAILSCALE.md) | Tailscale Serve/Funnel patterns, Aperture profile setup, and security notes. |
 | [PRODUCTION_FIXES.md](PRODUCTION_FIXES.md) | Known production-readiness fixes and their verification. |
 
 ## Extending It

--- a/docs/SITE_MAP.md
+++ b/docs/SITE_MAP.md
@@ -82,6 +82,7 @@ Integrations
   WhatsApp
   A2A
   External Coding Backends
+  Tailscale And Aperture
 
 Operations
   Security

--- a/docs/SITE_MAP.md
+++ b/docs/SITE_MAP.md
@@ -29,6 +29,7 @@ Use this map when turning the Markdown docs into a documentation website. It kee
 | Integrations | WhatsApp | [WHATSAPP_SETUP.md](WHATSAPP_SETUP.md) |
 | Integrations | A2A | [a2a.md](a2a.md) |
 | Integrations | External Coding Backends | [external-coding-backends.md](external-coding-backends.md) |
+| Integrations | Tailscale And Aperture | [deployment/TAILSCALE.md](deployment/TAILSCALE.md) |
 | Operations | Security | [SECURITY.md](../SECURITY.md) |
 | Operations | Payment Security | [security/payments.md](security/payments.md) |
 | Operations | Tool Governance Sidecar | [governance/sidecar-pattern.md](governance/sidecar-pattern.md) |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -204,7 +204,25 @@ OpenClaw supports native routing for several providers out-of-the-box. Change th
 - **Required**: `ApiKey`, `Model`, and usually `Endpoint`
 - **Notes**: These providers are accessed via the OpenAI-compatible REST abstractions. Ensure that you provide the proper base API URL as the `Endpoint` when required by the target service.
 
-#### 8. Microsoft.Extensions.AI provider bridge
+#### 8. Aperture by Tailscale
+- **Provider**: `"aperture"` or `"openai-compatible"` with an Aperture endpoint
+- **Required**: `Endpoint`/`BaseUrl` and `Model`; `ApiKey` is required for bearer-token mode
+- **Optional**: `AuthMode = "tailnet-identity"` for tailnet identity access without a provider bearer token
+- **Notes**: Aperture is an optional upstream AI gateway route. OpenClaw.NET still owns agents, tools, sessions, approvals, memory, channels, MCP, and runtime governance. Request metadata headers are disabled by default and are sent only when `SendRequestMetadata` is explicitly enabled.
+
+Setup helper:
+
+```bash
+openclaw setup provider aperture \
+  --endpoint https://YOUR_APERTURE_ENDPOINT \
+  --model YOUR_APERTURE_MODEL_ROUTE \
+  --auth-mode bearer \
+  --env-var OPENCLAW_APERTURE_TOKEN
+```
+
+For private access and Aperture deployment guidance, see [deployment/TAILSCALE.md](deployment/TAILSCALE.md).
+
+#### 9. Microsoft.Extensions.AI provider bridge
 - **Provider**: your dynamic provider id, for example `"my-meai-provider"`
 - **Required**: JIT runtime mode, dynamic native plugins enabled, a factory implementing `IMicrosoftExtensionsAiChatClientFactory`, and at least one model id
 - **Notes**: This optional bridge is for advanced .NET integrations where you already have an `IChatClient`. OpenClaw still owns routing, policy, budget checks, tracing, approvals, sessions, and usage accounting. See [Microsoft.Extensions.AI Provider Bridge](providers/microsoft-extensions-ai.md).

--- a/docs/deployment/TAILSCALE.md
+++ b/docs/deployment/TAILSCALE.md
@@ -1,0 +1,180 @@
+# Tailscale And Aperture Deployment
+
+This guide explains how OpenClaw.NET can fit with Tailscale and Aperture by Tailscale without changing the default local-first runtime.
+
+## Overview
+
+OpenClaw.NET is the runtime and harness layer. It owns agents, tools, sessions, memory, approvals, MCP, channels, the Admin UI, runtime events, evidence, governance, and harness execution.
+
+Tailscale is the private networking and identity-aware access layer. It owns tailnet reachability, ACLs, remote connectivity, and optional secure transport to the runtime.
+
+Aperture is an optional upstream AI gateway layer. It owns model/provider routing, model access governance, usage telemetry, and spend or access controls. OpenClaw.NET does not become an Aperture replacement.
+
+```text
+Client / Operator
+    |
+Tailscale Serve / Tailnet
+    |
+OpenClaw.NET
+    |
+Aperture (optional provider profile)
+    |
+OpenAI / Anthropic / Gemini / others
+```
+
+## Recommended Deployment Patterns
+
+- Local-only development: keep OpenClaw.NET bound to `127.0.0.1`, use the normal setup flow, and do not enable Tailscale or Aperture unless you need them.
+- Private tailnet deployment: keep OpenClaw.NET loopback-bound and expose `/admin`, `/chat`, `/mcp`, and `/ws` through Tailscale Serve.
+- Team/shared deployment: use Tailscale ACLs for operator access, keep OpenClaw.NET auth and approvals enabled, and review `/doctor/text` before sharing.
+- Aperture-backed provider deployment: add an Aperture model profile while leaving existing Ollama, OpenAI, Anthropic, Gemini, Azure OpenAI, and OpenAI-compatible profiles unchanged.
+- Public demo deployment: prefer a short-lived, hardened deployment. Avoid exposing admin surfaces publicly unless auth, tool posture, webhook signatures, and public-bind checks are all clean.
+
+## Tailscale Serve
+
+Tailscale Serve is the preferred way to make a private OpenClaw.NET runtime available to operators on a tailnet.
+
+Recommended posture:
+
+- Keep OpenClaw.NET bound to loopback, for example `127.0.0.1:18789`.
+- Let Tailscale handle private tailnet access.
+- Keep OpenClaw.NET auth tokens, operator accounts, and tool approvals enabled.
+
+Example:
+
+```bash
+tailscale serve 18789
+```
+
+For explicit HTTPS serving, use the current Tailscale CLI syntax for your platform. OpenClaw.NET also has optional Serve/Funnel lifecycle support through `OpenClaw:Tailscale`, but it is disabled by default.
+
+Serve is safer than a public bind because the gateway is not directly exposed to the internet. Access is limited to tailnet reachability and Tailscale identity/ACL policy, while OpenClaw.NET still enforces its own runtime governance.
+
+## Tailscale Funnel
+
+Tailscale Funnel exposes a service publicly. Use it only for deliberate cases such as temporary demos or webhook testing.
+
+Do not use Funnel as the default admin exposure pattern.
+
+Before using Funnel:
+
+- Require OpenClaw.NET auth.
+- Disable unsafe tools or route them through hardened execution backends.
+- Validate webhook signatures for public webhooks.
+- Review `/doctor/text` and public-bind posture.
+- Keep exposure time short and revoke it when the demo or test is done.
+
+## Aperture By Tailscale
+
+Aperture is an optional upstream AI gateway. OpenClaw.NET remains responsible for agent runtime behavior, tools, sessions, approvals, memory, runtime governance, and evidence.
+
+Aperture can handle provider routing, model access, spend controls, usage telemetry, and identity-aware provider access. Treat it as an upstream provider route, not as a replacement for OpenClaw.NET runtime governance.
+
+## Example Aperture Configuration
+
+Use the existing model profile system. A bearer-token Aperture route can be configured as an OpenAI-compatible profile:
+
+```json
+{
+  "OpenClaw": {
+    "Models": {
+      "Profiles": [
+        {
+          "Id": "aperture-default",
+          "Provider": "openai-compatible",
+          "BaseUrl": "https://YOUR_APERTURE_ENDPOINT",
+          "Model": "YOUR_APERTURE_MODEL_ROUTE",
+          "ApiKey": "env:OPENCLAW_APERTURE_TOKEN",
+          "Tags": ["aperture", "remote", "optional"]
+        }
+      ]
+    }
+  }
+}
+```
+
+OpenClaw.NET also accepts `Provider = "aperture"` as a first-class alias for the same OpenAI-compatible transport:
+
+```json
+{
+  "OpenClaw": {
+    "Models": {
+      "Profiles": [
+        {
+          "Id": "aperture-default",
+          "Provider": "aperture",
+          "BaseUrl": "https://YOUR_APERTURE_ENDPOINT",
+          "Model": "YOUR_APERTURE_MODEL_ROUTE",
+          "AuthMode": "tailnet-identity",
+          "SendRequestMetadata": false,
+          "Tags": ["aperture", "remote", "optional"]
+        }
+      ]
+    }
+  }
+}
+```
+
+This profile is optional. Users can continue using Ollama, OpenAI, Anthropic, Gemini, Azure OpenAI, embedded local models, or other OpenAI-compatible endpoints normally.
+
+The CLI helper writes the same profile shape:
+
+```bash
+openclaw setup provider aperture \
+  --config ~/.openclaw/config/openclaw.settings.json \
+  --endpoint https://YOUR_APERTURE_ENDPOINT \
+  --model YOUR_APERTURE_MODEL_ROUTE \
+  --auth-mode bearer \
+  --env-var OPENCLAW_APERTURE_TOKEN
+```
+
+For tailnet identity mode:
+
+```bash
+openclaw setup provider aperture \
+  --endpoint https://YOUR_APERTURE_ENDPOINT \
+  --model YOUR_APERTURE_MODEL_ROUTE \
+  --auth-mode tailnet-identity
+```
+
+## Tailscale Identity Headers
+
+Future OpenClaw.NET deployments may map Tailscale identity to operator identity, roles, or approval scopes. That is not enabled by default.
+
+Important trust boundaries:
+
+- Only trust identity headers from a trusted Serve path or proxy boundary.
+- Do not accept identity headers from arbitrary public clients.
+- Keep OpenClaw.NET auth and approval policy active unless you have a reviewed deployment-specific replacement.
+
+OpenClaw.NET can optionally send request metadata to an Aperture profile, but this is disabled by default. When enabled, the metadata is limited to OpenClaw-owned routing context such as session id, actor id, channel id, profile id, run mode, and purpose.
+
+## Tailscale SSH Future Direction
+
+Tailscale SSH is a future/experimental direction for OpenClaw.NET remote execution scenarios:
+
+- Approval-gated remote execution backends.
+- Private diagnostics on trusted machines.
+- Remote builders.
+- Remote agent workspaces.
+
+Do not treat this as implemented runtime behavior unless a specific execution backend is configured and documented.
+
+## Security Notes
+
+- Loopback-first remains the safest default.
+- Prefer Tailscale Serve over public binds for private operator access.
+- Funnel requires explicit hardening and should be temporary.
+- Tool approvals remain important even on a tailnet.
+- OpenClaw.NET governance, evidence, runtime events, and audit behavior still apply when Tailscale or Aperture is used.
+- Aperture/Tailscale metadata is never sent unless explicitly enabled.
+
+## Troubleshooting
+
+- Unreachable Aperture endpoint: verify the endpoint URL, tailnet reachability, DNS, and ACLs. `openclaw setup verify --offline` should still skip online probes rather than failing.
+- Tailnet not connected: run `tailscale status` and confirm the machine is logged in to the expected tailnet.
+- Serve misconfiguration: confirm Serve points to the OpenClaw.NET loopback port, usually `18789`.
+- Invalid model route: confirm the Aperture route name matches the route configured in Aperture.
+- Auth failures: for bearer mode, confirm `OPENCLAW_APERTURE_TOKEN` is set. For tailnet identity mode, confirm Aperture accepts requests without a bearer token from that tailnet identity.
+- Metadata missing: confirm `SendRequestMetadata` is enabled on the selected profile or `OpenClaw:Llm:SendRequestMetadata` is enabled for the root provider.
+- Metadata unexpected: disable `SendRequestMetadata`; it is opt-in and should stay off unless Aperture policy needs it.

--- a/src/OpenClaw.Cli/Program.cs
+++ b/src/OpenClaw.Cli/Program.cs
@@ -146,11 +146,13 @@ internal static class Program
               openclaw tui
               openclaw insights
               openclaw setup
+              openclaw setup provider aperture --config ~/.openclaw/config/openclaw.settings.json --endpoint https://YOUR_APERTURE_ENDPOINT --model YOUR_APERTURE_MODEL_ROUTE --auth-mode bearer --env-var OPENCLAW_APERTURE_TOKEN
               openclaw upgrade check
               openclaw upgrade check --config ~/.openclaw/config/openclaw.settings.json --offline
               openclaw upgrade rollback --config ~/.openclaw/config/openclaw.settings.json --offline
               openclaw setup --non-interactive --profile local --workspace ./workspace --provider openai --model gpt-4o --api-key env:MODEL_PROVIDER_KEY
               openclaw setup --non-interactive --profile local --workspace ./workspace --provider ollama --model llama3.2 --model-preset ollama-general
+              openclaw setup provider aperture --endpoint https://YOUR_APERTURE_ENDPOINT --model YOUR_APERTURE_MODEL_ROUTE --auth-mode tailnet-identity
               openclaw setup verify --config ~/.openclaw/config/openclaw.settings.json
               openclaw setup launch --config ~/.openclaw/config/openclaw.settings.json --with-companion --open-browser
               openclaw setup service --config ~/.openclaw/config/openclaw.settings.json --platform all

--- a/src/OpenClaw.Cli/SetupCommand.cs
+++ b/src/OpenClaw.Cli/SetupCommand.cs
@@ -509,14 +509,15 @@ internal static class SetupCommand
         string currentDirectory,
         bool canPrompt)
     {
-        var provider = args.FirstOrDefault(arg => !arg.StartsWith("--", StringComparison.Ordinal));
+        var providerIndex = Array.FindIndex(args, static arg => !arg.StartsWith("--", StringComparison.Ordinal));
+        var provider = providerIndex >= 0 ? args[providerIndex] : null;
         if (!string.Equals(provider, "aperture", StringComparison.OrdinalIgnoreCase))
         {
             error.WriteLine("Usage: openclaw setup provider aperture [--config <path>] [--profile-id <id>] [--endpoint <url>] [--model <route>] [--auth-mode <bearer|tailnet-identity>] [--env-var <name>] [--send-request-metadata <true|false>] [--workspace <path>] [--non-interactive]");
             return 2;
         }
 
-        var filteredArgs = args.Where(arg => !string.Equals(arg, provider, StringComparison.OrdinalIgnoreCase)).ToArray();
+        var filteredArgs = args.Where((_, index) => index != providerIndex).ToArray();
         CliArgs parsed;
         try
         {
@@ -594,7 +595,7 @@ internal static class SetupCommand
         }
         else
         {
-            var workspace = Path.GetFullPath(GatewayConfigFile.ExpandPath(parsed.GetOption("--workspace") ?? Path.Combine(currentDirectory, "workspace")));
+            var workspace = Path.GetFullPath(GatewayConfigFile.ExpandPath(parsed.GetOption("--workspace") ?? Path.Join(currentDirectory, "workspace")));
             var configDirectory = Path.GetDirectoryName(configPath)
                 ?? throw new InvalidOperationException("Config path must contain a directory.");
             var warnings = new List<string>();

--- a/src/OpenClaw.Cli/SetupCommand.cs
+++ b/src/OpenClaw.Cli/SetupCommand.cs
@@ -512,11 +512,11 @@ internal static class SetupCommand
         var provider = args.FirstOrDefault(arg => !arg.StartsWith("--", StringComparison.Ordinal));
         if (!string.Equals(provider, "aperture", StringComparison.OrdinalIgnoreCase))
         {
-            error.WriteLine("Usage: openclaw setup provider aperture [--config <path>] [--endpoint <url>] [--model <route>] [--auth-mode <bearer|tailnet-identity>] [--env-var <name>] [--send-request-metadata <true|false>]");
+            error.WriteLine("Usage: openclaw setup provider aperture [--config <path>] [--profile-id <id>] [--endpoint <url>] [--model <route>] [--auth-mode <bearer|tailnet-identity>] [--env-var <name>] [--send-request-metadata <true|false>] [--workspace <path>] [--non-interactive]");
             return 2;
         }
 
-        var filteredArgs = args.Where(arg => !string.Equals(arg, provider, StringComparison.Ordinal)).ToArray();
+        var filteredArgs = args.Where(arg => !string.Equals(arg, provider, StringComparison.OrdinalIgnoreCase)).ToArray();
         CliArgs parsed;
         try
         {
@@ -604,7 +604,7 @@ internal static class SetupCommand
                 18789,
                 GenerateAuthToken(),
                 workspace,
-                Path.Combine(configDirectory, "memory"),
+                Path.Join(configDirectory, "memory"),
                 "aperture",
                 model,
                 authMode == "bearer" ? $"env:{envVar}" : string.Empty,
@@ -636,10 +636,23 @@ internal static class SetupCommand
         if (string.IsNullOrWhiteSpace(config.Models.DefaultProfile) && config.Models.Profiles.Count == 1)
             config.Models.DefaultProfile = profileId;
 
+        var validationErrors = ConfigValidator.Validate(config);
+        if (validationErrors.Count > 0)
+        {
+            error.WriteLine("Config validation failed:");
+            foreach (var validationError in validationErrors)
+                error.WriteLine($"- {validationError}");
+            return 1;
+        }
+
+        var resolvedWorkspaceRoot = ResolveConfiguredPath(config.Tooling.WorkspaceRoot);
+        var resolvedMemoryStoragePath = ResolveConfiguredPath(config.Memory.StoragePath);
+
         Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
-        if (!string.IsNullOrWhiteSpace(config.Tooling.WorkspaceRoot))
-            Directory.CreateDirectory(config.Tooling.WorkspaceRoot);
-        Directory.CreateDirectory(config.Memory.StoragePath);
+        if (!string.IsNullOrWhiteSpace(resolvedWorkspaceRoot))
+            Directory.CreateDirectory(resolvedWorkspaceRoot);
+        if (!string.IsNullOrWhiteSpace(resolvedMemoryStoragePath))
+            Directory.CreateDirectory(resolvedMemoryStoragePath);
         await GatewayConfigFile.SaveAsync(config, configPath);
 
         var envExamplePath = GatewaySetupArtifacts.BuildEnvExamplePath(configPath);
@@ -648,7 +661,7 @@ internal static class SetupCommand
             GatewaySetupArtifacts.BuildEnvExample(
                 authMode == "bearer" ? $"env:{envVar}" : null,
                 config.AuthToken ?? GenerateAuthToken(),
-                string.IsNullOrWhiteSpace(config.Tooling.WorkspaceRoot) ? Path.Combine(currentDirectory, "workspace") : config.Tooling.WorkspaceRoot,
+                string.IsNullOrWhiteSpace(resolvedWorkspaceRoot) ? Path.Join(currentDirectory, "workspace") : resolvedWorkspaceRoot,
                 BuildReachableBaseUrl(config.BindAddress, config.Port)),
             CancellationToken.None);
 
@@ -681,6 +694,23 @@ internal static class SetupCommand
         if (bool.TryParse(raw.Trim(), out var parsed))
             return parsed;
         throw new ArgumentException($"Invalid boolean value: {raw}");
+    }
+
+    private static string? ResolveConfiguredPath(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        var resolved = SecretResolver.Resolve(value);
+        if (string.IsNullOrWhiteSpace(resolved))
+        {
+            if (value.TrimStart().StartsWith("env:", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            resolved = value;
+        }
+        resolved = GatewayConfigFile.ExpandPath(resolved);
+        return Path.IsPathRooted(resolved) ? resolved : Path.GetFullPath(resolved);
     }
 
     private sealed class SetupAnswers

--- a/src/OpenClaw.Cli/SetupCommand.cs
+++ b/src/OpenClaw.Cli/SetupCommand.cs
@@ -46,6 +46,8 @@ internal static class SetupCommand
             return new SetupCommandResult { ExitCode = await SetupLifecycleCommand.RunVerifyAsync(args[1..], output, error) };
         if (args.Length > 0 && string.Equals(args[0], "channel", StringComparison.OrdinalIgnoreCase))
             return new SetupCommandResult { ExitCode = await ChannelSetupCommand.RunAsync(args[1..], input, output, error, canPrompt) };
+        if (args.Length > 0 && string.Equals(args[0], "provider", StringComparison.OrdinalIgnoreCase))
+            return new SetupCommandResult { ExitCode = await RunProviderSetupAsync(args[1..], input, output, error, currentDirectory, canPrompt) };
 
         var parsed = CliArgs.Parse(args);
         var nonInteractive = parsed.HasFlag("--non-interactive");
@@ -497,6 +499,188 @@ internal static class SetupCommand
         {
             return OllamaDiscoveryResult.Empty;
         }
+    }
+
+    private static async Task<int> RunProviderSetupAsync(
+        string[] args,
+        TextReader input,
+        TextWriter output,
+        TextWriter error,
+        string currentDirectory,
+        bool canPrompt)
+    {
+        var provider = args.FirstOrDefault(arg => !arg.StartsWith("--", StringComparison.Ordinal));
+        if (!string.Equals(provider, "aperture", StringComparison.OrdinalIgnoreCase))
+        {
+            error.WriteLine("Usage: openclaw setup provider aperture [--config <path>] [--endpoint <url>] [--model <route>] [--auth-mode <bearer|tailnet-identity>] [--env-var <name>] [--send-request-metadata <true|false>]");
+            return 2;
+        }
+
+        var filteredArgs = args.Where(arg => !string.Equals(arg, provider, StringComparison.Ordinal)).ToArray();
+        CliArgs parsed;
+        try
+        {
+            parsed = CliArgs.Parse(filteredArgs);
+        }
+        catch (ArgumentException ex)
+        {
+            error.WriteLine(ex.Message);
+            return 2;
+        }
+
+        var nonInteractive = parsed.HasFlag("--non-interactive");
+        var configPath = Path.GetFullPath(GatewayConfigFile.ExpandPath(parsed.GetOption("--config") ?? DefaultConfigPath));
+        var profileId = parsed.GetOption("--profile-id") ?? "aperture-default";
+        var endpoint = parsed.GetOption("--endpoint");
+        var model = parsed.GetOption("--model");
+        string authMode;
+        try
+        {
+            authMode = NormalizeApertureAuthMode(parsed.GetOption("--auth-mode") ?? "bearer");
+        }
+        catch (ArgumentException ex)
+        {
+            error.WriteLine(ex.Message);
+            return 2;
+        }
+        var envVar = parsed.GetOption("--env-var") ?? "OPENCLAW_APERTURE_TOKEN";
+        bool sendMetadata;
+        try
+        {
+            sendMetadata = ParseBooleanOption(parsed.GetOption("--send-request-metadata"), defaultValue: false);
+        }
+        catch (ArgumentException ex)
+        {
+            error.WriteLine(ex.Message);
+            return 2;
+        }
+
+        if (!nonInteractive && canPrompt)
+        {
+            endpoint = Prompt(output, input, "Aperture endpoint", endpoint ?? "https://YOUR_APERTURE_ENDPOINT");
+            model = Prompt(output, input, "Aperture model route", model ?? "YOUR_APERTURE_MODEL_ROUTE");
+            try
+            {
+                authMode = NormalizeApertureAuthMode(Prompt(output, input, "Auth mode (bearer|tailnet-identity)", authMode));
+            }
+            catch (ArgumentException ex)
+            {
+                error.WriteLine(ex.Message);
+                return 2;
+            }
+            if (authMode == "bearer")
+                envVar = Prompt(output, input, "Bearer token env var", envVar);
+            try
+            {
+                sendMetadata = ParseBooleanOption(Prompt(output, input, "Send request metadata (true|false)", sendMetadata ? "true" : "false"), defaultValue: false);
+            }
+            catch (ArgumentException ex)
+            {
+                error.WriteLine(ex.Message);
+                return 2;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(endpoint) || string.IsNullOrWhiteSpace(model))
+        {
+            error.WriteLine("Aperture endpoint and model route are required. Re-run with --endpoint and --model, or run from an interactive terminal.");
+            return 2;
+        }
+
+        GatewayConfig config;
+        if (File.Exists(configPath))
+        {
+            config = GatewayConfigFile.Load(configPath);
+        }
+        else
+        {
+            var workspace = Path.GetFullPath(GatewayConfigFile.ExpandPath(parsed.GetOption("--workspace") ?? Path.Combine(currentDirectory, "workspace")));
+            var configDirectory = Path.GetDirectoryName(configPath)
+                ?? throw new InvalidOperationException("Config path must contain a directory.");
+            var warnings = new List<string>();
+            config = GatewaySetupProfileFactory.CreateProfileConfig(
+                "local",
+                "127.0.0.1",
+                18789,
+                GenerateAuthToken(),
+                workspace,
+                Path.Combine(configDirectory, "memory"),
+                "aperture",
+                model,
+                authMode == "bearer" ? $"env:{envVar}" : string.Empty,
+                modelPresetId: null,
+                warnings);
+            config.Llm.Endpoint = endpoint;
+            config.Llm.AuthMode = authMode;
+            config.Llm.SendRequestMetadata = sendMetadata;
+        }
+
+        var existingIndex = config.Models.Profiles.FindIndex(item => string.Equals(item.Id, profileId, StringComparison.OrdinalIgnoreCase));
+        var profile = new ModelProfileConfig
+        {
+            Id = profileId,
+            Provider = "aperture",
+            Model = model,
+            BaseUrl = endpoint,
+            ApiKey = authMode == "bearer" ? $"env:{envVar}" : null,
+            AuthMode = authMode,
+            SendRequestMetadata = sendMetadata,
+            Tags = ["aperture", "remote", "optional"]
+        };
+
+        if (existingIndex >= 0)
+            config.Models.Profiles[existingIndex] = profile;
+        else
+            config.Models.Profiles.Add(profile);
+
+        if (string.IsNullOrWhiteSpace(config.Models.DefaultProfile) && config.Models.Profiles.Count == 1)
+            config.Models.DefaultProfile = profileId;
+
+        Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
+        if (!string.IsNullOrWhiteSpace(config.Tooling.WorkspaceRoot))
+            Directory.CreateDirectory(config.Tooling.WorkspaceRoot);
+        Directory.CreateDirectory(config.Memory.StoragePath);
+        await GatewayConfigFile.SaveAsync(config, configPath);
+
+        var envExamplePath = GatewaySetupArtifacts.BuildEnvExamplePath(configPath);
+        await File.WriteAllTextAsync(
+            envExamplePath,
+            GatewaySetupArtifacts.BuildEnvExample(
+                authMode == "bearer" ? $"env:{envVar}" : null,
+                config.AuthToken ?? GenerateAuthToken(),
+                string.IsNullOrWhiteSpace(config.Tooling.WorkspaceRoot) ? Path.Combine(currentDirectory, "workspace") : config.Tooling.WorkspaceRoot,
+                BuildReachableBaseUrl(config.BindAddress, config.Port)),
+            CancellationToken.None);
+
+        output.WriteLine($"Wrote config: {configPath}");
+        output.WriteLine($"Wrote env example: {envExamplePath}");
+        output.WriteLine($"Aperture profile: {profileId}");
+        output.WriteLine($"Endpoint: {endpoint}");
+        output.WriteLine($"Model route: {model}");
+        output.WriteLine($"Auth mode: {authMode}");
+        output.WriteLine($"Request metadata: {(sendMetadata ? "enabled" : "disabled")}");
+        output.WriteLine();
+        output.WriteLine("Next steps:");
+        output.WriteLine($"openclaw setup verify --config {GatewayConfigFile.QuoteIfNeeded(configPath)} --offline");
+        output.WriteLine("openclaw models doctor");
+        return 0;
+    }
+
+    private static string NormalizeApertureAuthMode(string raw)
+    {
+        var normalized = raw.Trim().ToLowerInvariant();
+        if (normalized is not ("bearer" or "tailnet-identity"))
+            throw new ArgumentException("Aperture auth mode must be one of: bearer, tailnet-identity.");
+        return normalized;
+    }
+
+    private static bool ParseBooleanOption(string? raw, bool defaultValue)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return defaultValue;
+        if (bool.TryParse(raw.Trim(), out var parsed))
+            return parsed;
+        throw new ArgumentException($"Invalid boolean value: {raw}");
     }
 
     private sealed class SetupAnswers

--- a/src/OpenClaw.Core/Models/GatewayConfig.cs
+++ b/src/OpenClaw.Core/Models/GatewayConfig.cs
@@ -88,6 +88,8 @@ public sealed class LlmProviderConfig
     public string Model { get; set; } = "gpt-4o";
     public string? ApiKey { get; set; }
     public string? Endpoint { get; set; }
+    public string AuthMode { get; set; } = "bearer";
+    public bool SendRequestMetadata { get; set; } = false;
     public string[] FallbackModels { get; set; } = [];
     public int MaxTokens { get; set; } = 4096;
     public float Temperature { get; set; } = 0.7f;

--- a/src/OpenClaw.Core/Models/ModelProfiles.cs
+++ b/src/OpenClaw.Core/Models/ModelProfiles.cs
@@ -14,6 +14,8 @@ public sealed class ModelProfileConfig
     public string Model { get; set; } = "";
     public string? BaseUrl { get; set; }
     public string? ApiKey { get; set; }
+    public string? AuthMode { get; set; }
+    public bool? SendRequestMetadata { get; set; }
     public string[] Tags { get; set; } = [];
     public string[] FallbackProfileIds { get; set; } = [];
     public string[] FallbackModels { get; set; } = [];
@@ -67,6 +69,8 @@ public sealed class ModelProfile
     public required string ModelId { get; init; }
     public string? BaseUrl { get; init; }
     public string? ApiKey { get; init; }
+    public string AuthMode { get; init; } = "bearer";
+    public bool SendRequestMetadata { get; init; }
     public string[] Tags { get; init; } = [];
     public string[] FallbackProfileIds { get; init; } = [];
     public string[] FallbackModels { get; init; } = [];
@@ -84,6 +88,9 @@ public sealed class ModelProfileStatus
     public bool IsDefault { get; init; }
     public bool IsImplicit { get; init; }
     public bool IsAvailable { get; init; }
+    public string? ProviderGateway { get; init; }
+    public string AuthMode { get; init; } = "bearer";
+    public bool SendRequestMetadata { get; init; }
     public string[] Tags { get; init; } = [];
     public required ModelCapabilities Capabilities { get; init; }
     public PromptCachingConfig PromptCaching { get; init; } = new();

--- a/src/OpenClaw.Core/Validation/ConfigValidator.cs
+++ b/src/OpenClaw.Core/Validation/ConfigValidator.cs
@@ -69,6 +69,8 @@ public static class ConfigValidator
             errors.Add($"Llm.CircuitBreakerCooldownSeconds must be >= 1 (got {config.Llm.CircuitBreakerCooldownSeconds}).");
         if (!IsValidProviderAuthMode(config.Llm.AuthMode))
             errors.Add("Llm.AuthMode must be 'bearer' or 'tailnet-identity'.");
+        else if (IsTailnetIdentityAuth(config.Llm.AuthMode) && !SupportsTailnetIdentity(config.Llm.Provider))
+            errors.Add($"Llm.AuthMode 'tailnet-identity' is not supported for provider '{config.Llm.Provider}'.");
         ValidateApertureProviderConfig("Llm", "Endpoint", config.Llm.Provider, config.Llm.Endpoint, config.Llm.ApiKey, config.Llm.AuthMode, errors);
         ValidatePromptCaching("Llm.PromptCaching", config.Llm.Provider, config.Llm.PromptCaching, errors, isDynamicProvider: false);
         ValidateModelProfiles(config, errors, pluginBackedProvidersPossible);
@@ -631,6 +633,8 @@ public static class ConfigValidator
                 errors.Add($"Models.Profiles.{profile.Id}.Model must be set.");
             if (!string.IsNullOrWhiteSpace(profile.AuthMode) && !IsValidProviderAuthMode(profile.AuthMode))
                 errors.Add($"Models.Profiles.{profile.Id}.AuthMode must be 'bearer' or 'tailnet-identity'.");
+            else if (IsTailnetIdentityAuth(profile.AuthMode) && !SupportsTailnetIdentity(profile.Provider))
+                errors.Add($"Models.Profiles.{profile.Id}.AuthMode 'tailnet-identity' is not supported for provider '{profile.Provider}'.");
             ValidateApertureProviderConfig(
                 $"Models.Profiles.{profile.Id}",
                 "BaseUrl",
@@ -898,6 +902,11 @@ public static class ConfigValidator
 
     private static bool IsTailnetIdentityAuth(string? authMode)
         => string.Equals(authMode?.Trim(), "tailnet-identity", StringComparison.OrdinalIgnoreCase);
+
+    private static bool SupportsTailnetIdentity(string? provider)
+        => provider is not null &&
+           (provider.Equals("aperture", StringComparison.OrdinalIgnoreCase) ||
+            provider.Equals("openai-compatible", StringComparison.OrdinalIgnoreCase));
 
     private static bool SupportsExplicitCacheTtl(string? providerId, string? dialect)
     {

--- a/src/OpenClaw.Core/Validation/ConfigValidator.cs
+++ b/src/OpenClaw.Core/Validation/ConfigValidator.cs
@@ -69,6 +69,7 @@ public static class ConfigValidator
             errors.Add($"Llm.CircuitBreakerCooldownSeconds must be >= 1 (got {config.Llm.CircuitBreakerCooldownSeconds}).");
         if (!IsValidProviderAuthMode(config.Llm.AuthMode))
             errors.Add("Llm.AuthMode must be 'bearer' or 'tailnet-identity'.");
+        ValidateApertureProviderConfig("Llm", "Endpoint", config.Llm.Provider, config.Llm.Endpoint, config.Llm.ApiKey, config.Llm.AuthMode, errors);
         ValidatePromptCaching("Llm.PromptCaching", config.Llm.Provider, config.Llm.PromptCaching, errors, isDynamicProvider: false);
         ValidateModelProfiles(config, errors, pluginBackedProvidersPossible);
 
@@ -630,6 +631,14 @@ public static class ConfigValidator
                 errors.Add($"Models.Profiles.{profile.Id}.Model must be set.");
             if (!string.IsNullOrWhiteSpace(profile.AuthMode) && !IsValidProviderAuthMode(profile.AuthMode))
                 errors.Add($"Models.Profiles.{profile.Id}.AuthMode must be 'bearer' or 'tailnet-identity'.");
+            ValidateApertureProviderConfig(
+                $"Models.Profiles.{profile.Id}",
+                "BaseUrl",
+                profile.Provider,
+                profile.BaseUrl,
+                profile.ApiKey,
+                profile.AuthMode,
+                errors);
             if (!string.IsNullOrWhiteSpace(profile.PresetId))
             {
                 if (!LocalModelPresetCatalog.TryGet(profile.PresetId, out _))
@@ -683,6 +692,32 @@ public static class ConfigValidator
 
     private static string ResolveConfiguredPath(string? path)
         => ConfigPathResolver.Resolve(path);
+
+    private static void ValidateApertureProviderConfig(
+        string path,
+        string endpointPropertyName,
+        string? provider,
+        string? endpoint,
+        string? apiKey,
+        string? authMode,
+        ICollection<string> errors)
+    {
+        if (!string.Equals(provider, "aperture", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        if (string.IsNullOrWhiteSpace(endpoint))
+        {
+            errors.Add($"{path}.{endpointPropertyName} must be set when Provider='aperture'.");
+        }
+        else if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var uri) ||
+                 (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            errors.Add($"{path}.{endpointPropertyName} must be an absolute http(s) URL when Provider='aperture'.");
+        }
+
+        if (!IsTailnetIdentityAuth(authMode) && string.IsNullOrWhiteSpace(apiKey))
+            errors.Add($"{path}.ApiKey must be set when Provider='aperture' and AuthMode is not 'tailnet-identity'.");
+    }
 
     private static void ValidateWorkflows(WorkflowsConfig config, List<string> errors)
     {
@@ -860,6 +895,9 @@ public static class ConfigValidator
         var normalized = string.IsNullOrWhiteSpace(authMode) ? "bearer" : authMode.Trim().ToLowerInvariant();
         return normalized is "bearer" or "tailnet-identity";
     }
+
+    private static bool IsTailnetIdentityAuth(string? authMode)
+        => string.Equals(authMode?.Trim(), "tailnet-identity", StringComparison.OrdinalIgnoreCase);
 
     private static bool SupportsExplicitCacheTtl(string? providerId, string? dialect)
     {

--- a/src/OpenClaw.Core/Validation/ConfigValidator.cs
+++ b/src/OpenClaw.Core/Validation/ConfigValidator.cs
@@ -23,6 +23,7 @@ public static class ConfigValidator
         "ollama",
         "azure-openai",
         "openai-compatible",
+        "aperture",
         "anthropic-vertex",
         "amazon-bedrock",
         "groq",
@@ -66,6 +67,8 @@ public static class ConfigValidator
             errors.Add($"Llm.CircuitBreakerThreshold must be >= 1 (got {config.Llm.CircuitBreakerThreshold}).");
         if (config.Llm.CircuitBreakerCooldownSeconds < 1)
             errors.Add($"Llm.CircuitBreakerCooldownSeconds must be >= 1 (got {config.Llm.CircuitBreakerCooldownSeconds}).");
+        if (!IsValidProviderAuthMode(config.Llm.AuthMode))
+            errors.Add("Llm.AuthMode must be 'bearer' or 'tailnet-identity'.");
         ValidatePromptCaching("Llm.PromptCaching", config.Llm.Provider, config.Llm.PromptCaching, errors, isDynamicProvider: false);
         ValidateModelProfiles(config, errors, pluginBackedProvidersPossible);
 
@@ -625,6 +628,8 @@ public static class ConfigValidator
 
             if (string.IsNullOrWhiteSpace(profile.Model))
                 errors.Add($"Models.Profiles.{profile.Id}.Model must be set.");
+            if (!string.IsNullOrWhiteSpace(profile.AuthMode) && !IsValidProviderAuthMode(profile.AuthMode))
+                errors.Add($"Models.Profiles.{profile.Id}.AuthMode must be 'bearer' or 'tailnet-identity'.");
             if (!string.IsNullOrWhiteSpace(profile.PresetId))
             {
                 if (!LocalModelPresetCatalog.TryGet(profile.PresetId, out _))
@@ -829,6 +834,7 @@ public static class ConfigValidator
         var provider = (providerId ?? string.Empty).Trim();
         var requireExplicitDialect =
             provider.Equals("openai-compatible", StringComparison.OrdinalIgnoreCase)
+            || provider.Equals("aperture", StringComparison.OrdinalIgnoreCase)
             || provider.Equals("groq", StringComparison.OrdinalIgnoreCase)
             || provider.Equals("together", StringComparison.OrdinalIgnoreCase)
             || provider.Equals("lmstudio", StringComparison.OrdinalIgnoreCase)
@@ -847,6 +853,12 @@ public static class ConfigValidator
                 errors.Add($"{prefix}.KeepWarmEnabled is only valid for providers with explicit cache TTL semantics.");
             }
         }
+    }
+
+    private static bool IsValidProviderAuthMode(string? authMode)
+    {
+        var normalized = string.IsNullOrWhiteSpace(authMode) ? "bearer" : authMode.Trim().ToLowerInvariant();
+        return normalized is "bearer" or "tailnet-identity";
     }
 
     private static bool SupportsExplicitCacheTtl(string? providerId, string? dialect)

--- a/src/OpenClaw.Core/Validation/ModelDoctorEvaluator.cs
+++ b/src/OpenClaw.Core/Validation/ModelDoctorEvaluator.cs
@@ -94,6 +94,9 @@ public static class ModelDoctorEvaluator
                 IsDefault = string.Equals(normalizedId, defaultProfileId, StringComparison.OrdinalIgnoreCase),
                 IsImplicit = config.Models.Profiles.Count == 0 && string.Equals(normalizedId, "default", StringComparison.OrdinalIgnoreCase),
                 IsAvailable = validationIssues.Length == 0,
+                ProviderGateway = ResolveProviderGateway(profile, providerId),
+                AuthMode = Normalize(profile.AuthMode) ?? Normalize(config.Llm.AuthMode) ?? "bearer",
+                SendRequestMetadata = profile.SendRequestMetadata ?? config.Llm.SendRequestMetadata,
                 Tags = ResolveTags(profile),
                 Capabilities = ResolveCapabilities(profile, providerId),
                 PromptCaching = MergePromptCaching(config.Llm.PromptCaching, profile.PromptCaching),
@@ -162,7 +165,7 @@ public static class ModelDoctorEvaluator
             yield return "BaseUrl is required for this provider unless inherited from OpenClaw:Llm:Endpoint.";
         }
 
-        if (RequiresCredentials(providerId) &&
+        if (RequiresCredentials(providerId, profile, config) &&
             string.IsNullOrWhiteSpace(ResolveSecretValue(profile.ApiKey)) &&
             string.IsNullOrWhiteSpace(ResolveSecretValue(config.Llm.ApiKey)))
         {
@@ -171,10 +174,17 @@ public static class ModelDoctorEvaluator
     }
 
     private static bool RequiresEndpoint(string providerId)
-        => providerId is "openai-compatible" or "groq" or "together" or "lmstudio" or "anthropic-vertex" or "amazon-bedrock" or "azure-openai";
+        => providerId is "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" or "anthropic-vertex" or "amazon-bedrock" or "azure-openai";
 
-    private static bool RequiresCredentials(string providerId)
-        => providerId is not "ollama" and not "lmstudio" and not "embedded";
+    private static bool RequiresCredentials(string providerId, ModelProfileConfig profile, GatewayConfig config)
+    {
+        if (providerId is "ollama" or "lmstudio" or "embedded")
+            return false;
+
+        var authMode = Normalize(profile.AuthMode) ?? Normalize(config.Llm.AuthMode);
+        return !(providerId is "aperture" or "openai-compatible" &&
+                 string.Equals(authMode, "tailnet-identity", StringComparison.OrdinalIgnoreCase));
+    }
 
     private static ModelCapabilities GuessCapabilities(string providerId)
     {
@@ -199,23 +209,23 @@ public static class ModelDoctorEvaluator
             };
         }
 
-        var supportsTools = provider is "openai" or "openai-compatible" or "azure-openai" or "groq" or "together" or "lmstudio" or "anthropic" or "claude" or "anthropic-vertex" or "amazon-bedrock" or "gemini" or "google";
-        var supportsVision = provider is "openai" or "openai-compatible" or "azure-openai" or "gemini" or "google" or "ollama" or "amazon-bedrock";
+        var supportsTools = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai" or "groq" or "together" or "lmstudio" or "anthropic" or "claude" or "anthropic-vertex" or "amazon-bedrock" or "gemini" or "google";
+        var supportsVision = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai" or "gemini" or "google" or "ollama" or "amazon-bedrock";
         var supportsPromptCaching = provider is "openai" or "azure-openai" or "anthropic" or "claude" or "anthropic-vertex" or "gemini" or "google";
         var supportsExplicitCacheRetention = provider is "anthropic" or "claude" or "anthropic-vertex";
         return new ModelCapabilities
         {
             SupportsTools = supportsTools,
             SupportsVision = supportsVision,
-            SupportsJsonSchema = provider is "openai" or "openai-compatible" or "azure-openai",
-            SupportsStructuredOutputs = provider is "openai" or "openai-compatible" or "azure-openai",
+            SupportsJsonSchema = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai",
+            SupportsStructuredOutputs = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai",
             SupportsStreaming = true,
-            SupportsParallelToolCalls = provider is "openai" or "openai-compatible" or "azure-openai",
-            SupportsReasoningEffort = provider is "openai" or "openai-compatible" or "azure-openai",
+            SupportsParallelToolCalls = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai",
+            SupportsReasoningEffort = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai",
             SupportsSystemMessages = true,
             SupportsImageInput = supportsVision,
             SupportsVideoInput = supportsVision,
-            SupportsAudioInput = provider is "openai" or "openai-compatible" or "azure-openai",
+            SupportsAudioInput = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai",
             SupportsPromptCaching = supportsPromptCaching,
             SupportsExplicitCacheRetention = supportsExplicitCacheRetention,
             ReportsCacheReadTokens = supportsPromptCaching,
@@ -273,6 +283,19 @@ public static class ModelDoctorEvaluator
             .Concat(preset.Tags)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
+    }
+
+    private static string? ResolveProviderGateway(ModelProfileConfig profile, string providerId)
+    {
+        if (providerId.Equals("aperture", StringComparison.OrdinalIgnoreCase) ||
+            profile.Tags.Contains("aperture", StringComparer.OrdinalIgnoreCase) ||
+            (!string.IsNullOrWhiteSpace(profile.BaseUrl) &&
+             profile.BaseUrl.Contains("aperture", StringComparison.OrdinalIgnoreCase)))
+        {
+            return "Aperture";
+        }
+
+        return null;
     }
 
     private static IReadOnlyList<string> ResolveCompatibilityNotes(ModelProfileConfig profile, GatewayConfig config)

--- a/src/OpenClaw.Core/Validation/ProviderSmokeProbe.cs
+++ b/src/OpenClaw.Core/Validation/ProviderSmokeProbe.cs
@@ -149,7 +149,7 @@ public static class ProviderSmokeProbe
         return provider switch
         {
             "openai" or "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" or "azure-openai"
-                => BuildOpenAiStyleRequest(provider, config, apiKey),
+                => BuildOpenAiStyleRequest(provider, config, apiKey, suppressAuthorization: IsTailnetIdentityAuth(config.AuthMode)),
             "ollama" => BuildOllamaRequest(config),
             "anthropic" or "claude" or "anthropic-vertex" or "amazon-bedrock"
                 => BuildAnthropicStyleRequest(provider, config, apiKey),
@@ -159,7 +159,11 @@ public static class ProviderSmokeProbe
         };
     }
 
-    private static HttpRequestMessage BuildOpenAiStyleRequest(string provider, LlmProviderConfig config, string? apiKey)
+    private static HttpRequestMessage BuildOpenAiStyleRequest(
+        string provider,
+        LlmProviderConfig config,
+        string? apiKey,
+        bool suppressAuthorization)
     {
         var endpoint = provider switch
         {
@@ -176,7 +180,7 @@ public static class ProviderSmokeProbe
             throw new InvalidOperationException($"Provider '{provider}' requires OpenClaw:Llm:Endpoint to run a smoke probe.");
 
         var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
-        if (!string.IsNullOrWhiteSpace(apiKey))
+        if (!suppressAuthorization && !string.IsNullOrWhiteSpace(apiKey))
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
         request.Content = BuildJsonContent(
             $$"""

--- a/src/OpenClaw.Core/Validation/ProviderSmokeProbe.cs
+++ b/src/OpenClaw.Core/Validation/ProviderSmokeProbe.cs
@@ -149,7 +149,11 @@ public static class ProviderSmokeProbe
         return provider switch
         {
             "openai" or "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" or "azure-openai"
-                => BuildOpenAiStyleRequest(provider, config, apiKey, suppressAuthorization: IsTailnetIdentityAuth(config.AuthMode)),
+                => BuildOpenAiStyleRequest(
+                    provider,
+                    config,
+                    apiKey,
+                    suppressAuthorization: IsTailnetIdentityAuth(config.AuthMode) && SupportsTailnetIdentity(provider)),
             "ollama" => BuildOllamaRequest(config),
             "anthropic" or "claude" or "anthropic-vertex" or "amazon-bedrock"
                 => BuildAnthropicStyleRequest(provider, config, apiKey),
@@ -282,6 +286,9 @@ public static class ProviderSmokeProbe
 
     private static bool IsTailnetIdentityAuth(string? authMode)
         => string.Equals(authMode?.Trim(), "tailnet-identity", StringComparison.OrdinalIgnoreCase);
+
+    private static bool SupportsTailnetIdentity(string provider)
+        => provider is "aperture" or "openai-compatible";
 
     private static TimeSpan GetProbeTimeout(int configuredTimeoutSeconds)
     {

--- a/src/OpenClaw.Core/Validation/ProviderSmokeProbe.cs
+++ b/src/OpenClaw.Core/Validation/ProviderSmokeProbe.cs
@@ -47,7 +47,7 @@ public static class ProviderSmokeProbe
         }
 
         var apiKey = SecretResolver.Resolve(config.ApiKey);
-        if (!HasRequiredCredentials(provider, apiKey))
+        if (!HasRequiredCredentials(provider, apiKey, config.AuthMode))
         {
             return new ProviderSmokeProbeResult
             {
@@ -141,14 +141,14 @@ public static class ProviderSmokeProbe
             return registration.TreatAsConfigured;
 
         var apiKey = SecretResolver.Resolve(config.ApiKey);
-        return HasRequiredCredentials(provider, apiKey);
+        return HasRequiredCredentials(provider, apiKey, config.AuthMode);
     }
 
     private static HttpRequestMessage BuildRequest(string provider, LlmProviderConfig config, string? apiKey)
     {
         return provider switch
         {
-            "openai" or "openai-compatible" or "groq" or "together" or "lmstudio" or "azure-openai"
+            "openai" or "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" or "azure-openai"
                 => BuildOpenAiStyleRequest(provider, config, apiKey),
             "ollama" => BuildOllamaRequest(config),
             "anthropic" or "claude" or "anthropic-vertex" or "amazon-bedrock"
@@ -168,6 +168,7 @@ public static class ProviderSmokeProbe
             "together" => AppendPath(config.Endpoint, "https://api.together.xyz/v1", "chat/completions"),
             "lmstudio" => AppendPath(config.Endpoint, "http://127.0.0.1:1234/v1", "chat/completions"),
             "azure-openai" => AppendPath(config.Endpoint, null, "chat/completions"),
+            "aperture" => AppendPath(config.Endpoint, null, "chat/completions"),
             _ => AppendPath(config.Endpoint, null, "chat/completions")
         };
 
@@ -264,15 +265,19 @@ public static class ProviderSmokeProbe
         return $"{uri}{separator}{Uri.EscapeDataString(key)}={Uri.EscapeDataString(value)}";
     }
 
-    private static bool HasRequiredCredentials(string provider, string? apiKey)
+    private static bool HasRequiredCredentials(string provider, string? apiKey, string? authMode)
         => provider switch
         {
             "ollama" or "lmstudio" or "embedded" => true,
+            "aperture" or "openai-compatible" when IsTailnetIdentityAuth(authMode) => true,
             _ => !string.IsNullOrWhiteSpace(apiKey)
         };
 
     private static string NormalizeProvider(string? provider)
         => string.IsNullOrWhiteSpace(provider) ? string.Empty : provider.Trim().ToLowerInvariant();
+
+    private static bool IsTailnetIdentityAuth(string? authMode)
+        => string.Equals(authMode?.Trim(), "tailnet-identity", StringComparison.OrdinalIgnoreCase);
 
     private static TimeSpan GetProbeTimeout(int configuredTimeoutSeconds)
     {

--- a/src/OpenClaw.Gateway/Extensions/LlmClientFactory.cs
+++ b/src/OpenClaw.Gateway/Extensions/LlmClientFactory.cs
@@ -188,6 +188,7 @@ public static class LlmClientFactory
                     Provider = config.Provider,
                     ApiKey = config.ApiKey,
                     AuthMode = config.AuthMode,
+                    SendRequestMetadata = config.SendRequestMetadata,
                     Model = config.Model,
                     Endpoint = config.Endpoint
                 }, embeddingModel!),

--- a/src/OpenClaw.Gateway/Extensions/LlmClientFactory.cs
+++ b/src/OpenClaw.Gateway/Extensions/LlmClientFactory.cs
@@ -185,7 +185,9 @@ public static class LlmClientFactory
             "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" =>
                 CreateOpenAiEmbeddingClient(new LlmProviderConfig
                 {
+                    Provider = config.Provider,
                     ApiKey = config.ApiKey,
+                    AuthMode = config.AuthMode,
                     Model = config.Model,
                     Endpoint = config.Endpoint
                 }, embeddingModel!),
@@ -231,6 +233,9 @@ public static class LlmClientFactory
     private static IEmbeddingGenerator<string, Embedding<float>> CreateOpenAiEmbeddingClient(
         LlmProviderConfig config, string embeddingModel)
     {
+        if (IsTailnetIdentityAuth(config.AuthMode))
+            throw new InvalidOperationException("Embeddings do not support AuthMode=tailnet-identity yet. Configure bearer auth for embeddings or disable embeddings for this profile.");
+
         var transport = CreateTransportOptions(config.Endpoint);
         var client = new OpenAI.OpenAIClient(
             new ApiKeyCredential(config.ApiKey ?? throw new InvalidOperationException("API key required for embeddings.")),
@@ -257,7 +262,7 @@ public static class LlmClientFactory
         if (string.IsNullOrWhiteSpace(apiKey))
         {
             if (!IsTailnetIdentityAuth(llm.AuthMode))
-                throw new InvalidOperationException("MODEL_PROVIDER_KEY must be set for the OpenAI-compatible provider.");
+                throw new InvalidOperationException(BuildMissingOpenAiCompatibleKeyMessage(llm.Provider));
 
             apiKey = "openclaw-tailnet-identity";
         }
@@ -333,12 +338,24 @@ public static class LlmClientFactory
 
     private static bool IsTailnetIdentityAuth(string? authMode)
         => string.Equals(authMode?.Trim(), "tailnet-identity", StringComparison.OrdinalIgnoreCase);
+
+    private static string BuildMissingOpenAiCompatibleKeyMessage(string provider)
+        => string.Equals(provider, "aperture", StringComparison.OrdinalIgnoreCase)
+            ? "OPENCLAW_APERTURE_TOKEN or OpenClaw:Llm:ApiKey must be set for provider 'aperture' when AuthMode is 'bearer'."
+            : $"MODEL_PROVIDER_KEY must be set for provider '{provider}'.";
 }
 
 internal sealed class OpenClawProviderRequestPolicy : PipelinePolicy
 {
     internal const string MetadataHeadersPropertyName = "openclaw.request_metadata_headers";
     private static readonly AsyncLocal<IReadOnlyDictionary<string, string>?> RequestHeaders = new();
+    private static readonly HashSet<string> BlockedMetadataHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Authorization",
+        "Cookie",
+        "Proxy-Authorization",
+        "WWW-Authenticate"
+    };
     private readonly bool _removeAuthorization;
 
     public OpenClawProviderRequestPolicy(bool removeAuthorization)
@@ -374,8 +391,14 @@ internal sealed class OpenClawProviderRequestPolicy : PipelinePolicy
 
         foreach (var (name, value) in headers)
         {
-            if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(value))
-                message.Request.Headers.Set(name, value);
+            var headerName = name.Trim();
+            var headerValue = value.Trim();
+            if (!string.IsNullOrWhiteSpace(headerName) &&
+                !string.IsNullOrWhiteSpace(headerValue) &&
+                !BlockedMetadataHeaderNames.Contains(headerName))
+            {
+                message.Request.Headers.Set(headerName, headerValue);
+            }
         }
     }
 

--- a/src/OpenClaw.Gateway/Extensions/LlmClientFactory.cs
+++ b/src/OpenClaw.Gateway/Extensions/LlmClientFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using Anthropic;
@@ -132,18 +133,19 @@ public static class LlmClientFactory
             "azure-openai" => CreateAzureOpenAiClient(config)
                 .GetChatClient(config.Model)
                 .AsIChatClient(),
-            "openai-compatible" or "groq" or "together" or "lmstudio" =>
-                CreateOpenAiClient(new LlmProviderConfig
+            "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" =>
+                CreateOpenAiCompatibleClient(new LlmProviderConfig
                 {
+                    Provider = config.Provider,
                     ApiKey = config.ApiKey,
+                    AuthMode = config.AuthMode,
+                    SendRequestMetadata = config.SendRequestMetadata,
                     Model = config.Model,
                     Endpoint = config.Endpoint
                         ?? throw new InvalidOperationException(
                             $"Endpoint must be set for provider '{config.Provider}'. " +
                             "Set OpenClaw:Llm:Endpoint or MODEL_PROVIDER_ENDPOINT.")
-                })
-                .GetChatClient(config.Model)
-                .AsIChatClient(),
+                }),
             "amazon-bedrock" => CreateAnthropicClient(new LlmProviderConfig
                 {
                     ApiKey = config.ApiKey,
@@ -156,7 +158,7 @@ public static class LlmClientFactory
                 .AsIChatClient(config.Model),
             _ => throw new InvalidOperationException(
                 $"Unsupported LLM provider: {config.Provider}. " +
-                "Supported: openai, anthropic, claude, anthropic-vertex, gemini, google, ollama, embedded, azure-openai, openai-compatible, groq, together, lmstudio, amazon-bedrock")
+                "Supported: openai, anthropic, claude, anthropic-vertex, gemini, google, ollama, embedded, azure-openai, openai-compatible, aperture, groq, together, lmstudio, amazon-bedrock")
         };
     }
 
@@ -180,7 +182,7 @@ public static class LlmClientFactory
                 Model = config.Model
             }, embeddingModel!),
             "gemini" or "google" => CreateGeminiEmbeddingClient(config, embeddingModel!),
-            "openai-compatible" or "groq" or "together" or "lmstudio" =>
+            "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" =>
                 CreateOpenAiEmbeddingClient(new LlmProviderConfig
                 {
                     ApiKey = config.ApiKey,
@@ -245,6 +247,32 @@ public static class LlmClientFactory
         return new OpenAI.OpenAIClient(new ApiKeyCredential(llm.ApiKey), CreateOpenAiClientOptions(transport));
     }
 
+    private static IChatClient CreateOpenAiCompatibleClient(LlmProviderConfig llm)
+    {
+        var policy = RequiresOpenClawRequestPolicy(llm)
+            ? new OpenClawProviderRequestPolicy(IsTailnetIdentityAuth(llm.AuthMode))
+            : null;
+
+        var apiKey = llm.ApiKey;
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            if (!IsTailnetIdentityAuth(llm.AuthMode))
+                throw new InvalidOperationException("MODEL_PROVIDER_KEY must be set for the OpenAI-compatible provider.");
+
+            apiKey = "openclaw-tailnet-identity";
+        }
+
+        var transport = CreateTransportOptions(llm.Endpoint);
+        var options = CreateOpenAiClientOptions(transport, policy);
+        var client = new OpenAI.OpenAIClient(new ApiKeyCredential(apiKey), options)
+            .GetChatClient(llm.Model)
+            .AsIChatClient();
+
+        return policy is null
+            ? client
+            : new OpenClawProviderRequestMetadataChatClient(client);
+    }
+
     private static OpenAI.OpenAIClient CreateAzureOpenAiClient(LlmProviderConfig llm)
     {
         if (string.IsNullOrWhiteSpace(llm.ApiKey))
@@ -283,7 +311,9 @@ public static class LlmClientFactory
                 : new Uri(endpoint, UriKind.Absolute),
             HiddenRetryCount: 0);
 
-    private static OpenAI.OpenAIClientOptions CreateOpenAiClientOptions(LlmClientTransportOptions transport)
+    private static OpenAI.OpenAIClientOptions CreateOpenAiClientOptions(
+        LlmClientTransportOptions transport,
+        PipelinePolicy? requestPolicy = null)
     {
         var options = new OpenAI.OpenAIClientOptions
         {
@@ -292,7 +322,108 @@ public static class LlmClientFactory
 
         if (transport.Endpoint is not null)
             options.Endpoint = transport.Endpoint;
+        if (requestPolicy is not null)
+            options.AddPolicy(requestPolicy, PipelinePosition.BeforeTransport);
 
         return options;
+    }
+
+    private static bool RequiresOpenClawRequestPolicy(LlmProviderConfig config)
+        => config.SendRequestMetadata || IsTailnetIdentityAuth(config.AuthMode);
+
+    private static bool IsTailnetIdentityAuth(string? authMode)
+        => string.Equals(authMode?.Trim(), "tailnet-identity", StringComparison.OrdinalIgnoreCase);
+}
+
+internal sealed class OpenClawProviderRequestPolicy : PipelinePolicy
+{
+    internal const string MetadataHeadersPropertyName = "openclaw.request_metadata_headers";
+    private static readonly AsyncLocal<IReadOnlyDictionary<string, string>?> RequestHeaders = new();
+    private readonly bool _removeAuthorization;
+
+    public OpenClawProviderRequestPolicy(bool removeAuthorization)
+        => _removeAuthorization = removeAuthorization;
+
+    public override void Process(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+    {
+        Apply(message);
+        ProcessNext(message, pipeline, currentIndex);
+    }
+
+    public override ValueTask ProcessAsync(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+    {
+        Apply(message);
+        return ProcessNextAsync(message, pipeline, currentIndex);
+    }
+
+    internal static IDisposable PushHeaders(IReadOnlyDictionary<string, string>? headers)
+    {
+        var previous = RequestHeaders.Value;
+        RequestHeaders.Value = headers;
+        return new HeaderScope(previous);
+    }
+
+    private void Apply(PipelineMessage message)
+    {
+        if (_removeAuthorization)
+            message.Request.Headers.Remove("Authorization");
+
+        var headers = RequestHeaders.Value;
+        if (headers is null)
+            return;
+
+        foreach (var (name, value) in headers)
+        {
+            if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(value))
+                message.Request.Headers.Set(name, value);
+        }
+    }
+
+    private sealed class HeaderScope(IReadOnlyDictionary<string, string>? previous) : IDisposable
+    {
+        public void Dispose() => RequestHeaders.Value = previous;
+    }
+}
+
+internal sealed class OpenClawProviderRequestMetadataChatClient(IChatClient inner) : IChatClient
+{
+    public async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var (headers, effectiveOptions) = ExtractMetadataHeaders(options);
+        using var _ = OpenClawProviderRequestPolicy.PushHeaders(headers);
+        return await inner.GetResponseAsync(messages, effectiveOptions, cancellationToken);
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var (headers, effectiveOptions) = ExtractMetadataHeaders(options);
+        using var _ = OpenClawProviderRequestPolicy.PushHeaders(headers);
+        await foreach (var update in inner.GetStreamingResponseAsync(messages, effectiveOptions, cancellationToken).WithCancellation(cancellationToken))
+            yield return update;
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+        => serviceType.IsInstanceOfType(this) ? this : inner.GetService(serviceType, serviceKey);
+
+    public void Dispose() => inner.Dispose();
+
+    private static (IReadOnlyDictionary<string, string>? Headers, ChatOptions? Options) ExtractMetadataHeaders(ChatOptions? options)
+    {
+        if (options?.AdditionalProperties is null ||
+            !options.AdditionalProperties.TryGetValue(OpenClawProviderRequestPolicy.MetadataHeadersPropertyName, out var raw) ||
+            raw is not IReadOnlyDictionary<string, string> headers)
+        {
+            return (null, options);
+        }
+
+        var clone = options.Clone();
+        clone.AdditionalProperties?.Remove(OpenClawProviderRequestPolicy.MetadataHeadersPropertyName);
+        return (headers, clone);
     }
 }

--- a/src/OpenClaw.Gateway/GatewayLlmExecutionService.cs
+++ b/src/OpenClaw.Gateway/GatewayLlmExecutionService.cs
@@ -7,6 +7,7 @@ using OpenClaw.Agent;
 using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Models;
 using OpenClaw.Core.Observability;
+using OpenClaw.Gateway.Extensions;
 using OpenClaw.Gateway.Models;
 using OpenClaw.Gateway.PromptCaching;
 
@@ -248,6 +249,7 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
                 }
 
                 effectiveOptions.ModelId = modelId;
+                AddRequestMetadataIfEnabled(effectiveOptions, session, candidate.Profile, streaming: false);
                 var prepared = _promptCacheCoordinator.Prepare(session, candidate.Profile, modelId, messages, effectiveOptions);
                 _promptCacheWarmRegistry.Record(prepared);
 
@@ -376,6 +378,7 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
             }
 
             var selectedModelId = ResolveRequestedModelId(session, candidate.Profile);
+            AddRequestMetadataIfEnabled(effectiveOptions, session, candidate.Profile, streaming: true);
             var prepared = _promptCacheCoordinator.Prepare(session, candidate.Profile, selectedModelId, messages, effectiveOptions);
             _promptCacheWarmRegistry.Record(prepared);
             var routeState = GetOrAddRouteState(candidate.Profile.Id, candidate.Profile.ProviderId, selectedModelId);
@@ -621,6 +624,37 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
         return true;
     }
 
+    private static void AddRequestMetadataIfEnabled(ChatOptions options, Session session, ModelProfile profile, bool streaming)
+    {
+        if (!profile.SendRequestMetadata)
+            return;
+
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        AddHeader(headers, "X-OpenClaw-Session-Id", session.Id);
+        AddHeader(headers, "X-OpenClaw-Actor-Id", session.SenderId);
+        AddHeader(headers, "X-OpenClaw-Channel-Id", session.ChannelId);
+        AddHeader(headers, "X-OpenClaw-Model-Profile", profile.Id);
+        AddHeader(headers, "X-OpenClaw-Run-Mode", streaming ? "streaming" : "standard");
+        AddHeader(headers, "X-OpenClaw-Purpose", "chat");
+
+        if (headers.Count == 0)
+            return;
+
+        options.AdditionalProperties ??= new AdditionalPropertiesDictionary();
+        options.AdditionalProperties[OpenClawProviderRequestPolicy.MetadataHeadersPropertyName] = headers;
+    }
+
+    private static void AddHeader(Dictionary<string, string> headers, string name, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+
+        var sanitized = value.Trim();
+        if (sanitized.Length > 256)
+            sanitized = sanitized[..256];
+        headers[name] = sanitized;
+    }
+
     private static void NormalizePromptCacheUsage(ChatResponse response)
     {
         if (response.Usage is null)
@@ -767,6 +801,7 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
         => providerId.Trim().ToLowerInvariant() switch
         {
             "openai" => "MODEL_PROVIDER_KEY or OPENAI_API_KEY",
+            "aperture" => "OPENCLAW_APERTURE_TOKEN, MODEL_PROVIDER_KEY, or AuthMode=tailnet-identity",
             _ => "MODEL_PROVIDER_KEY"
         };
 
@@ -774,6 +809,7 @@ internal sealed class GatewayLlmExecutionService : ILlmExecutionService
         => providerId.Trim().ToLowerInvariant() switch
         {
             "openai" => "OpenAI",
+            "aperture" => "Aperture",
             "azure-openai" => "Azure OpenAI",
             "anthropic" or "claude" => "Anthropic",
             "gemini" or "google" => "Gemini",

--- a/src/OpenClaw.Gateway/Models/ConfiguredModelProfileRegistry.cs
+++ b/src/OpenClaw.Gateway/Models/ConfiguredModelProfileRegistry.cs
@@ -73,6 +73,9 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry, ID
                 IsDefault = item.IsDefault,
                 IsImplicit = item.Profile.IsImplicit,
                 IsAvailable = item.Client is not null && item.ValidationIssues.Length == 0,
+                ProviderGateway = ResolveProviderGateway(item.Profile),
+                AuthMode = item.Profile.AuthMode,
+                SendRequestMetadata = item.Profile.SendRequestMetadata,
                 Tags = item.Profile.Tags,
                 Capabilities = item.Profile.Capabilities,
                 PromptCaching = item.Profile.PromptCaching,
@@ -163,6 +166,8 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry, ID
             Model = config.Llm.Model,
             BaseUrl = config.Llm.Endpoint,
             ApiKey = config.Llm.ApiKey,
+            AuthMode = config.Llm.AuthMode,
+            SendRequestMetadata = config.Llm.SendRequestMetadata,
             FallbackModels = config.Llm.FallbackModels,
             Capabilities = GuessCapabilities(config.Llm.Provider),
             PromptCaching = ClonePromptCaching(config.Llm.PromptCaching)
@@ -191,8 +196,8 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry, ID
             };
         }
 
-        var supportsTools = provider is "openai" or "openai-compatible" or "azure-openai" or "groq" or "together" or "lmstudio" or "anthropic" or "claude" or "anthropic-vertex" or "amazon-bedrock" or "gemini" or "google";
-        var supportsVision = provider is "openai" or "openai-compatible" or "azure-openai" or "gemini" or "google" or "ollama" or "amazon-bedrock";
+        var supportsTools = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai" or "groq" or "together" or "lmstudio" or "anthropic" or "claude" or "anthropic-vertex" or "amazon-bedrock" or "gemini" or "google";
+        var supportsVision = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai" or "gemini" or "google" or "ollama" or "amazon-bedrock";
         var supportsPromptCaching = provider is "openai" or "azure-openai" or "anthropic" or "claude" or "anthropic-vertex" or "gemini" or "google";
         var supportsExplicitCacheRetention = provider is "anthropic" or "claude" or "anthropic-vertex";
         var reportsCacheReadTokens = supportsPromptCaching;
@@ -201,15 +206,15 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry, ID
         {
             SupportsTools = supportsTools,
             SupportsVision = supportsVision,
-            SupportsJsonSchema = provider is "openai" or "openai-compatible" or "azure-openai",
-            SupportsStructuredOutputs = provider is "openai" or "openai-compatible" or "azure-openai",
+            SupportsJsonSchema = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai",
+            SupportsStructuredOutputs = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai",
             SupportsStreaming = true,
-            SupportsParallelToolCalls = provider is "openai" or "openai-compatible" or "azure-openai",
-            SupportsReasoningEffort = provider is "openai" or "openai-compatible" or "azure-openai",
+            SupportsParallelToolCalls = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai",
+            SupportsReasoningEffort = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai",
             SupportsSystemMessages = true,
             SupportsImageInput = supportsVision,
             SupportsVideoInput = supportsVision,
-            SupportsAudioInput = provider is "openai" or "openai-compatible" or "azure-openai",
+            SupportsAudioInput = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai",
             SupportsPromptCaching = supportsPromptCaching,
             SupportsExplicitCacheRetention = supportsExplicitCacheRetention,
             ReportsCacheReadTokens = reportsCacheReadTokens,
@@ -226,6 +231,8 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry, ID
             ModelId = Normalize(model.Model) ?? config.Llm.Model,
             BaseUrl = ResolveSecretValue(model.BaseUrl),
             ApiKey = ResolveSecretValue(model.ApiKey),
+            AuthMode = Normalize(model.AuthMode) ?? Normalize(config.Llm.AuthMode) ?? "bearer",
+            SendRequestMetadata = model.SendRequestMetadata ?? config.Llm.SendRequestMetadata,
             Tags = MergeTags(model),
             FallbackProfileIds = NormalizeDistinct(model.FallbackProfileIds),
             FallbackModels = NormalizeDistinct(model.FallbackModels),
@@ -244,6 +251,7 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry, ID
         if (string.IsNullOrWhiteSpace(profile.ModelId))
             yield return "Model is required.";
         if ((profile.ProviderId.Equals("openai-compatible", StringComparison.OrdinalIgnoreCase) ||
+             profile.ProviderId.Equals("aperture", StringComparison.OrdinalIgnoreCase) ||
              profile.ProviderId.Equals("groq", StringComparison.OrdinalIgnoreCase) ||
              profile.ProviderId.Equals("together", StringComparison.OrdinalIgnoreCase) ||
              profile.ProviderId.Equals("lmstudio", StringComparison.OrdinalIgnoreCase) ||
@@ -253,11 +261,12 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry, ID
             string.IsNullOrWhiteSpace(profile.BaseUrl) &&
             string.IsNullOrWhiteSpace(config.Llm.Endpoint))
         {
-            yield return "BaseUrl is required for OpenAI-compatible, Anthropic Vertex, Amazon Bedrock, and Azure OpenAI profiles unless inherited from OpenClaw:Llm:Endpoint.";
+            yield return "BaseUrl is required for OpenAI-compatible, Aperture, Anthropic Vertex, Amazon Bedrock, and Azure OpenAI profiles unless inherited from OpenClaw:Llm:Endpoint.";
         }
 
         if ((profile.ProviderId.Equals("openai", StringComparison.OrdinalIgnoreCase) ||
              profile.ProviderId.Equals("openai-compatible", StringComparison.OrdinalIgnoreCase) ||
+             profile.ProviderId.Equals("aperture", StringComparison.OrdinalIgnoreCase) ||
              profile.ProviderId.Equals("groq", StringComparison.OrdinalIgnoreCase) ||
              profile.ProviderId.Equals("together", StringComparison.OrdinalIgnoreCase) ||
              profile.ProviderId.Equals("azure-openai", StringComparison.OrdinalIgnoreCase) ||
@@ -267,6 +276,7 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry, ID
              profile.ProviderId.Equals("amazon-bedrock", StringComparison.OrdinalIgnoreCase) ||
              profile.ProviderId.Equals("gemini", StringComparison.OrdinalIgnoreCase) ||
              profile.ProviderId.Equals("google", StringComparison.OrdinalIgnoreCase)) &&
+            !AllowsTailnetIdentityAuth(profile.ProviderId, profile.AuthMode) &&
             string.IsNullOrWhiteSpace(profile.ApiKey) &&
             string.IsNullOrWhiteSpace(config.Llm.ApiKey))
         {
@@ -281,6 +291,8 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry, ID
             Model = profile.ModelId,
             ApiKey = profile.ApiKey ?? config.Llm.ApiKey,
             Endpoint = ResolveEndpoint(config, profile),
+            AuthMode = profile.AuthMode,
+            SendRequestMetadata = profile.SendRequestMetadata,
             FallbackModels = profile.FallbackModels,
             MaxTokens = profile.Capabilities.MaxOutputTokens > 0 ? profile.Capabilities.MaxOutputTokens : config.Llm.MaxTokens,
             Temperature = config.Llm.Temperature,
@@ -390,6 +402,20 @@ internal sealed class ConfiguredModelProfileRegistry : IModelProfileRegistry, ID
     private static bool ProfileUsesCompatibilityTransport(ModelProfile profile)
         => profile.ProviderId.Equals("ollama", StringComparison.OrdinalIgnoreCase) &&
            OllamaEndpointNormalizer.UsesCompatibilityEndpoint(profile.BaseUrl);
+
+    private static string? ResolveProviderGateway(ModelProfile profile)
+        => IsApertureProfile(profile) ? "Aperture" : null;
+
+    private static bool IsApertureProfile(ModelProfile profile)
+        => profile.ProviderId.Equals("aperture", StringComparison.OrdinalIgnoreCase) ||
+           profile.Tags.Contains("aperture", StringComparer.OrdinalIgnoreCase) ||
+           (!string.IsNullOrWhiteSpace(profile.BaseUrl) &&
+            profile.BaseUrl.Contains("aperture", StringComparison.OrdinalIgnoreCase));
+
+    private static bool AllowsTailnetIdentityAuth(string providerId, string? authMode)
+        => (providerId.Equals("aperture", StringComparison.OrdinalIgnoreCase) ||
+            providerId.Equals("openai-compatible", StringComparison.OrdinalIgnoreCase)) &&
+           string.Equals(authMode?.Trim(), "tailnet-identity", StringComparison.OrdinalIgnoreCase);
 
     private static IReadOnlyList<string> BuildCompatibilityNotes(ModelProfile profile)
     {

--- a/src/OpenClaw.Tests/ConfigValidatorTests.cs
+++ b/src/OpenClaw.Tests/ConfigValidatorTests.cs
@@ -103,6 +103,25 @@ public sealed class ConfigValidatorTests
     }
 
     [Fact]
+    public void Validate_UnsupportedTailnetIdentityProvider_ReturnsError()
+    {
+        var config = new GatewayConfig
+        {
+            Llm = new LlmProviderConfig
+            {
+                Provider = "openai",
+                Model = "gpt-4.1",
+                ApiKey = "env:MODEL_PROVIDER_KEY",
+                AuthMode = "tailnet-identity"
+            }
+        };
+
+        var errors = ConfigValidator.Validate(config);
+
+        Assert.Contains(errors, error => error.Contains("tailnet-identity", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void Validate_WebhookHmacEnabledWithoutSecret_ReturnsError()
     {
         var config = new GatewayConfig

--- a/src/OpenClaw.Tests/ConfigValidatorTests.cs
+++ b/src/OpenClaw.Tests/ConfigValidatorTests.cs
@@ -56,6 +56,53 @@ public sealed class ConfigValidatorTests
     }
 
     [Fact]
+    public void Validate_RootApertureBearerWithoutEndpointOrApiKey_ReturnsErrors()
+    {
+        var config = new GatewayConfig
+        {
+            Llm = new LlmProviderConfig
+            {
+                Provider = "aperture",
+                Model = "team/default",
+                AuthMode = "bearer"
+            }
+        };
+
+        var errors = ConfigValidator.Validate(config);
+
+        Assert.Contains(errors, error => error.Contains("Llm.Endpoint", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("Llm.ApiKey", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ApertureProfileTailnetIdentityWithoutApiKey_IsAccepted()
+    {
+        var config = new GatewayConfig
+        {
+            Models = new ModelsConfig
+            {
+                Profiles =
+                [
+                    new ModelProfileConfig
+                    {
+                        Id = "aperture-default",
+                        Provider = "aperture",
+                        Model = "team/default",
+                        BaseUrl = "https://aperture.example.test/v1",
+                        AuthMode = "tailnet-identity"
+                    }
+                ],
+                DefaultProfile = "aperture-default"
+            }
+        };
+
+        var errors = ConfigValidator.Validate(config);
+
+        Assert.DoesNotContain(errors, error => error.Contains("Models.Profiles.aperture-default.ApiKey", StringComparison.Ordinal));
+        Assert.DoesNotContain(errors, error => error.Contains("Models.Profiles.aperture-default.Endpoint", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Validate_WebhookHmacEnabledWithoutSecret_ReturnsError()
     {
         var config = new GatewayConfig

--- a/src/OpenClaw.Tests/LlmClientFactoryTests.cs
+++ b/src/OpenClaw.Tests/LlmClientFactoryTests.cs
@@ -1,4 +1,10 @@
 using Microsoft.Extensions.AI;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using NSubstitute;
 using OpenClaw.Core.Models;
 using OpenClaw.Gateway.Extensions;
@@ -82,5 +88,100 @@ public sealed class LlmClientFactoryTests
         });
 
         Assert.NotNull(client);
+    }
+
+    [Fact]
+    public async Task ApertureTailnetIdentity_DoesNotSendAuthorizationHeader()
+    {
+        await using var server = await StartOpenAiCompatibleServerAsync();
+        var client = LlmClientFactory.CreateChatClient(new LlmProviderConfig
+        {
+            Provider = "aperture",
+            Endpoint = $"{server.BaseUrl}/v1",
+            Model = "aperture-route",
+            AuthMode = "tailnet-identity"
+        });
+
+        var response = await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "ready?")],
+            new ChatOptions { ModelId = "aperture-route" },
+            CancellationToken.None);
+
+        Assert.Equal("READY", response.Text);
+        Assert.False(server.Headers.ContainsKey("Authorization"));
+    }
+
+    [Fact]
+    public async Task ApertureMetadata_OptInSendsHeadersAndKeepsBearerAuth()
+    {
+        await using var server = await StartOpenAiCompatibleServerAsync();
+        var client = LlmClientFactory.CreateChatClient(new LlmProviderConfig
+        {
+            Provider = "aperture",
+            Endpoint = $"{server.BaseUrl}/v1",
+            Model = "aperture-route",
+            ApiKey = "test-token",
+            SendRequestMetadata = true
+        });
+
+        var options = new ChatOptions { ModelId = "aperture-route" };
+        options.AdditionalProperties ??= new AdditionalPropertiesDictionary();
+        options.AdditionalProperties[OpenClawProviderRequestPolicy.MetadataHeadersPropertyName] =
+            new Dictionary<string, string>
+            {
+                ["X-OpenClaw-Session-Id"] = "sess-1",
+                ["X-OpenClaw-Model-Profile"] = "aperture-default"
+            };
+
+        var response = await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "ready?")],
+            options,
+            CancellationToken.None);
+
+        Assert.Equal("READY", response.Text);
+        Assert.Equal("Bearer test-token", server.Headers["Authorization"]);
+        Assert.Equal("sess-1", server.Headers["X-OpenClaw-Session-Id"]);
+        Assert.Equal("aperture-default", server.Headers["X-OpenClaw-Model-Profile"]);
+    }
+
+    private static async Task<OpenAiCompatibleTestServer> StartOpenAiCompatibleServerAsync()
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        var app = builder.Build();
+        app.MapPost("/v1/chat/completions", (HttpContext ctx) =>
+        {
+            headers.Clear();
+            foreach (var header in ctx.Request.Headers)
+                headers[header.Key] = header.Value.ToString();
+
+            return Results.Json(new
+            {
+                id = "chatcmpl-test",
+                @object = "chat.completion",
+                created = 0,
+                model = "aperture-route",
+                choices = new[]
+                {
+                    new
+                    {
+                        index = 0,
+                        message = new { role = "assistant", content = "READY" },
+                        finish_reason = "stop"
+                    }
+                }
+            });
+        });
+
+        await app.StartAsync();
+        var address = app.Urls.FirstOrDefault()
+            ?? app.Services.GetRequiredService<IServerAddressesFeature>().Addresses.First();
+        return new OpenAiCompatibleTestServer(app, address.TrimEnd('/'), headers);
+    }
+
+    private sealed record OpenAiCompatibleTestServer(WebApplication App, string BaseUrl, Dictionary<string, string> Headers) : IAsyncDisposable
+    {
+        public async ValueTask DisposeAsync() => await App.DisposeAsync();
     }
 }

--- a/src/OpenClaw.Tests/LlmClientFactoryTests.cs
+++ b/src/OpenClaw.Tests/LlmClientFactoryTests.cs
@@ -185,6 +185,26 @@ public sealed class LlmClientFactoryTests
         Assert.False(server.Headers.ContainsKey("Authorization"));
     }
 
+    [Fact]
+    public async Task UnsupportedTailnetIdentityProvider_SmokeProbeKeepsAuthorization()
+    {
+        await using var server = await StartOpenAiCompatibleServerAsync();
+
+        var result = await ProviderSmokeProbe.ProbeAsync(
+            new LlmProviderConfig
+            {
+                Provider = "groq",
+                Endpoint = $"{server.BaseUrl}/v1",
+                Model = "llama-test",
+                ApiKey = "provider-token",
+                AuthMode = "tailnet-identity"
+            },
+            CancellationToken.None);
+
+        Assert.Equal(SetupCheckStates.Pass, result.Status);
+        Assert.Equal("Bearer provider-token", server.Headers["Authorization"]);
+    }
+
     private static async Task<OpenAiCompatibleTestServer> StartOpenAiCompatibleServerAsync()
     {
         var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/src/OpenClaw.Tests/LlmClientFactoryTests.cs
+++ b/src/OpenClaw.Tests/LlmClientFactoryTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NSubstitute;
 using OpenClaw.Core.Models;
+using OpenClaw.Core.Validation;
 using OpenClaw.Gateway.Extensions;
 using Xunit;
 
@@ -129,6 +130,8 @@ public sealed class LlmClientFactoryTests
         options.AdditionalProperties[OpenClawProviderRequestPolicy.MetadataHeadersPropertyName] =
             new Dictionary<string, string>
             {
+                ["Authorization"] = "Bearer attacker",
+                ["Cookie"] = "session=attacker",
                 ["X-OpenClaw-Session-Id"] = "sess-1",
                 ["X-OpenClaw-Model-Profile"] = "aperture-default"
             };
@@ -140,8 +143,46 @@ public sealed class LlmClientFactoryTests
 
         Assert.Equal("READY", response.Text);
         Assert.Equal("Bearer test-token", server.Headers["Authorization"]);
+        Assert.False(server.Headers.ContainsKey("Cookie"));
         Assert.Equal("sess-1", server.Headers["X-OpenClaw-Session-Id"]);
         Assert.Equal("aperture-default", server.Headers["X-OpenClaw-Model-Profile"]);
+    }
+
+    [Fact]
+    public void ApertureTailnetIdentity_EmbeddingsFailFastWithoutApiKey()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            LlmClientFactory.CreateEmbeddingGenerator(
+                new LlmProviderConfig
+                {
+                    Provider = "aperture",
+                    Endpoint = "https://aperture.example.test/v1",
+                    Model = "aperture-route",
+                    AuthMode = "tailnet-identity"
+                },
+                "text-embedding-3-small"));
+
+        Assert.Contains("AuthMode=tailnet-identity", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ApertureTailnetIdentity_SmokeProbeSuppressesAuthorizationEvenWithStaleKey()
+    {
+        await using var server = await StartOpenAiCompatibleServerAsync();
+
+        var result = await ProviderSmokeProbe.ProbeAsync(
+            new LlmProviderConfig
+            {
+                Provider = "aperture",
+                Endpoint = $"{server.BaseUrl}/v1",
+                Model = "aperture-route",
+                ApiKey = "stale-token",
+                AuthMode = "tailnet-identity"
+            },
+            CancellationToken.None);
+
+        Assert.Equal(SetupCheckStates.Pass, result.Status);
+        Assert.False(server.Headers.ContainsKey("Authorization"));
     }
 
     private static async Task<OpenAiCompatibleTestServer> StartOpenAiCompatibleServerAsync()
@@ -175,8 +216,12 @@ public sealed class LlmClientFactoryTests
         });
 
         await app.StartAsync();
-        var address = app.Urls.FirstOrDefault()
-            ?? app.Services.GetRequiredService<IServerAddressesFeature>().Addresses.First();
+        var address = app.Services
+            .GetRequiredService<Microsoft.AspNetCore.Hosting.Server.IServer>()
+            .Features
+            .Get<IServerAddressesFeature>()!
+            .Addresses
+            .First();
         return new OpenAiCompatibleTestServer(app, address.TrimEnd('/'), headers);
     }
 

--- a/src/OpenClaw.Tests/ModelProfileSelectionTests.cs
+++ b/src/OpenClaw.Tests/ModelProfileSelectionTests.cs
@@ -650,6 +650,87 @@ public sealed class ModelProfileSelectionTests
     }
 
     [Fact]
+    public void ModelDoctor_ApertureTailnetIdentity_DoesNotRequireApiKey()
+    {
+        var config = new GatewayConfig
+        {
+            Llm = new LlmProviderConfig
+            {
+                Provider = "openai",
+                Model = "gpt-4o",
+                ApiKey = "env:MODEL_PROVIDER_KEY"
+            },
+            Models = new ModelsConfig
+            {
+                Profiles =
+                [
+                    new ModelProfileConfig
+                    {
+                        Id = "aperture-default",
+                        Provider = "aperture",
+                        Model = "route/default",
+                        BaseUrl = "https://aperture.example.test/v1",
+                        AuthMode = "tailnet-identity",
+                        SendRequestMetadata = true
+                    }
+                ]
+            }
+        };
+
+        var doctor = ModelDoctorEvaluator.Build(config);
+        var profile = Assert.Single(doctor.Profiles);
+
+        Assert.Empty(profile.ValidationIssues);
+        Assert.Equal("Aperture", profile.ProviderGateway);
+        Assert.Equal("tailnet-identity", profile.AuthMode);
+        Assert.True(profile.SendRequestMetadata);
+    }
+
+    [Fact]
+    public void Registry_ApertureProfileFailure_IsolatedFromDefaultProvider()
+    {
+        LlmClientFactory.ResetDynamicProviders();
+        LlmClientFactory.RegisterProvider("fake-profile-tests", new EvaluationChatClient());
+
+        var config = new GatewayConfig
+        {
+            Llm = new LlmProviderConfig
+            {
+                Provider = "fake-profile-tests",
+                Model = "default-model"
+            },
+            Models = new ModelsConfig
+            {
+                DefaultProfile = "default",
+                Profiles =
+                [
+                    new ModelProfileConfig
+                    {
+                        Id = "default",
+                        Provider = "fake-profile-tests",
+                        Model = "default-model"
+                    },
+                    new ModelProfileConfig
+                    {
+                        Id = "broken-aperture",
+                        Provider = "aperture",
+                        Model = "route/default",
+                        AuthMode = "bearer"
+                    }
+                ]
+            }
+        };
+
+        using var registry = new ConfiguredModelProfileRegistry(config, NullLogger<ConfiguredModelProfileRegistry>.Instance);
+        var statuses = registry.ListStatuses();
+
+        Assert.Contains(statuses, status => status.Id == "default" && status.IsAvailable);
+        var broken = Assert.Single(statuses, status => status.Id == "broken-aperture");
+        Assert.False(broken.IsAvailable);
+        Assert.Contains(broken.ValidationIssues, issue => issue.Contains("BaseUrl is required", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task GatewayExecution_FallsBackWhenSelectedProfileContextTooSmall()
     {
         LlmClientFactory.ResetDynamicProviders();

--- a/src/OpenClaw.Tests/SetupCommandTests.cs
+++ b/src/OpenClaw.Tests/SetupCommandTests.cs
@@ -399,7 +399,7 @@ public sealed class SetupCommandTests
         var root = CreateTempRoot();
         try
         {
-            var configPath = Path.Combine(root, "config", "openclaw.settings.json");
+            var configPath = Path.Join(root, "config", "openclaw.settings.json");
             var workspace = Path.Combine(root, "workspace");
             using var setupOutput = new StringWriter();
             using var setupError = new StringWriter();
@@ -470,7 +470,7 @@ public sealed class SetupCommandTests
         var root = CreateTempRoot();
         try
         {
-            var configPath = Path.Combine(root, "config", "openclaw.settings.json");
+            var configPath = Path.Join(root, "config", "openclaw.settings.json");
             var workspace = Path.Combine(root, "workspace");
             using var setupOutput = new StringWriter();
             using var setupError = new StringWriter();
@@ -635,7 +635,7 @@ public sealed class SetupCommandTests
         var root = CreateTempRoot();
         try
         {
-            var configPath = Path.Combine(root, "config", "openclaw.settings.json");
+            var configPath = Path.Join(root, "config", "openclaw.settings.json");
             using var output = new StringWriter();
             using var error = new StringWriter();
             using var input = new StringReader(string.Empty);
@@ -672,7 +672,7 @@ public sealed class SetupCommandTests
             Assert.True(profile.GetProperty("sendRequestMetadata").GetBoolean());
             Assert.False(profile.TryGetProperty("apiKey", out _));
 
-            var envExample = await File.ReadAllTextAsync(Path.Combine(root, "config", "openclaw.settings.env.example"));
+            var envExample = await File.ReadAllTextAsync(Path.Join(root, "config", "openclaw.settings.env.example"));
             Assert.DoesNotContain("OPENCLAW_APERTURE_TOKEN", envExample, StringComparison.Ordinal);
             Assert.Contains("OPENCLAW_AUTH_TOKEN=", envExample, StringComparison.Ordinal);
         }

--- a/src/OpenClaw.Tests/SetupCommandTests.cs
+++ b/src/OpenClaw.Tests/SetupCommandTests.cs
@@ -27,7 +27,7 @@ public sealed class SetupCommandTests
         var root = CreateTempRoot();
         try
         {
-            var configPath = Path.Combine(root, "config", "openclaw.settings.json");
+            var configPath = Path.Join(root, "config", "openclaw.settings.json");
             var workspace = Path.Combine(root, "workspace");
             using var output = new StringWriter();
             using var error = new StringWriter();
@@ -69,7 +69,7 @@ public sealed class SetupCommandTests
             var memory = openClaw.GetProperty("memory");
             Assert.Equal(Path.Combine(root, "config", "memory"), memory.GetProperty("storagePath").GetString());
 
-            var envExample = await File.ReadAllTextAsync(Path.Combine(root, "config", "openclaw.settings.env.example"));
+            var envExample = await File.ReadAllTextAsync(Path.Join(root, "config", "openclaw.settings.env.example"));
             Assert.Contains("OPENAI_API_KEY=replace-me", envExample, StringComparison.Ordinal);
             Assert.Contains($"OPENCLAW_WORKSPACE={workspace}", envExample, StringComparison.Ordinal);
 
@@ -643,9 +643,10 @@ public sealed class SetupCommandTests
             var exitCode = await SetupCommand.RunAsync(
                 [
                     "provider",
-                    "aperture",
+                    "Aperture",
                     "--non-interactive",
                     "--config", configPath,
+                    "--profile-id", "aperture",
                     "--endpoint", "https://aperture.example.test/v1",
                     "--model", "team/default",
                     "--auth-mode", "tailnet-identity",
@@ -663,7 +664,7 @@ public sealed class SetupCommandTests
             using var document = JsonDocument.Parse(await File.ReadAllTextAsync(configPath));
             var openClaw = document.RootElement.GetProperty("OpenClaw");
             var profile = Assert.Single(openClaw.GetProperty("models").GetProperty("profiles").EnumerateArray());
-            Assert.Equal("aperture-default", profile.GetProperty("id").GetString());
+            Assert.Equal("aperture", profile.GetProperty("id").GetString());
             Assert.Equal("aperture", profile.GetProperty("provider").GetString());
             Assert.Equal("team/default", profile.GetProperty("model").GetString());
             Assert.Equal("https://aperture.example.test/v1", profile.GetProperty("baseUrl").GetString());

--- a/src/OpenClaw.Tests/SetupCommandTests.cs
+++ b/src/OpenClaw.Tests/SetupCommandTests.cs
@@ -629,6 +629,57 @@ public sealed class SetupCommandTests
         }
     }
 
+    [Fact]
+    public async Task RunAsync_SetupProviderAperture_WritesTailnetIdentityProfile()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var configPath = Path.Combine(root, "config", "openclaw.settings.json");
+            using var output = new StringWriter();
+            using var error = new StringWriter();
+
+            var exitCode = await SetupCommand.RunAsync(
+                [
+                    "provider",
+                    "aperture",
+                    "--non-interactive",
+                    "--config", configPath,
+                    "--endpoint", "https://aperture.example.test/v1",
+                    "--model", "team/default",
+                    "--auth-mode", "tailnet-identity",
+                    "--send-request-metadata", "true"
+                ],
+                new StringReader(string.Empty),
+                output,
+                error,
+                root,
+                canPrompt: false);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(string.Empty, error.ToString());
+
+            using var document = JsonDocument.Parse(await File.ReadAllTextAsync(configPath));
+            var openClaw = document.RootElement.GetProperty("OpenClaw");
+            var profile = Assert.Single(openClaw.GetProperty("models").GetProperty("profiles").EnumerateArray());
+            Assert.Equal("aperture-default", profile.GetProperty("id").GetString());
+            Assert.Equal("aperture", profile.GetProperty("provider").GetString());
+            Assert.Equal("team/default", profile.GetProperty("model").GetString());
+            Assert.Equal("https://aperture.example.test/v1", profile.GetProperty("baseUrl").GetString());
+            Assert.Equal("tailnet-identity", profile.GetProperty("authMode").GetString());
+            Assert.True(profile.GetProperty("sendRequestMetadata").GetBoolean());
+            Assert.False(profile.TryGetProperty("apiKey", out _));
+
+            var envExample = await File.ReadAllTextAsync(Path.Combine(root, "config", "openclaw.settings.env.example"));
+            Assert.DoesNotContain("OPENCLAW_APERTURE_TOKEN", envExample, StringComparison.Ordinal);
+            Assert.Contains("OPENCLAW_AUTH_TOKEN=", envExample, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     private static string CreateTempRoot()
     {
         var root = Path.Combine(Path.GetTempPath(), "openclaw-setup-tests", Guid.NewGuid().ToString("n"));

--- a/src/OpenClaw.Tests/SetupCommandTests.cs
+++ b/src/OpenClaw.Tests/SetupCommandTests.cs
@@ -638,6 +638,7 @@ public sealed class SetupCommandTests
             var configPath = Path.Combine(root, "config", "openclaw.settings.json");
             using var output = new StringWriter();
             using var error = new StringWriter();
+            using var input = new StringReader(string.Empty);
 
             var exitCode = await SetupCommand.RunAsync(
                 [
@@ -650,7 +651,7 @@ public sealed class SetupCommandTests
                     "--auth-mode", "tailnet-identity",
                     "--send-request-metadata", "true"
                 ],
-                new StringReader(string.Empty),
+                input,
                 output,
                 error,
                 root,


### PR DESCRIPTION
## Summary

Adds first-class documentation for Tailscale deployment patterns and optional Aperture-by-Tailscale provider routing without changing the default OpenClaw.NET provider behavior or quickstart.

## Changes

- Add `docs/deployment/TAILSCALE.md` with Serve/Funnel guidance, Aperture positioning, security notes, identity-header caveats, SSH future direction, and troubleshooting.
- Add discoverability links in README and docs navigation.
- Treat `Provider = "aperture"` as an OpenAI-compatible upstream route with Aperture-friendly labels/status.
- Add optional `AuthMode` and `SendRequestMetadata` configuration, including no-key `tailnet-identity` mode.
- Add `openclaw setup provider aperture` helper.
- Extend doctor/smoke checks for Aperture while keeping offline mode non-failing.
- Add tests for provider behavior, no-key auth, metadata opt-in, doctor validation, failure isolation, and setup output.

## Validation

- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj --configuration Release --filter "FullyQualifiedName~LlmClientFactoryTests|FullyQualifiedName~ModelProfileSelectionTests|FullyQualifiedName~SetupCommandTests|FullyQualifiedName~DocsConsistencyTests|FullyQualifiedName~ConfigValidatorTests"`
- `dotnet test OpenClaw.Net.slnx --configuration Release`
- `dotnet build OpenClaw.Net.slnx --configuration Release --no-restore`

## Notes

Metadata propagation is disabled by default and only applies to explicitly enabled profiles. Invalid Aperture profiles remain isolated from unrelated valid providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Aperture (via Tailscale) as a supported LLM provider with selectable auth modes (bearer or tailnet-identity).
  * Per-profile opt-in request-metadata transmission for richer context.
  * New CLI provider setup flow and help examples for configuring Aperture and auth modes.

* **Documentation**
  * New Tailscale & Aperture integration guide plus updated docs/navigation entries and troubleshooting notes.

* **Tests**
  * Added tests covering Aperture auth modes, metadata behavior, profile handling, and setup command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/clawdotnet/openclaw.net/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->