### PR TITLE
[codex] Add harness regression suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Start here:
 - **Passive Harness Contracts** for inspectable agent-work plans without changing default chat or approval behavior
 - **Passive Evidence Bundles** for inspectable run evidence, checks, risks, and human review without default runtime interception
 - **Passive Governance Ledger** for durable approval and oversight decisions without auto-approving future actions
+- **Harness Regression Suite** via `openclaw harness test` for offline checks before trusting harness/runtime changes
 - **First-class optional Microsoft Agent Framework adapter** for `Runtime.Orchestrator=maf` without a special build
 - **Durable workflow delegation** through supported workflow backends such as `maf-durable-http`
 - **CLI and Companion** setup flows for source checkouts and desktop bundles

--- a/docs/HARNESS_REGRESSION.md
+++ b/docs/HARNESS_REGRESSION.md
@@ -1,0 +1,95 @@
+# Harness Regression Suite
+
+The Harness Regression Suite checks whether important OpenClaw.NET runtime guarantees still hold.
+
+It is designed for:
+
+- maintainers
+- contributors
+- CI
+- release preparation
+- review-first harness changes
+- future Harness Evolution Proposals
+
+It helps answer:
+
+- Does quickstart still work?
+- Are security defaults still safe?
+- Are approvals still enforced?
+- Does memory still round-trip?
+- Do harness models still serialize?
+- Are provider configs valid?
+- Are MCP/OpenAI-compatible surfaces structurally intact?
+
+## Usage
+
+Run the suite from a checkout or an installed CLI:
+
+```bash
+openclaw harness test
+openclaw harness test --offline
+openclaw harness test --category security
+openclaw harness test --json
+openclaw harness test --strict
+```
+
+From source, use:
+
+```bash
+dotnet run --project src/OpenClaw.Cli -c Release -- harness test
+```
+
+The command is offline-first and does not require cloud provider keys. It does not start the gateway, call model providers, or contact external MCP servers.
+
+## Output
+
+Default text output is intended for humans:
+
+```text
+OpenClaw Harness Regression
+
+PASS onboarding.quickstart_config - Config loaded successfully.
+PASS security.url_safety_defaults - Default URL safety blocks loopback, private, and metadata targets.
+PASS providers.config_shape - Provider/model shape is valid without external network calls.
+PASS mcp.initialize_shape - MCP initialize request shape serializes without running a gateway.
+FAIL security.public_bind_hardening - Public/non-loopback bind is missing required hardening.
+
+Summary:
+14 passed, 1 failed, 1 skipped, 0 warning, 0 not applicable
+```
+
+Use `--json` to emit the `HarnessRegressionReport` model. Use `--output <path>` to also write the selected output format to a file.
+
+## Categories
+
+Use `--category <name>` to run a focused subset:
+
+- `onboarding`
+- `security`
+- `approvals`
+- `memory`
+- `providers`
+- `tools`
+- `mcp`
+- `openai_compat`
+- `sessions`
+- `harness`
+- `deployment`
+- `docs`
+
+## Exit Codes
+
+- `0`: all required checks passed or were skipped appropriately
+- non-zero: at least one required check failed
+- `--strict`: treats required warnings and skips as failures
+
+## What This Does Not Do Yet
+
+- It is not a replacement for unit tests.
+- It is not a full model/provider integration test.
+- It is not a guarantee that every agent outcome is correct.
+- It does not require provider keys by default.
+- It does not run automatically during normal runtime.
+- It does not create Evidence Bundles by default.
+
+The suite is a CLI/checking surface. Normal chat, providers, tool execution, approvals, memory, Companion setup, MCP, and OpenAI-compatible routes are unchanged unless the command is explicitly invoked.

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ Use this page as the map. If you are unsure where to go next, the groups below a
 | [HARNESS_CONTRACTS.md](HARNESS_CONTRACTS.md) | Passive, inspectable Harness Contract records for future plan-execute-verify and evidence workflows. |
 | [EVIDENCE_BUNDLES.md](EVIDENCE_BUNDLES.md) | Passive evidence records for what happened, what was checked, remaining uncertainty, and operator trust. |
 | [GOVERNANCE_LEDGER.md](GOVERNANCE_LEDGER.md) | Passive approval and oversight decision history as durable harness state. |
+| [HARNESS_REGRESSION.md](HARNESS_REGRESSION.md) | Offline-first CLI regression checks for harness safety, onboarding, memory, provider-shape, MCP, OpenAI-compatible, and serialization guarantees. |
 | [governance/sidecar-pattern.md](governance/sidecar-pattern.md) | Optional central tool-governance middleware, sidecar flow, decisions, and audit fields. |
 | [governance/microsoft-agent-governance.md](governance/microsoft-agent-governance.md) | Microsoft Agent Governance sidecar integration notes and deployment cautions. |
 | [deployment/TAILSCALE.md](deployment/TAILSCALE.md) | Optional Tailscale Serve private runtime access guidance. |
@@ -47,6 +48,7 @@ Use this page as the map. If you are unsure where to go next, the groups below a
 | --- | --- |
 | [testing/agent-testing-harness.md](testing/agent-testing-harness.md) | Scenario-based agent tests, trace artifacts, explicit oracles, CLI usage, xUnit usage, and future runtime/gateway adapter seams. |
 | [testing/ai-assisted-testing-playbook.md](testing/ai-assisted-testing-playbook.md) | Disciplined AI-assisted testing workflow: scenario matrices, oracle requirements, boundary cases, human review, and trace-to-regression loops. |
+| [HARNESS_REGRESSION.md](HARNESS_REGRESSION.md) | `openclaw harness test` for offline regression checks before trusting harness/runtime changes. |
 | [MODEL_PROFILES.md#evaluation-harness](MODEL_PROFILES.md#evaluation-harness) | Existing gateway-backed model/profile evaluation surface exposed by `openclaw eval`. |
 
 ## Channels and Integrations

--- a/docs/SITE_MAP.md
+++ b/docs/SITE_MAP.md
@@ -18,6 +18,7 @@ Use this map when turning the Markdown docs into a documentation website. It kee
 | Guides | Prompt Caching | [PROMPT_CACHING.md](PROMPT_CACHING.md) |
 | Guides | Agent Testing Harness | [testing/agent-testing-harness.md](testing/agent-testing-harness.md) |
 | Guides | AI-Assisted Testing Playbook | [testing/ai-assisted-testing-playbook.md](testing/ai-assisted-testing-playbook.md) |
+| Guides | Harness Regression Suite | [HARNESS_REGRESSION.md](HARNESS_REGRESSION.md) |
 | Reference | Compatibility | [COMPATIBILITY.md](COMPATIBILITY.md) |
 | Reference | Sessions | [SESSIONS.md](SESSIONS.md) |
 | Reference | Canvas and A2UI | [CANVAS_A2UI.md](CANVAS_A2UI.md) |
@@ -67,6 +68,7 @@ Guides
   Prompt Caching
   Agent Testing Harness
   AI-Assisted Testing Playbook
+  Harness Regression Suite
 
 Reference
   Compatibility

--- a/src/OpenClaw.Cli/CliArgs.cs
+++ b/src/OpenClaw.Cli/CliArgs.cs
@@ -82,6 +82,7 @@ internal sealed class CliArgs
             or "--apply"
             or "--non-interactive"
             or "--offline"
+            or "--strict"
             or "--require-provider"
             or "--with-companion"
             or "--open-browser"

--- a/src/OpenClaw.Cli/HarnessCommands.cs
+++ b/src/OpenClaw.Cli/HarnessCommands.cs
@@ -1,0 +1,119 @@
+using OpenClaw.Testing;
+
+namespace OpenClaw.Cli;
+
+internal static class HarnessCommands
+{
+    public static Task<int> RunAsync(string[] args)
+        => RunAsync(args, Console.Out, Console.Error);
+
+    internal static async Task<int> RunAsync(string[] args, TextWriter output, TextWriter error)
+    {
+        if (args.Length == 0 || args[0] is "-h" or "--help" or "help")
+        {
+            PrintHelp(output);
+            return 0;
+        }
+
+        var subcommand = args[0].Trim().ToLowerInvariant();
+        if (subcommand is not ("test" or "regression"))
+        {
+            error.WriteLine($"Unknown harness subcommand: {subcommand}");
+            PrintHelp(output);
+            return 2;
+        }
+
+        var parsed = CliArgs.Parse(args.Skip(1).ToArray());
+        if (parsed.ShowHelp)
+        {
+            PrintHelp(output);
+            return 0;
+        }
+
+        return await RunRegressionAsync(parsed, output);
+    }
+
+    internal static async Task<int> RunRegressionAliasAsync(string[] args, TextWriter output, TextWriter error)
+    {
+        if (args.Length == 0 || args[0] is "-h" or "--help" or "help")
+        {
+            PrintAliasHelp(output);
+            return 0;
+        }
+
+        if (!string.Equals(args[0], "test", StringComparison.OrdinalIgnoreCase))
+        {
+            error.WriteLine($"Unknown regression subcommand: {args[0]}");
+            PrintAliasHelp(output);
+            return 2;
+        }
+
+        var forwarded = new[] { "test" }.Concat(args.Skip(1)).ToArray();
+        return await RunAsync(forwarded, output, error);
+    }
+
+    private static async Task<int> RunRegressionAsync(CliArgs parsed, TextWriter output)
+    {
+        var options = new HarnessRegressionOptions
+        {
+            ConfigPath = parsed.GetOption("--config"),
+            Category = parsed.GetOption("--category"),
+            Offline = true,
+            Strict = parsed.HasFlag("--strict"),
+            ProposalId = parsed.GetOption("--proposal"),
+            OutputPath = parsed.GetOption("--output")
+        };
+
+        var report = await new HarnessRegressionRunner().RunAsync(options, CancellationToken.None);
+        var renderJson = parsed.HasFlag("--json");
+        var rendered = renderJson
+            ? HarnessRegressionReportFormatter.ToJson(report)
+            : HarnessRegressionReportFormatter.ToText(report);
+
+        var outputPath = parsed.GetOption("--output");
+        if (!string.IsNullOrWhiteSpace(outputPath))
+        {
+            var fullPath = Path.GetFullPath(outputPath);
+            var directory = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrWhiteSpace(directory))
+                Directory.CreateDirectory(directory);
+            await File.WriteAllTextAsync(fullPath, rendered);
+        }
+
+        output.Write(rendered);
+        if (!renderJson && !string.IsNullOrWhiteSpace(outputPath))
+            output.WriteLine($"Report written: {Path.GetFullPath(outputPath)}");
+
+        return HarnessRegressionRunner.GetExitCode(report);
+    }
+
+    private static void PrintHelp(TextWriter output)
+    {
+        output.WriteLine("""
+            openclaw harness
+
+            Usage:
+              openclaw harness test [--config <path>] [--category <name>] [--json] [--offline] [--strict] [--proposal <id>] [--output <path>]
+              openclaw harness regression [--config <path>] [--category <name>] [--json] [--offline] [--strict] [--proposal <id>] [--output <path>]
+
+            Categories:
+              onboarding, security, approvals, memory, providers, tools, mcp,
+              openai_compat, sessions, harness, deployment, docs
+
+            Notes:
+              - Runs offline by default and does not require provider keys.
+              - Provider/network checks are structural only unless a future online mode is added.
+              - Strict mode treats required warnings and skips as failures.
+            """);
+    }
+
+    private static void PrintAliasHelp(TextWriter output)
+    {
+        output.WriteLine("""
+            openclaw regression
+
+            Usage:
+              openclaw regression test [--config <path>] [--category <name>] [--json] [--offline] [--strict] [--proposal <id>] [--output <path>]
+            """);
+    }
+}

--- a/src/OpenClaw.Cli/Program.cs
+++ b/src/OpenClaw.Cli/Program.cs
@@ -36,6 +36,8 @@ internal static class Program
                 "payment" => await PaymentCommands.RunAsync(rest),
                 "external" => await ExternalCliCommands.RunAsync(rest),
                 "test" => await TestingCommands.RunAsync(rest),
+                "harness" => await HarnessCommands.RunAsync(rest),
+                "regression" => await HarnessCommands.RunRegressionAliasAsync(rest, Console.Out, Console.Error),
                 "init" => InitCommand.Run(rest),
                 "migrate" => await MigrateAsync(rest),
                 "pulse" => await PulseAsync(rest),
@@ -104,6 +106,8 @@ internal static class Program
               openclaw payment <setup|funding list|virtual-card issue|execute|status> [options]
               openclaw external <list|status|commands|preview|execute> [options]
               openclaw test <init|run|report|gates> [options]
+              openclaw harness <test|regression> [options]
+              openclaw regression test [options]
               openclaw eval <run|compare> [options]
               openclaw accounts <list|add|remove|probe> [options]
               openclaw backends <list|probe|run|session send> [options]
@@ -167,6 +171,8 @@ internal static class Program
               openclaw external list
               openclaw test run
               openclaw test gates
+              openclaw harness test
+              openclaw harness test --category security --strict
               openclaw models list
               openclaw models presets
               openclaw models doctor

--- a/src/OpenClaw.Testing/HarnessRegressionInterfaces.cs
+++ b/src/OpenClaw.Testing/HarnessRegressionInterfaces.cs
@@ -1,0 +1,129 @@
+namespace OpenClaw.Testing;
+
+public interface IHarnessRegressionScenario
+{
+    string Id { get; }
+    string Name { get; }
+    string Category { get; }
+    bool Required { get; }
+
+    ValueTask<HarnessRegressionScenarioResult> RunAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken = default);
+}
+
+internal abstract class HarnessRegressionScenarioBase(
+    string id,
+    string name,
+    string category,
+    bool required = true) : IHarnessRegressionScenario
+{
+    public string Id { get; } = id;
+    public string Name { get; } = name;
+    public string Category { get; } = category;
+    public bool Required { get; } = required;
+
+    public async ValueTask<HarnessRegressionScenarioResult> RunAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var startedAt = DateTimeOffset.UtcNow;
+        try
+        {
+            var result = await EvaluateAsync(context, cancellationToken);
+            return Complete(result, startedAt);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        {
+            return Complete(Failed(
+                "Scenario threw an exception.",
+                error: ex.Message,
+                details: ex.ToString()), startedAt);
+        }
+    }
+
+    protected abstract ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken);
+
+    protected static HarnessRegressionScenarioResult Passed(
+        string summary,
+        string? details = null,
+        string severity = HarnessRegressionSeverity.Info)
+        => Build(HarnessRegressionScenarioStatus.Passed, summary, details, severity);
+
+    protected static HarnessRegressionScenarioResult Failed(
+        string summary,
+        string? details = null,
+        string? error = null,
+        string severity = HarnessRegressionSeverity.High)
+        => Build(HarnessRegressionScenarioStatus.Failed, summary, details, severity, error);
+
+    protected static HarnessRegressionScenarioResult Skipped(
+        string summary,
+        string? details = null,
+        string severity = HarnessRegressionSeverity.Info)
+        => Build(HarnessRegressionScenarioStatus.Skipped, summary, details, severity);
+
+    protected static HarnessRegressionScenarioResult Warning(
+        string summary,
+        string? details = null,
+        string severity = HarnessRegressionSeverity.Medium)
+        => Build(HarnessRegressionScenarioStatus.Warning, summary, details, severity);
+
+    protected static HarnessRegressionScenarioResult NotApplicable(
+        string summary,
+        string? details = null,
+        string severity = HarnessRegressionSeverity.Info)
+        => Build(HarnessRegressionScenarioStatus.NotApplicable, summary, details, severity);
+
+    private static HarnessRegressionScenarioResult Build(
+        string status,
+        string summary,
+        string? details,
+        string severity,
+        string? error = null)
+        => new()
+        {
+            Status = status,
+            Summary = summary,
+            Details = details,
+            Severity = severity,
+            Error = error
+        };
+
+    private HarnessRegressionScenarioResult Complete(
+        HarnessRegressionScenarioResult result,
+        DateTimeOffset startedAt)
+    {
+        var completedAt = DateTimeOffset.UtcNow;
+        return new HarnessRegressionScenarioResult
+        {
+            Id = Id,
+            Name = Name,
+            Category = Normalize(Category),
+            Status = string.IsNullOrWhiteSpace(result.Status)
+                ? HarnessRegressionScenarioStatus.NotApplicable
+                : Normalize(result.Status),
+            Severity = string.IsNullOrWhiteSpace(result.Severity)
+                ? HarnessRegressionSeverity.Info
+                : Normalize(result.Severity),
+            Required = Required,
+            Summary = result.Summary,
+            Details = result.Details,
+            Error = result.Error,
+            StartedAtUtc = startedAt,
+            CompletedAtUtc = completedAt,
+            DurationMs = (long)Math.Max(0, (completedAt - startedAt).TotalMilliseconds),
+            EvidenceBundleId = result.EvidenceBundleId,
+            RelatedContractId = result.RelatedContractId
+        };
+    }
+
+    private static string Normalize(string value)
+        => value.Trim().ToLowerInvariant();
+}

--- a/src/OpenClaw.Testing/HarnessRegressionJsonContext.cs
+++ b/src/OpenClaw.Testing/HarnessRegressionJsonContext.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+using OpenClaw.Client;
+
+namespace OpenClaw.Testing;
+
+[JsonSerializable(typeof(HarnessRegressionReport))]
+[JsonSerializable(typeof(HarnessRegressionScenarioResult))]
+[JsonSerializable(typeof(HarnessRegressionSummary))]
+[JsonSerializable(typeof(HarnessRegressionRecommendation))]
+[JsonSerializable(typeof(List<HarnessRegressionScenarioResult>))]
+[JsonSerializable(typeof(List<HarnessRegressionRecommendation>))]
+[JsonSerializable(typeof(McpJsonRpcRequest))]
+[JsonSerializable(typeof(McpInitializeRequest))]
+[JsonSerializable(typeof(McpClientCapabilities))]
+[JsonSerializable(typeof(McpClientInfo))]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    PropertyNameCaseInsensitive = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = true)]
+public sealed partial class HarnessRegressionJsonContext : JsonSerializerContext;

--- a/src/OpenClaw.Testing/HarnessRegressionModels.cs
+++ b/src/OpenClaw.Testing/HarnessRegressionModels.cs
@@ -1,0 +1,114 @@
+using OpenClaw.Core.Models;
+
+namespace OpenClaw.Testing;
+
+public static class HarnessRegressionScenarioStatus
+{
+    public const string Passed = "passed";
+    public const string Failed = "failed";
+    public const string Skipped = "skipped";
+    public const string Warning = "warning";
+    public const string NotApplicable = "not_applicable";
+}
+
+public static class HarnessRegressionCategory
+{
+    public const string Onboarding = "onboarding";
+    public const string Security = "security";
+    public const string Approvals = "approvals";
+    public const string Memory = "memory";
+    public const string Providers = "providers";
+    public const string Tools = "tools";
+    public const string Mcp = "mcp";
+    public const string OpenAiCompat = "openai_compat";
+    public const string Sessions = "sessions";
+    public const string Harness = "harness";
+    public const string Deployment = "deployment";
+    public const string Docs = "docs";
+}
+
+public static class HarnessRegressionSeverity
+{
+    public const string Info = "info";
+    public const string Low = "low";
+    public const string Medium = "medium";
+    public const string High = "high";
+    public const string Critical = "critical";
+}
+
+public sealed class HarnessRegressionOptions
+{
+    public string? ConfigPath { get; init; }
+    public string? Category { get; init; }
+    public bool Offline { get; init; } = true;
+    public bool Strict { get; init; }
+    public string? ProposalId { get; init; }
+    public string? OutputPath { get; init; }
+}
+
+public sealed class HarnessRegressionContext
+{
+    public required string ConfigPath { get; init; }
+    public bool ConfigPathExplicit { get; init; }
+    public bool ConfigExists { get; init; }
+    public GatewayConfig? Config { get; init; }
+    public string? ConfigLoadError { get; init; }
+    public bool Offline { get; init; }
+    public bool Strict { get; init; }
+    public string? ProposalId { get; init; }
+    public required string TempWorkspacePath { get; init; }
+    public TextWriter? Logger { get; init; }
+}
+
+public sealed class HarnessRegressionReport
+{
+    public string Id { get; init; } = "";
+    public DateTimeOffset StartedAtUtc { get; init; }
+    public DateTimeOffset CompletedAtUtc { get; init; }
+    public long DurationMs { get; init; }
+    public string? ConfigPath { get; init; }
+    public string? ProposalId { get; init; }
+    public bool Offline { get; init; }
+    public bool Strict { get; init; }
+    public string OverallStatus { get; init; } = HarnessRegressionScenarioStatus.Passed;
+    public IReadOnlyList<HarnessRegressionScenarioResult> Results { get; init; } = [];
+    public HarnessRegressionSummary Summary { get; init; } = new();
+    public IReadOnlyList<HarnessRegressionRecommendation> Recommendations { get; init; } = [];
+}
+
+public sealed class HarnessRegressionScenarioResult
+{
+    public string Id { get; init; } = "";
+    public string Name { get; init; } = "";
+    public string Category { get; init; } = HarnessRegressionCategory.Harness;
+    public string Status { get; init; } = HarnessRegressionScenarioStatus.NotApplicable;
+    public string Severity { get; init; } = HarnessRegressionSeverity.Info;
+    public bool Required { get; init; } = true;
+    public string Summary { get; init; } = "";
+    public string? Details { get; init; }
+    public string? Error { get; init; }
+    public DateTimeOffset StartedAtUtc { get; init; }
+    public DateTimeOffset CompletedAtUtc { get; init; }
+    public long DurationMs { get; init; }
+    public string? EvidenceBundleId { get; init; }
+    public string? RelatedContractId { get; init; }
+}
+
+public sealed class HarnessRegressionSummary
+{
+    public int Total { get; init; }
+    public int Passed { get; init; }
+    public int Failed { get; init; }
+    public int Skipped { get; init; }
+    public int Warning { get; init; }
+    public int NotApplicable { get; init; }
+}
+
+public sealed class HarnessRegressionRecommendation
+{
+    public string Id { get; init; } = "";
+    public string Severity { get; init; } = HarnessRegressionSeverity.Info;
+    public string Summary { get; init; } = "";
+    public string? Command { get; init; }
+    public string? Details { get; init; }
+}

--- a/src/OpenClaw.Testing/HarnessRegressionRunner.cs
+++ b/src/OpenClaw.Testing/HarnessRegressionRunner.cs
@@ -1,0 +1,382 @@
+using System.Text.Json;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Setup;
+
+namespace OpenClaw.Testing;
+
+public sealed class HarnessRegressionRunner
+{
+    private readonly IReadOnlyList<IHarnessRegressionScenario> _scenarios;
+
+    public HarnessRegressionRunner(IEnumerable<IHarnessRegressionScenario>? scenarios = null)
+    {
+        _scenarios = (scenarios ?? HarnessRegressionScenarios.CreateDefault()).ToArray();
+    }
+
+    public IReadOnlyList<IHarnessRegressionScenario> Scenarios => _scenarios;
+
+    public async ValueTask<HarnessRegressionReport> RunAsync(
+        HarnessRegressionOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        options ??= new HarnessRegressionOptions();
+        var startedAt = DateTimeOffset.UtcNow;
+        var context = BuildContext(options);
+        try
+        {
+            var selected = SelectScenarios(options.Category).ToArray();
+            var results = new List<HarnessRegressionScenarioResult>(selected.Length);
+
+            if (selected.Length == 0)
+            {
+                results.Add(BuildNoScenariosResult(options.Category));
+            }
+            else
+            {
+                foreach (var scenario in selected)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var result = await scenario.RunAsync(context, cancellationToken);
+                    results.Add(NormalizeResult(scenario, result));
+                }
+            }
+
+            var completedAt = DateTimeOffset.UtcNow;
+            var summary = BuildSummary(results);
+            var overallStatus = ResolveOverallStatus(results, options.Strict);
+
+            return new HarnessRegressionReport
+            {
+                Id = CreateReportId(startedAt),
+                StartedAtUtc = startedAt,
+                CompletedAtUtc = completedAt,
+                DurationMs = (long)Math.Max(0, (completedAt - startedAt).TotalMilliseconds),
+                ConfigPath = context.ConfigPath,
+                ProposalId = options.ProposalId,
+                Offline = context.Offline,
+                Strict = options.Strict,
+                OverallStatus = overallStatus,
+                Results = results,
+                Summary = summary,
+                Recommendations = BuildRecommendations(results)
+            };
+        }
+        finally
+        {
+            TryDeleteDirectory(context.TempWorkspacePath);
+        }
+    }
+
+    public static int GetExitCode(HarnessRegressionReport report)
+    {
+        if (report.Results.Any(static result =>
+                result.Required &&
+                string.Equals(result.Status, HarnessRegressionScenarioStatus.Failed, StringComparison.OrdinalIgnoreCase)))
+        {
+            return 1;
+        }
+
+        if (report.Strict && report.Results.Any(static result =>
+                result.Required &&
+                (string.Equals(result.Status, HarnessRegressionScenarioStatus.Warning, StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(result.Status, HarnessRegressionScenarioStatus.Skipped, StringComparison.OrdinalIgnoreCase))))
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private HarnessRegressionContext BuildContext(HarnessRegressionOptions options)
+    {
+        var configPathExplicit = !string.IsNullOrWhiteSpace(options.ConfigPath);
+        var configPath = Path.GetFullPath(GatewaySetupPaths.ExpandPath(
+            options.ConfigPath ?? GatewaySetupPaths.DefaultConfigPath));
+        var configExists = File.Exists(configPath);
+        GatewayConfig? config = null;
+        string? configLoadError = null;
+
+        if (configExists)
+        {
+            try
+            {
+                config = GatewayConfigFile.Load(configPath);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            {
+                configLoadError = ex.Message;
+            }
+        }
+        else
+        {
+            configLoadError = $"Config file not found: {configPath}";
+        }
+
+        return new HarnessRegressionContext
+        {
+            ConfigPath = configPath,
+            ConfigPathExplicit = configPathExplicit,
+            ConfigExists = configExists,
+            Config = config,
+            ConfigLoadError = configLoadError,
+            Offline = options.Offline,
+            Strict = options.Strict,
+            ProposalId = options.ProposalId,
+            TempWorkspacePath = CreateTempWorkspace()
+        };
+    }
+
+    private IEnumerable<IHarnessRegressionScenario> SelectScenarios(string? category)
+    {
+        if (string.IsNullOrWhiteSpace(category))
+            return _scenarios;
+
+        var normalized = Normalize(category);
+        return _scenarios.Where(scenario =>
+            string.Equals(scenario.Category, normalized, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static HarnessRegressionScenarioResult BuildNoScenariosResult(string? category)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new HarnessRegressionScenarioResult
+        {
+            Id = "harness.no_scenarios",
+            Name = "No scenarios selected",
+            Category = HarnessRegressionCategory.Harness,
+            Status = HarnessRegressionScenarioStatus.Failed,
+            Severity = HarnessRegressionSeverity.Medium,
+            Required = true,
+            Summary = string.IsNullOrWhiteSpace(category)
+                ? "No harness regression scenarios are registered."
+                : $"No harness regression scenarios matched category '{category}'.",
+            StartedAtUtc = now,
+            CompletedAtUtc = now
+        };
+    }
+
+    private static HarnessRegressionScenarioResult NormalizeResult(
+        IHarnessRegressionScenario scenario,
+        HarnessRegressionScenarioResult result)
+    {
+        var startedAt = result.StartedAtUtc == default ? DateTimeOffset.UtcNow : result.StartedAtUtc;
+        var completedAt = result.CompletedAtUtc == default ? startedAt : result.CompletedAtUtc;
+        return new HarnessRegressionScenarioResult
+        {
+            Id = string.IsNullOrWhiteSpace(result.Id) ? scenario.Id : result.Id,
+            Name = string.IsNullOrWhiteSpace(result.Name) ? scenario.Name : result.Name,
+            Category = NormalizeOrFallback(result.Category, scenario.Category),
+            Status = string.IsNullOrWhiteSpace(result.Status)
+                ? HarnessRegressionScenarioStatus.NotApplicable
+                : Normalize(result.Status),
+            Severity = string.IsNullOrWhiteSpace(result.Severity)
+                ? HarnessRegressionSeverity.Info
+                : Normalize(result.Severity),
+            Required = scenario.Required,
+            Summary = result.Summary,
+            Details = result.Details,
+            Error = result.Error,
+            StartedAtUtc = startedAt,
+            CompletedAtUtc = completedAt,
+            DurationMs = result.DurationMs <= 0
+                ? (long)Math.Max(0, (completedAt - startedAt).TotalMilliseconds)
+                : result.DurationMs,
+            EvidenceBundleId = result.EvidenceBundleId,
+            RelatedContractId = result.RelatedContractId
+        };
+    }
+
+    private static HarnessRegressionSummary BuildSummary(IReadOnlyList<HarnessRegressionScenarioResult> results)
+        => new()
+        {
+            Total = results.Count,
+            Passed = Count(results, HarnessRegressionScenarioStatus.Passed),
+            Failed = Count(results, HarnessRegressionScenarioStatus.Failed),
+            Skipped = Count(results, HarnessRegressionScenarioStatus.Skipped),
+            Warning = Count(results, HarnessRegressionScenarioStatus.Warning),
+            NotApplicable = Count(results, HarnessRegressionScenarioStatus.NotApplicable)
+        };
+
+    private static int Count(IReadOnlyList<HarnessRegressionScenarioResult> results, string status)
+        => results.Count(result => string.Equals(result.Status, status, StringComparison.OrdinalIgnoreCase));
+
+    private static string ResolveOverallStatus(
+        IReadOnlyList<HarnessRegressionScenarioResult> results,
+        bool strict)
+    {
+        if (results.Any(static result =>
+                result.Required &&
+                string.Equals(result.Status, HarnessRegressionScenarioStatus.Failed, StringComparison.OrdinalIgnoreCase)))
+        {
+            return HarnessRegressionScenarioStatus.Failed;
+        }
+
+        if (strict && results.Any(static result =>
+                result.Required &&
+                (string.Equals(result.Status, HarnessRegressionScenarioStatus.Warning, StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(result.Status, HarnessRegressionScenarioStatus.Skipped, StringComparison.OrdinalIgnoreCase))))
+        {
+            return HarnessRegressionScenarioStatus.Failed;
+        }
+
+        if (results.Any(static result =>
+                string.Equals(result.Status, HarnessRegressionScenarioStatus.Warning, StringComparison.OrdinalIgnoreCase)))
+        {
+            return HarnessRegressionScenarioStatus.Warning;
+        }
+
+        return HarnessRegressionScenarioStatus.Passed;
+    }
+
+    private static IReadOnlyList<HarnessRegressionRecommendation> BuildRecommendations(
+        IReadOnlyList<HarnessRegressionScenarioResult> results)
+    {
+        var recommendations = new List<HarnessRegressionRecommendation>();
+
+        if (results.Any(static result =>
+                result.Id == "onboarding.quickstart_config" &&
+                (IsStatus(result, HarnessRegressionScenarioStatus.Skipped) ||
+                 IsStatus(result, HarnessRegressionScenarioStatus.Failed))))
+        {
+            recommendations.Add(new HarnessRegressionRecommendation
+            {
+                Id = "setup.verify",
+                Severity = HarnessRegressionSeverity.Medium,
+                Summary = "Create or verify the OpenClaw config before trusting runtime checks.",
+                Command = "openclaw setup verify --offline"
+            });
+        }
+
+        if (results.Any(static result =>
+                IsCategory(result, HarnessRegressionCategory.Security) &&
+                (IsStatus(result, HarnessRegressionScenarioStatus.Failed) ||
+                 IsStatus(result, HarnessRegressionScenarioStatus.Warning))))
+        {
+            recommendations.Add(new HarnessRegressionRecommendation
+            {
+                Id = "security.posture",
+                Severity = HarnessRegressionSeverity.High,
+                Summary = "Review operator security posture before widening the runtime surface.",
+                Command = "openclaw admin posture"
+            });
+        }
+
+        if (results.Any(static result =>
+                IsCategory(result, HarnessRegressionCategory.Providers) &&
+                (IsStatus(result, HarnessRegressionScenarioStatus.Failed) ||
+                 IsStatus(result, HarnessRegressionScenarioStatus.Warning))))
+        {
+            recommendations.Add(new HarnessRegressionRecommendation
+            {
+                Id = "models.doctor",
+                Severity = HarnessRegressionSeverity.Medium,
+                Summary = "Review model profile shape and provider readiness.",
+                Command = "openclaw models doctor"
+            });
+        }
+
+        if (results.Any(static result =>
+                IsStatus(result, HarnessRegressionScenarioStatus.Skipped) ||
+                IsStatus(result, HarnessRegressionScenarioStatus.NotApplicable)))
+        {
+            recommendations.Add(new HarnessRegressionRecommendation
+            {
+                Id = "harness.docs",
+                Severity = HarnessRegressionSeverity.Info,
+                Summary = "Review skipped and not-applicable checks before using the report as release evidence.",
+                Command = "openclaw harness test --strict"
+            });
+        }
+
+        return recommendations;
+    }
+
+    private static string Normalize(string value)
+        => value.Trim().ToLowerInvariant();
+
+    private static string CreateReportId(DateTimeOffset startedAt)
+        => $"hreg_{startedAt:yyyyMMddHHmmss}_{Guid.NewGuid():N}"[..40];
+
+    private static string CreateTempWorkspace()
+    {
+        var path = Path.Join(Path.GetTempPath(), $"openclaw-harness-regression-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch (IOException)
+        {
+            return;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return;
+        }
+    }
+
+    private static string NormalizeOrFallback(string? value, string fallback)
+        => string.IsNullOrWhiteSpace(value) ? Normalize(fallback) : Normalize(value);
+
+    private static bool IsStatus(HarnessRegressionScenarioResult result, string status)
+        => string.Equals(result.Status, status, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsCategory(HarnessRegressionScenarioResult result, string category)
+        => string.Equals(result.Category, category, StringComparison.OrdinalIgnoreCase);
+}
+
+public static class HarnessRegressionReportFormatter
+{
+    public static string ToJson(HarnessRegressionReport report)
+        => JsonSerializer.Serialize(report, HarnessRegressionJsonContext.Default.HarnessRegressionReport);
+
+    public static string ToText(HarnessRegressionReport report)
+    {
+        using var writer = new StringWriter();
+        writer.WriteLine("OpenClaw Harness Regression");
+        writer.WriteLine();
+
+        foreach (var result in report.Results)
+        {
+            writer.WriteLine($"{Label(result.Status)} {result.Id} - {result.Summary}");
+            if (!string.IsNullOrWhiteSpace(result.Error))
+                writer.WriteLine($"  error: {result.Error}");
+        }
+
+        writer.WriteLine();
+        writer.WriteLine("Summary:");
+        writer.WriteLine(
+            $"{report.Summary.Passed} passed, {report.Summary.Failed} failed, {report.Summary.Skipped} skipped, {report.Summary.Warning} warning, {report.Summary.NotApplicable} not applicable");
+
+        if (report.Recommendations.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("Next steps:");
+            foreach (var recommendation in report.Recommendations)
+            {
+                writer.WriteLine(string.IsNullOrWhiteSpace(recommendation.Command)
+                    ? $"- {recommendation.Summary}"
+                    : $"- {recommendation.Command}");
+            }
+        }
+
+        return writer.ToString();
+    }
+
+    private static string Label(string status)
+        => status.Trim().ToLowerInvariant() switch
+        {
+            HarnessRegressionScenarioStatus.Passed => "PASS",
+            HarnessRegressionScenarioStatus.Failed => "FAIL",
+            HarnessRegressionScenarioStatus.Skipped => "SKIP",
+            HarnessRegressionScenarioStatus.Warning => "WARN",
+            HarnessRegressionScenarioStatus.NotApplicable => "N/A ",
+            _ => "????"
+        };
+}

--- a/src/OpenClaw.Testing/HarnessRegressionScenarios.cs
+++ b/src/OpenClaw.Testing/HarnessRegressionScenarios.cs
@@ -1,0 +1,785 @@
+using System.Text.Json;
+using OpenClaw.Client;
+using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Governance;
+using OpenClaw.Core.Memory;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Pipeline;
+using OpenClaw.Core.Security;
+using OpenClaw.Core.Skills;
+using OpenClaw.Core.Validation;
+using static OpenClaw.Testing.HarnessRegressionScenarioText;
+
+namespace OpenClaw.Testing;
+
+public static class HarnessRegressionScenarios
+{
+    public static IReadOnlyList<IHarnessRegressionScenario> CreateDefault() =>
+    [
+        new QuickstartConfigLoadsScenario(),
+        new ProviderConfigShapeScenario(),
+        new PublicBindHardeningScenario(),
+        new UrlSafetyDefaultsScenario(),
+        new ToolApprovalPolicyScenario(),
+        new MemoryStoreRoundTripScenario(),
+        new SessionStoreRoundTripScenario(),
+        new HarnessContractSerializationScenario(),
+        new EvidenceBundleSerializationScenario(),
+        new GovernanceLedgerSerializationScenario(),
+        new McpInitializeShapeScenario(),
+        new OpenAiCompatRequestShapeScenario(),
+        new LearningProposalReviewFirstScenario(),
+        new ManagedSkillValidationScenario(),
+        new TailscaleServeProfileNonPublicScenario(),
+        new HarnessRegressionDocsScenario()
+    ];
+}
+
+internal sealed class QuickstartConfigLoadsScenario()
+    : HarnessRegressionScenarioBase(
+        "onboarding.quickstart_config",
+        "Quickstart config loads",
+        HarnessRegressionCategory.Onboarding)
+{
+    protected override ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (context.Config is not null)
+        {
+            return ValueTask.FromResult(Passed(
+                "Config loaded successfully.",
+                $"Config path: {context.ConfigPath}"));
+        }
+
+        if (!context.ConfigPathExplicit && !context.ConfigExists)
+        {
+            return ValueTask.FromResult(Skipped(
+                "No default config was found; run setup or pass --config to check a specific config.",
+                $"Expected config path: {context.ConfigPath}"));
+        }
+
+        return ValueTask.FromResult(Failed(
+            "Config could not be loaded.",
+            $"Config path: {context.ConfigPath}",
+            context.ConfigLoadError));
+    }
+}
+
+internal sealed class ProviderConfigShapeScenario()
+    : HarnessRegressionScenarioBase(
+        "providers.config_shape",
+        "Provider config shape",
+        HarnessRegressionCategory.Providers)
+{
+    protected override ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (context.Config is null)
+            return ValueTask.FromResult(Skipped("Provider shape was skipped because no config is loaded."));
+
+        var config = context.Config;
+        var failures = new List<string>();
+        var notes = new List<string>();
+        var provider = Normalize(config.Llm.Provider);
+        var model = Normalize(config.Llm.Model);
+
+        if (string.IsNullOrWhiteSpace(provider))
+            failures.Add("OpenClaw:Llm:Provider must be set.");
+        if (string.IsNullOrWhiteSpace(model))
+            failures.Add("OpenClaw:Llm:Model must be set.");
+        if (!IsValidAuthMode(config.Llm.AuthMode))
+            failures.Add("OpenClaw:Llm:AuthMode must be bearer or tailnet-identity.");
+        if (RequiresEndpoint(provider) && !IsAbsoluteHttpUrl(config.Llm.Endpoint))
+            failures.Add($"Provider '{provider}' requires an absolute http(s) endpoint.");
+
+        foreach (var profile in config.Models.Profiles)
+        {
+            if (string.IsNullOrWhiteSpace(profile.Id))
+                failures.Add("Models.Profiles[].Id must be set.");
+            if (string.IsNullOrWhiteSpace(profile.Provider))
+                failures.Add($"Models.Profiles.{profile.Id}.Provider must be set.");
+            if (string.IsNullOrWhiteSpace(profile.Model))
+                failures.Add($"Models.Profiles.{profile.Id}.Model must be set.");
+            if (!string.IsNullOrWhiteSpace(profile.AuthMode) && !IsValidAuthMode(profile.AuthMode))
+                failures.Add($"Models.Profiles.{profile.Id}.AuthMode must be bearer or tailnet-identity.");
+            if (RequiresEndpoint(Normalize(profile.Provider)) && !IsAbsoluteHttpUrl(profile.BaseUrl ?? config.Llm.Endpoint))
+                failures.Add($"Models.Profiles.{profile.Id} requires an absolute http(s) base URL.");
+        }
+
+        if (context.Offline)
+            notes.Add("Credential and network checks were skipped because offline mode is enabled.");
+
+        if (failures.Count > 0)
+            return ValueTask.FromResult(Failed("Provider/model shape has blocking issue(s).", Join(failures)));
+
+        var details = Join(notes);
+        return ValueTask.FromResult(Passed(
+            "Provider/model shape is valid without external network calls.",
+            string.IsNullOrWhiteSpace(details) ? null : details));
+    }
+
+    private static string Normalize(string? value)
+        => string.IsNullOrWhiteSpace(value) ? "" : value.Trim().ToLowerInvariant();
+
+    private static bool IsValidAuthMode(string? value)
+        => string.IsNullOrWhiteSpace(value) ||
+           string.Equals(value, "bearer", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(value, "tailnet-identity", StringComparison.OrdinalIgnoreCase);
+
+    private static bool RequiresEndpoint(string provider)
+        => provider is "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" or "anthropic-vertex" or "amazon-bedrock" or "azure-openai";
+
+    private static bool IsAbsoluteHttpUrl(string? value)
+        => Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
+           (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+}
+
+internal sealed class PublicBindHardeningScenario()
+    : HarnessRegressionScenarioBase(
+        "security.public_bind_hardening",
+        "Public bind hardening",
+        HarnessRegressionCategory.Security)
+{
+    protected override ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (context.Config is null)
+            return ValueTask.FromResult(Skipped("Public bind posture was skipped because no config is loaded."));
+
+        var config = context.Config;
+        if (BindAddressClassifier.IsLoopbackBind(config.BindAddress))
+            return ValueTask.FromResult(Passed("Gateway bind address is loopback-only."));
+
+        var failures = new List<string>();
+        var warnings = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(config.AuthToken))
+            failures.Add("AuthToken must be configured for non-loopback binds.");
+        if (config.Canvas.Enabled && !config.Canvas.AllowOnPublicBind)
+            failures.Add("Canvas command forwarding is enabled on a public bind without Canvas.AllowOnPublicBind.");
+        if ((config.Plugins.Enabled || config.Plugins.DynamicNative.Enabled || config.Plugins.Mcp.Enabled) &&
+            !config.Security.AllowPluginBridgeOnPublicBind)
+        {
+            failures.Add("Plugin execution is enabled on a public bind without AllowPluginBridgeOnPublicBind.");
+        }
+        if (UnsafeLocalToolingExposed(config) && !config.Security.AllowUnsafeToolingOnPublicBind)
+            failures.Add("Unsafe local tooling is exposed on a public bind without explicit opt-in.");
+        if (!config.Security.RequireRequesterMatchForHttpToolApproval)
+            failures.Add("Requester-matched HTTP tool approvals are disabled on a public bind.");
+
+        if (failures.Count > 0)
+            return ValueTask.FromResult(Failed("Public/non-loopback bind is missing required hardening.", Join([.. failures, .. warnings])));
+        if (warnings.Count > 0)
+            return ValueTask.FromResult(Warning("Public bind has posture warning(s).", Join(warnings)));
+
+        return ValueTask.FromResult(Passed("Public bind hardening posture is acceptable."));
+    }
+
+    private static bool UnsafeLocalToolingExposed(GatewayConfig config)
+    {
+        if (IsUnsafeLocalExecutionToolExposed(config, "shell", ToolSandboxMode.Prefer))
+            return true;
+
+        if (IsUnsafeLocalExecutionToolExposed(config, "process", ToolSandboxMode.Prefer))
+            return true;
+
+        if (config.Plugins.Native.CodeExec.Enabled &&
+            IsLocalExecutionRoute(config, "code_exec") &&
+            !ToolSandboxPolicy.IsRequireSandboxed(config, "code_exec", ToolSandboxMode.Prefer))
+        {
+            return true;
+        }
+
+        return config.Tooling.AllowedWriteRoots.Contains("*", StringComparer.Ordinal) ||
+               config.Tooling.AllowedReadRoots.Contains("*", StringComparer.Ordinal);
+    }
+
+    private static bool IsUnsafeLocalExecutionToolExposed(
+        GatewayConfig config,
+        string toolName,
+        ToolSandboxMode defaultMode)
+        => config.Tooling.AllowShell &&
+           IsLocalExecutionRoute(config, toolName) &&
+           !ToolSandboxPolicy.IsRequireSandboxed(config, toolName, defaultMode);
+
+    private static bool IsLocalExecutionRoute(GatewayConfig config, string toolName)
+    {
+        if (TryResolveExecutionBackend(config, toolName, out var backendName))
+            return string.Equals(backendName, ExecutionBackendType.Local, StringComparison.OrdinalIgnoreCase);
+
+        return string.Equals(config.Execution.DefaultBackend, ExecutionBackendType.Local, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryResolveExecutionBackend(GatewayConfig config, string toolName, out string? backendName)
+    {
+        backendName = null;
+        if (!config.Execution.Enabled)
+            return false;
+
+        if (config.Execution.Tools.TryGetValue(toolName, out var route) && !string.IsNullOrWhiteSpace(route.Backend))
+        {
+            backendName = route.Backend;
+            return true;
+        }
+
+        if (string.Equals(toolName, "process", StringComparison.OrdinalIgnoreCase) &&
+            config.Execution.Tools.TryGetValue("shell", out var shellRoute) &&
+            !string.IsNullOrWhiteSpace(shellRoute.Backend))
+        {
+            backendName = shellRoute.Backend;
+            return true;
+        }
+
+        return false;
+    }
+}
+
+internal sealed class UrlSafetyDefaultsScenario()
+    : HarnessRegressionScenarioBase(
+        "security.url_safety_defaults",
+        "URL safety defaults",
+        HarnessRegressionCategory.Security)
+{
+    protected override ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var defaults = new UrlSafetyConfig();
+        var blocked = new[]
+        {
+            "http://localhost/",
+            "http://127.0.0.1/",
+            "http://10.0.0.1/",
+            "http://169.254.169.254/"
+        };
+        var allowedFailures = blocked
+            .Select(url => new { Url = url, Result = UrlSafetyValidator.ValidateHttpUrl(new Uri(url), defaults, resolveDns: false) })
+            .Where(item => item.Result.Allowed)
+            .Select(item => item.Url)
+            .ToArray();
+
+        if (allowedFailures.Length > 0)
+            return ValueTask.FromResult(Failed("Default URL safety did not block private target(s).", Join(allowedFailures)));
+
+        if (context.Config?.Tooling.UrlSafety is { Enabled: false } ||
+            context.Config?.Tooling.UrlSafety is { BlockPrivateNetworkTargets: false })
+        {
+            return ValueTask.FromResult(Warning(
+                "Default URL safety blocks private targets, but the loaded config weakens URL safety.",
+                "Set Tooling.UrlSafety.Enabled=true and Tooling.UrlSafety.BlockPrivateNetworkTargets=true."));
+        }
+
+        return ValueTask.FromResult(Passed("Default URL safety blocks loopback, private, and metadata targets."));
+    }
+}
+
+internal sealed class ToolApprovalPolicyScenario()
+    : HarnessRegressionScenarioBase(
+        "approvals.tool_approval_policy",
+        "Tool approval policy",
+        HarnessRegressionCategory.Approvals)
+{
+    private static readonly string[] HighRiskTools = ["shell", "code_exec", "git", "external_cli", "payment"];
+
+    protected override ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var missing = new List<string>();
+        foreach (var tool in HighRiskTools)
+        {
+            var descriptor = ToolGovernanceDescriptorCatalog.Resolve(
+                tool,
+                description: "",
+                ToolActionPolicyResolver.Resolve(tool, "{}"));
+            if (!descriptor.RequiresApproval)
+                missing.Add(tool);
+        }
+
+        if (missing.Count > 0)
+            return ValueTask.FromResult(Failed("High-risk tool descriptors no longer require approval.", Join(missing)));
+
+        var supervised = new GatewayConfig
+        {
+            Tooling =
+            {
+                AutonomyMode = "supervised",
+                RequireToolApproval = true,
+                ApprovalRequiredTools = ["shell", "write_file", "code_exec", "git", "external_cli", "payment"]
+            }
+        };
+        var configuredMissing = HighRiskTools
+            .Where(tool => !supervised.Tooling.ApprovalRequiredTools.Contains(tool, StringComparer.OrdinalIgnoreCase))
+            .ToArray();
+
+        if (configuredMissing.Length > 0)
+            return ValueTask.FromResult(Failed("Synthetic supervised approval policy does not cover high-risk tool(s).", Join(configuredMissing)));
+
+        if (context.Config?.Tooling is { AutonomyMode: "supervised", RequireToolApproval: false })
+        {
+            return ValueTask.FromResult(Warning(
+                "High-risk tool descriptors require approval, but the loaded supervised config has RequireToolApproval=false.",
+                "Run openclaw admin approvals simulate --tool shell to inspect effective runtime policy."));
+        }
+
+        return ValueTask.FromResult(Passed("High-risk tool descriptors and supervised approval policy remain approval-first."));
+    }
+}
+
+internal sealed class MemoryStoreRoundTripScenario()
+    : HarnessRegressionScenarioBase(
+        "memory.store_round_trip",
+        "Memory store round-trip",
+        HarnessRegressionCategory.Memory)
+{
+    protected override async ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        var root = HarnessRegressionPaths.Child(context.TempWorkspacePath, "memory");
+        await using var store = new FileMemoryStore(root, maxCachedSessions: 4);
+        const string key = "harness:regression:note";
+        const string content = "Harness regression memory note.";
+
+        await store.SaveNoteAsync(key, content, cancellationToken);
+        var loaded = await store.LoadNoteAsync(key, cancellationToken);
+        var listed = await store.ListNotesWithPrefixAsync("harness:", cancellationToken);
+        var hits = await ((IMemoryNoteSearch)store).SearchNotesAsync("regression memory", "harness:", 5, cancellationToken);
+
+        if (!string.Equals(content, loaded, StringComparison.Ordinal))
+            return Failed("Memory note did not load with the saved content.");
+        if (!listed.Contains(key, StringComparer.Ordinal))
+            return Failed("Memory note prefix listing did not include the saved note.");
+        if (!hits.Any(hit => string.Equals(hit.Key, key, StringComparison.Ordinal)))
+            return Failed("Memory note search did not find the saved note.");
+
+        return Passed("File memory store saved, loaded, listed, and searched a note.");
+    }
+}
+
+internal sealed class SessionStoreRoundTripScenario()
+    : HarnessRegressionScenarioBase(
+        "sessions.store_round_trip",
+        "Session store round-trip",
+        HarnessRegressionCategory.Sessions)
+{
+    protected override async ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        var root = HarnessRegressionPaths.Child(context.TempWorkspacePath, "sessions");
+        await using var store = new FileMemoryStore(root, maxCachedSessions: 4);
+        var session = new Session
+        {
+            Id = "sess_harness_regression",
+            ChannelId = "harness",
+            SenderId = "regression"
+        };
+
+        await store.SaveSessionAsync(session, cancellationToken);
+        var loaded = await store.GetSessionAsync(session.Id, cancellationToken);
+
+        return loaded is not null &&
+               loaded.Id == session.Id &&
+               loaded.ChannelId == session.ChannelId &&
+               loaded.SenderId == session.SenderId
+            ? Passed("File session store saved and loaded a session.")
+            : Failed("File session store did not load the saved session.");
+    }
+}
+
+internal sealed class HarnessContractSerializationScenario()
+    : HarnessRegressionScenarioBase(
+        "harness.contract_serialization",
+        "Harness Contract serialization",
+        HarnessRegressionCategory.Harness)
+{
+    protected override ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var contract = new HarnessContract
+        {
+            Id = "hctr_regression",
+            Status = HarnessContractStatus.Proposed,
+            Goal = "Verify harness model serialization.",
+            ApprovalRequired = HarnessContractApprovalRequirements.Required,
+            PlannedActions =
+            [
+                new HarnessContractAction
+                {
+                    Id = "act_read",
+                    Title = "Read docs",
+                    ToolName = "read_file",
+                    ActionType = "read"
+                }
+            ],
+            VerificationPlan =
+            [
+                new HarnessContractVerificationStep
+                {
+                    Id = "verify_json",
+                    Title = "JSON round-trip",
+                    Kind = "serialization"
+                }
+            ]
+        };
+
+        var json = JsonSerializer.Serialize(contract, CoreJsonContext.Default.HarnessContract);
+        var restored = JsonSerializer.Deserialize(json, CoreJsonContext.Default.HarnessContract);
+
+        return restored is not null &&
+               restored.Id == contract.Id &&
+               restored.PlannedActions.Count == 1 &&
+               restored.VerificationPlan.Count == 1
+            ? ValueTask.FromResult(Passed("Harness Contract model round-tripped through source-generated JSON."))
+            : ValueTask.FromResult(Failed("Harness Contract model did not round-trip correctly."));
+    }
+}
+
+internal sealed class EvidenceBundleSerializationScenario()
+    : HarnessRegressionScenarioBase(
+        "harness.evidence_bundle_serialization",
+        "Evidence Bundle serialization",
+        HarnessRegressionCategory.Harness)
+{
+    protected override ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var bundle = new EvidenceBundle
+        {
+            Id = "evb_regression",
+            Title = "Harness regression evidence",
+            Summary = "Synthetic evidence bundle for regression serialization.",
+            Confidence = EvidenceConfidenceLevels.High,
+            HarnessContractId = "hctr_regression",
+            Checks =
+            [
+                new EvidenceCheck
+                {
+                    Id = "check_round_trip",
+                    Name = "Round-trip",
+                    Status = EvidenceCheckStatuses.Passed,
+                    Summary = "Model round-tripped."
+                }
+            ]
+        };
+
+        var json = JsonSerializer.Serialize(bundle, CoreJsonContext.Default.EvidenceBundle);
+        var restored = JsonSerializer.Deserialize(json, CoreJsonContext.Default.EvidenceBundle);
+
+        return restored is not null &&
+               restored.Id == bundle.Id &&
+               restored.Checks.Count == 1 &&
+               restored.HarnessContractId == bundle.HarnessContractId
+            ? ValueTask.FromResult(Passed("Evidence Bundle model round-tripped through source-generated JSON."))
+            : ValueTask.FromResult(Failed("Evidence Bundle model did not round-trip correctly."));
+    }
+}
+
+internal sealed class GovernanceLedgerSerializationScenario()
+    : HarnessRegressionScenarioBase(
+        "harness.governance_ledger_serialization",
+        "Governance Ledger serialization",
+        HarnessRegressionCategory.Harness)
+{
+    protected override ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var entry = new GovernanceLedgerEntry
+        {
+            Id = "gov_regression",
+            Decision = GovernanceDecisions.Approved,
+            Status = GovernanceDecisionStatuses.Active,
+            Source = GovernanceLedgerSources.ToolApproval,
+            ToolName = "shell",
+            ActionSummary = "Run a supervised shell command.",
+            RiskLevel = GovernanceRiskLevels.High,
+            Scope = GovernanceScopes.Session,
+            HarnessContractId = "hctr_regression",
+            EvidenceBundleId = "evb_regression",
+            PolicyHint = new GovernancePolicyHint
+            {
+                RequiresReview = true,
+                Notes = "Review before reuse."
+            }
+        };
+
+        var json = JsonSerializer.Serialize(entry, CoreJsonContext.Default.GovernanceLedgerEntry);
+        var restored = JsonSerializer.Deserialize(json, CoreJsonContext.Default.GovernanceLedgerEntry);
+
+        return restored is not null &&
+               restored.Id == entry.Id &&
+               restored.Decision == GovernanceDecisions.Approved &&
+               restored.PolicyHint is { RequiresReview: true }
+            ? ValueTask.FromResult(Passed("Governance Ledger entry round-tripped through source-generated JSON."))
+            : ValueTask.FromResult(Failed("Governance Ledger entry did not round-trip correctly."));
+    }
+}
+
+internal sealed class McpInitializeShapeScenario()
+    : HarnessRegressionScenarioBase(
+        "mcp.initialize_shape",
+        "MCP initialize shape",
+        HarnessRegressionCategory.Mcp)
+{
+    protected override ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var initialize = new McpInitializeRequest
+        {
+            ProtocolVersion = "2025-03-26",
+            ClientInfo = new McpClientInfo { Name = "openclaw-harness", Version = "1.0.0" }
+        };
+        var rpc = new McpJsonRpcRequest
+        {
+            Id = "1",
+            Method = "initialize",
+            Params = JsonSerializer.SerializeToElement(
+                initialize,
+                HarnessRegressionJsonContext.Default.McpInitializeRequest)
+        };
+
+        var json = JsonSerializer.Serialize(rpc, HarnessRegressionJsonContext.Default.McpJsonRpcRequest);
+        var restored = JsonSerializer.Deserialize(json, HarnessRegressionJsonContext.Default.McpJsonRpcRequest);
+
+        return restored is not null &&
+               restored.Jsonrpc == "2.0" &&
+               restored.Method == "initialize" &&
+               restored.Params.TryGetProperty("clientInfo", out var clientInfo) &&
+               clientInfo.TryGetProperty("name", out var name) &&
+               name.GetString() == "openclaw-harness"
+            ? ValueTask.FromResult(Passed("MCP initialize request shape serializes without running a gateway."))
+            : ValueTask.FromResult(Failed("MCP initialize request shape did not serialize correctly."));
+    }
+}
+
+internal sealed class OpenAiCompatRequestShapeScenario()
+    : HarnessRegressionScenarioBase(
+        "openai_compat.request_shape",
+        "OpenAI-compatible request shape",
+        HarnessRegressionCategory.OpenAiCompat)
+{
+    protected override ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        const string json = """
+            {
+              "model": "gpt-4o-mini",
+              "messages": [{ "role": "user", "content": "ping" }],
+              "stream": false,
+              "max_tokens": 32
+            }
+            """;
+
+        var request = JsonSerializer.Deserialize(json, CoreJsonContext.Default.OpenAiChatCompletionRequest);
+        if (request is null || request.Messages.Count != 1 || request.Messages[0].Content.ToPromptText() != "ping")
+            return ValueTask.FromResult(Failed("OpenAI-compatible chat completion request did not parse."));
+
+        var serialized = JsonSerializer.Serialize(request, CoreJsonContext.Default.OpenAiChatCompletionRequest);
+        return serialized.Contains("\"max_tokens\"", StringComparison.Ordinal)
+            ? ValueTask.FromResult(Passed("OpenAI-compatible request shape parses and serializes without a provider."))
+            : ValueTask.FromResult(Failed("OpenAI-compatible request serialization lost max_tokens shape."));
+    }
+}
+
+internal sealed class LearningProposalReviewFirstScenario()
+    : HarnessRegressionScenarioBase(
+        "harness.learning_proposal_review_first",
+        "Learning proposal review-first default",
+        HarnessRegressionCategory.Harness)
+{
+    protected override ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var defaults = new LearningConfig();
+        if (!defaults.ReviewRequired)
+            return ValueTask.FromResult(Failed("LearningConfig defaults no longer require review."));
+
+        if (context.Config?.Learning is { Enabled: true, ReviewRequired: false })
+        {
+            return ValueTask.FromResult(Warning(
+                "Learning defaults require review, but the loaded config disables learning review.",
+                "Set Learning:ReviewRequired=true for review-first harness evolution."));
+        }
+
+        return ValueTask.FromResult(Passed("Learning proposals default to review-required."));
+    }
+}
+
+internal sealed class ManagedSkillValidationScenario()
+    : HarnessRegressionScenarioBase(
+        "tools.managed_skill_validation",
+        "Managed skill validation",
+        HarnessRegressionCategory.Tools)
+{
+    protected override async ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        var skillRoot = HarnessRegressionPaths.Child(context.TempWorkspacePath, "managed-skill");
+        Directory.CreateDirectory(skillRoot);
+        await File.WriteAllTextAsync(
+            Path.Join(skillRoot, "SKILL.md"),
+            """
+            ---
+            name: harness-regression-demo
+            description: Deterministic managed skill validation fixture.
+            metadata: {"always":true}
+            ---
+            Use this deterministic skill for harness regression checks.
+            """,
+            cancellationToken);
+
+        var inspection = SkillInspector.InspectPath(skillRoot, SkillSource.Managed);
+        return inspection.Success &&
+               inspection.Definition is not null &&
+               inspection.Definition.Name == "harness-regression-demo"
+            ? Passed("Managed SKILL.md draft parsed successfully.", $"Skill file: {inspection.SkillFilePath}")
+            : Failed("Managed SKILL.md draft validation failed.", error: inspection.ErrorMessage);
+    }
+}
+
+internal sealed class TailscaleServeProfileNonPublicScenario()
+    : HarnessRegressionScenarioBase(
+        "deployment.tailscale_serve_profile_non_public",
+        "Tailscale Serve profile non-public bind",
+        HarnessRegressionCategory.Deployment)
+{
+    protected override ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var synthetic = new GatewayConfig();
+        synthetic.Deployment.Mode = "tailscale-serve";
+        if (!TailscaleServeAdvisor.IsTailscaleServeConfigured(synthetic) ||
+            !BindAddressClassifier.IsLoopbackBind(synthetic.BindAddress))
+        {
+            return ValueTask.FromResult(Failed("Tailscale Serve profile default is no longer loopback-only."));
+        }
+
+        if (context.Config is not null &&
+            TailscaleServeAdvisor.IsTailscaleServeConfigured(context.Config) &&
+            !BindAddressClassifier.IsLoopbackBind(context.Config.BindAddress))
+        {
+            return ValueTask.FromResult(Failed(
+                "Loaded Tailscale Serve config is public-bound.",
+                "Tailscale Serve should proxy to a loopback OpenClaw gateway by default."));
+        }
+
+        return ValueTask.FromResult(Passed("Tailscale Serve profile remains loopback-bound by default."));
+    }
+}
+
+internal sealed class HarnessRegressionDocsScenario()
+    : HarnessRegressionScenarioBase(
+        "docs.harness_regression_docs",
+        "Harness regression docs",
+        HarnessRegressionCategory.Docs)
+{
+    protected override ValueTask<HarnessRegressionScenarioResult> EvaluateAsync(
+        HarnessRegressionContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var root = FindRepositoryRoot();
+        if (root is null)
+        {
+            return ValueTask.FromResult(NotApplicable(
+                "Repository docs tree was not found from this runtime location.",
+                "Installed binaries may not include source documentation."));
+        }
+
+        var docPath = Path.Join(root, "docs", "HARNESS_REGRESSION.md");
+        var indexPath = Path.Join(root, "docs", "README.md");
+        var siteMapPath = Path.Join(root, "docs", "SITE_MAP.md");
+        var missing = new List<string>();
+
+        if (!File.Exists(docPath))
+            missing.Add("docs/HARNESS_REGRESSION.md");
+        if (!File.Exists(indexPath) || !File.ReadAllText(indexPath).Contains("HARNESS_REGRESSION.md", StringComparison.Ordinal))
+            missing.Add("docs/README.md link");
+        if (!File.Exists(siteMapPath) || !File.ReadAllText(siteMapPath).Contains("HARNESS_REGRESSION.md", StringComparison.Ordinal))
+            missing.Add("docs/SITE_MAP.md link");
+
+        return missing.Count == 0
+            ? ValueTask.FromResult(Passed("Harness regression documentation is present and indexed."))
+            : ValueTask.FromResult(Failed("Harness regression documentation is missing or not indexed.", Join(missing)));
+    }
+
+    private static string? FindRepositoryRoot()
+    {
+        foreach (var start in new[] { Directory.GetCurrentDirectory(), AppContext.BaseDirectory })
+        {
+            var candidate = new DirectoryInfo(start);
+            while (candidate is not null)
+            {
+                if (File.Exists(Path.Join(candidate.FullName, "README.md")) &&
+                    Directory.Exists(Path.Join(candidate.FullName, "docs")))
+                {
+                    return candidate.FullName;
+                }
+
+                candidate = candidate.Parent;
+            }
+        }
+
+        return null;
+    }
+}
+
+internal static class HarnessRegressionScenarioText
+{
+    public static string Join(IEnumerable<string> values)
+        => string.Join(Environment.NewLine, values.Where(static value => !string.IsNullOrWhiteSpace(value)));
+}
+
+internal static class HarnessRegressionPaths
+{
+    public static string Child(string root, string childName)
+    {
+        var fullRoot = Path.GetFullPath(root);
+        var fullChild = Path.GetFullPath(Path.Join(fullRoot, Path.GetFileName(childName)));
+        var rootPrefix = fullRoot.EndsWith(Path.DirectorySeparatorChar)
+            ? fullRoot
+            : fullRoot + Path.DirectorySeparatorChar;
+
+        if (!fullChild.StartsWith(rootPrefix, StringComparison.Ordinal))
+            throw new InvalidOperationException($"Resolved harness path escaped the temp workspace: {childName}");
+
+        return fullChild;
+    }
+}

--- a/src/OpenClaw.Testing/OpenClaw.Testing.csproj
+++ b/src/OpenClaw.Testing/OpenClaw.Testing.csproj
@@ -7,4 +7,8 @@
     <Description>Scenario-based testing harness primitives for OpenClaw.NET agent traces and oracles.</Description>
     <PackageTags>openclaw;ai;agent;testing;dotnet</PackageTags>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OpenClaw.Client\OpenClaw.Client.csproj" />
+    <ProjectReference Include="..\OpenClaw.Core\OpenClaw.Core.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/OpenClaw.Tests/HarnessRegressionTests.cs
+++ b/src/OpenClaw.Tests/HarnessRegressionTests.cs
@@ -1,0 +1,353 @@
+using System.Text.Json;
+using OpenClaw.Cli;
+using OpenClaw.Core.Models;
+using OpenClaw.Testing;
+using Xunit;
+using CoreGatewayConfigFile = OpenClaw.Core.Setup.GatewayConfigFile;
+
+namespace OpenClaw.Tests;
+
+public sealed class HarnessRegressionTests
+{
+    [Fact]
+    public async Task Runner_ExecutesScenarios()
+    {
+        var scenario = new StubScenario("harness.stub", HarnessRegressionCategory.Harness, HarnessRegressionScenarioStatus.Passed);
+        var report = await new HarnessRegressionRunner([scenario]).RunAsync();
+
+        Assert.Single(report.Results);
+        Assert.Equal("harness.stub", report.Results[0].Id);
+        Assert.Equal(1, scenario.RunCount);
+    }
+
+    [Fact]
+    public async Task PassingScenarios_ProducePassedStatus()
+    {
+        var report = await new HarnessRegressionRunner([
+            new StubScenario("harness.pass", HarnessRegressionCategory.Harness, HarnessRegressionScenarioStatus.Passed)
+        ]).RunAsync();
+
+        Assert.Equal(HarnessRegressionScenarioStatus.Passed, report.OverallStatus);
+        Assert.Equal(1, report.Summary.Passed);
+        Assert.Equal(0, HarnessRegressionRunner.GetExitCode(report));
+    }
+
+    [Fact]
+    public async Task FailingScenario_CausesNonZeroExit()
+    {
+        var report = await new HarnessRegressionRunner([
+            new StubScenario("harness.fail", HarnessRegressionCategory.Harness, HarnessRegressionScenarioStatus.Failed)
+        ]).RunAsync();
+
+        Assert.Equal(HarnessRegressionScenarioStatus.Failed, report.OverallStatus);
+        Assert.Equal(1, HarnessRegressionRunner.GetExitCode(report));
+    }
+
+    [Fact]
+    public async Task SkippedScenario_DoesNotFailByDefault()
+    {
+        var report = await new HarnessRegressionRunner([
+            new StubScenario("harness.skip", HarnessRegressionCategory.Harness, HarnessRegressionScenarioStatus.Skipped)
+        ]).RunAsync();
+
+        Assert.Equal(1, report.Summary.Skipped);
+        Assert.Equal(0, HarnessRegressionRunner.GetExitCode(report));
+    }
+
+    [Fact]
+    public async Task StrictMode_TreatsRequiredWarningAsFailure()
+    {
+        var report = await new HarnessRegressionRunner([
+            new StubScenario("harness.warn", HarnessRegressionCategory.Harness, HarnessRegressionScenarioStatus.Warning)
+        ]).RunAsync(new HarnessRegressionOptions { Strict = true });
+
+        Assert.Equal(HarnessRegressionScenarioStatus.Failed, report.OverallStatus);
+        Assert.Equal(1, HarnessRegressionRunner.GetExitCode(report));
+    }
+
+    [Fact]
+    public async Task Runner_NormalizesScenarioStatusBeforeFormatting()
+    {
+        var report = await new HarnessRegressionRunner([
+            new StubScenario("harness.upper", HarnessRegressionCategory.Harness, "FAILED")
+        ]).RunAsync();
+
+        Assert.Equal(HarnessRegressionScenarioStatus.Failed, report.Results[0].Status);
+        Assert.Contains("FAIL harness.upper", HarnessRegressionReportFormatter.ToText(report), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Runner_ClampsNegativeScenarioDuration()
+    {
+        var report = await new HarnessRegressionRunner([
+            new NegativeDurationScenario()
+        ]).RunAsync();
+
+        Assert.True(report.Results[0].DurationMs >= 0);
+    }
+
+    [Fact]
+    public async Task Runner_CleansTempWorkspaceWhenCancelled()
+    {
+        var scenario = new CancellingScenario();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await new HarnessRegressionRunner([scenario]).RunAsync());
+
+        Assert.NotNull(scenario.TempWorkspacePath);
+        Assert.False(Directory.Exists(scenario.TempWorkspacePath));
+    }
+
+    [Fact]
+    public async Task CategoryFilter_SelectsMatchingScenarios()
+    {
+        var security = new StubScenario("security.pass", HarnessRegressionCategory.Security, HarnessRegressionScenarioStatus.Passed);
+        var memory = new StubScenario("memory.pass", HarnessRegressionCategory.Memory, HarnessRegressionScenarioStatus.Passed);
+
+        var report = await new HarnessRegressionRunner([security, memory]).RunAsync(
+            new HarnessRegressionOptions { Category = HarnessRegressionCategory.Security });
+
+        Assert.Single(report.Results);
+        Assert.Equal("security.pass", report.Results[0].Id);
+        Assert.Equal(1, security.RunCount);
+        Assert.Equal(0, memory.RunCount);
+    }
+
+    [Fact]
+    public async Task JsonOutput_SerializesReport()
+    {
+        var report = await new HarnessRegressionRunner([
+            new StubScenario("harness.json", HarnessRegressionCategory.Harness, HarnessRegressionScenarioStatus.Passed)
+        ]).RunAsync();
+
+        var json = HarnessRegressionReportFormatter.ToJson(report);
+        var restored = JsonSerializer.Deserialize(json, HarnessRegressionJsonContext.Default.HarnessRegressionReport);
+
+        Assert.NotNull(restored);
+        Assert.Equal(report.Id, restored!.Id);
+        Assert.Single(restored.Results);
+    }
+
+    [Fact]
+    public async Task TextOutput_ContainsSummary()
+    {
+        var report = await new HarnessRegressionRunner([
+            new StubScenario("harness.text", HarnessRegressionCategory.Harness, HarnessRegressionScenarioStatus.Passed)
+        ]).RunAsync();
+
+        var text = HarnessRegressionReportFormatter.ToText(report);
+
+        Assert.Contains("OpenClaw Harness Regression", text, StringComparison.Ordinal);
+        Assert.Contains("PASS harness.text", text, StringComparison.Ordinal);
+        Assert.Contains("Summary:", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task OfflineMode_SkipsProviderCredentialAndNetworkChecks()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var configPath = Path.Join(root, "openclaw.settings.json");
+            await CoreGatewayConfigFile.SaveAsync(new GatewayConfig
+            {
+                Llm =
+                {
+                    Provider = "openai",
+                    Model = "gpt-4o",
+                    ApiKey = null
+                }
+            }, configPath);
+
+            var report = await new HarnessRegressionRunner().RunAsync(new HarnessRegressionOptions
+            {
+                ConfigPath = configPath,
+                Category = HarnessRegressionCategory.Providers,
+                Offline = true
+            });
+
+            var result = Assert.Single(report.Results);
+            Assert.Equal("providers.config_shape", result.Id);
+            Assert.Equal(HarnessRegressionScenarioStatus.Passed, result.Status);
+            Assert.Contains("Credential and network checks were skipped", result.Details ?? "", StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task MemoryStoreRoundTripScenario_WorksWithTempPath()
+    {
+        var report = await new HarnessRegressionRunner().RunAsync(new HarnessRegressionOptions
+        {
+            Category = HarnessRegressionCategory.Memory
+        });
+
+        var result = Assert.Single(report.Results);
+        Assert.Equal("memory.store_round_trip", result.Id);
+        Assert.Equal(HarnessRegressionScenarioStatus.Passed, result.Status);
+    }
+
+    [Fact]
+    public async Task HarnessModelSerializationScenarios_Run()
+    {
+        var report = await new HarnessRegressionRunner().RunAsync(new HarnessRegressionOptions
+        {
+            Category = HarnessRegressionCategory.Harness
+        });
+
+        Assert.Contains(report.Results, result => result.Id == "harness.contract_serialization" && result.Status == HarnessRegressionScenarioStatus.Passed);
+        Assert.Contains(report.Results, result => result.Id == "harness.evidence_bundle_serialization" && result.Status == HarnessRegressionScenarioStatus.Passed);
+        Assert.Contains(report.Results, result => result.Id == "harness.governance_ledger_serialization" && result.Status == HarnessRegressionScenarioStatus.Passed);
+    }
+
+    [Fact]
+    public async Task HarnessCommand_RunsTextOutput()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var exit = await HarnessCommands.RunAsync(["test", "--category", "memory"], output, error);
+
+        Assert.Equal(0, exit);
+        Assert.Equal(string.Empty, error.ToString());
+        Assert.Contains("OpenClaw Harness Regression", output.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Summary:", output.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HarnessCommand_RunsJsonOutput()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var exit = await HarnessCommands.RunAsync(["test", "--category", "memory", "--json"], output, error);
+        var restored = JsonSerializer.Deserialize(output.ToString(), HarnessRegressionJsonContext.Default.HarnessRegressionReport);
+
+        Assert.Equal(0, exit);
+        Assert.Equal(string.Empty, error.ToString());
+        Assert.NotNull(restored);
+        Assert.Equal("memory.store_round_trip", Assert.Single(restored!.Results).Id);
+    }
+
+    [Fact]
+    public async Task HarnessCommand_StrictReturnsNonZeroForSkippedRequiredScenario()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            using var output = new StringWriter();
+            using var error = new StringWriter();
+
+            var exit = await HarnessCommands.RunAsync(
+                ["test", "--config", Path.Join(root, "missing.json"), "--category", "security", "--strict"],
+                output,
+                error);
+
+            Assert.Equal(1, exit);
+            Assert.Equal(string.Empty, error.ToString());
+            Assert.Contains("SKIP security.public_bind_hardening", output.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RegressionAlias_RunsHarnessTest()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var exit = await HarnessCommands.RunRegressionAliasAsync(["test", "--category", "sessions"], output, error);
+
+        Assert.Equal(0, exit);
+        Assert.Equal(string.Empty, error.ToString());
+        Assert.Contains("sessions.store_round_trip", output.ToString(), StringComparison.Ordinal);
+    }
+
+    private static string CreateTempRoot()
+    {
+        var root = Path.Join(Path.GetTempPath(), $"openclaw-harness-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private sealed class CancellingScenario : IHarnessRegressionScenario
+    {
+        public string Id => "harness.cancel";
+        public string Name => Id;
+        public string Category => HarnessRegressionCategory.Harness;
+        public bool Required => true;
+        public string? TempWorkspacePath { get; private set; }
+
+        public ValueTask<HarnessRegressionScenarioResult> RunAsync(
+            HarnessRegressionContext context,
+            CancellationToken cancellationToken = default)
+        {
+            TempWorkspacePath = context.TempWorkspacePath;
+            throw new OperationCanceledException(cancellationToken);
+        }
+    }
+
+    private sealed class NegativeDurationScenario : IHarnessRegressionScenario
+    {
+        public string Id => "harness.negative_duration";
+        public string Name => Id;
+        public string Category => HarnessRegressionCategory.Harness;
+        public bool Required => true;
+
+        public ValueTask<HarnessRegressionScenarioResult> RunAsync(
+            HarnessRegressionContext context,
+            CancellationToken cancellationToken = default)
+        {
+            var now = DateTimeOffset.UtcNow;
+            return ValueTask.FromResult(new HarnessRegressionScenarioResult
+            {
+                Id = Id,
+                Name = Name,
+                Category = Category,
+                Status = HarnessRegressionScenarioStatus.Passed,
+                Summary = "negative duration",
+                StartedAtUtc = now,
+                CompletedAtUtc = now,
+                DurationMs = -1
+            });
+        }
+    }
+
+    private sealed class StubScenario(
+        string id,
+        string category,
+        string status,
+        bool required = true) : IHarnessRegressionScenario
+    {
+        public string Id { get; } = id;
+        public string Name => Id;
+        public string Category { get; } = category;
+        public bool Required { get; } = required;
+        public int RunCount { get; private set; }
+
+        public ValueTask<HarnessRegressionScenarioResult> RunAsync(
+            HarnessRegressionContext context,
+            CancellationToken cancellationToken = default)
+        {
+            RunCount++;
+            var now = DateTimeOffset.UtcNow;
+            return ValueTask.FromResult(new HarnessRegressionScenarioResult
+            {
+                Id = Id,
+                Name = Name,
+                Category = Category,
+                Status = status,
+                Required = Required,
+                Summary = $"{status} summary",
+                StartedAtUtc = now,
+                CompletedAtUtc = now
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds an offline-first Harness Regression Suite for OpenClaw.NET as an explicitly invoked CLI/checking surface.

- Adds `openclaw harness test`, `openclaw harness regression`, and `openclaw regression test`.
- Introduces reusable regression report/result models, runner, context, JSON/text formatters, and scenario interface in `OpenClaw.Testing`.
- Implements baseline offline scenarios for onboarding config loading, provider-shape validation, security posture, URL safety defaults, tool approval policy, memory/session round trips, harness model serialization, MCP/OpenAI-compatible request shapes, learning defaults, managed skill validation, deployment posture, and docs presence.
- Adds tests for runner behavior, strict/default exit handling, category filtering, JSON/text output, CLI aliases, offline provider behavior, memory round trip, and harness serialization checks.
- Documents usage in `docs/HARNESS_REGRESSION.md` and adds lightweight docs index/README links.

## Behavior Notes

The suite does not run automatically during normal runtime. It does not change normal chat behavior, provider behavior, tool execution, approvals, memory behavior, Companion setup, MCP routes, or OpenAI-compatible routes.

## Validation

- `dotnet build OpenClaw.Net.slnx`
- `dotnet test src/OpenClaw.Tests/OpenClaw.Tests.csproj --no-build --filter HarnessRegressionTests`
- `dotnet test OpenClaw.Net.slnx --no-build` (`1451/1451` passed)
- `dotnet publish src/OpenClaw.Cli/OpenClaw.Cli.csproj -c Release -r osx-arm64 --self-contained true`
- Smoke-tested `openclaw harness test`, category filters, and JSON output from both source and published binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `openclaw harness test` (alias `openclaw regression test`) CLI to run offline regression checks; supports category filtering, `--strict`, `--json` output, `--output` file and built-in help.

* **New Features**
  * Built-in regression scenarios covering config/onboarding, providers/models, security/hardening, persistence, serialization, tooling, docs and recommendations; produces text or JSON reports and exit codes.

* **Documentation**
  * Added full Harness Regression Suite docs and updated docs index/navigation and README links.

* **Tests**
  * Added end-to-end tests for runner behavior, strict mode, filtering, cancellation cleanup, offline mode, formatting and CLI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/clawdotnet/openclaw.net/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->