### PR TITLE
Add JSON converter for IReadOnlySet<string>

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.x"
           cache-dependency-path: src/whatsapp-whatsmeow-worker/go.sum
 
       - name: Check Go module tidiness

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.x"
+          go-version: "1.26.4"
           cache-dependency-path: src/whatsapp-whatsmeow-worker/go.sum
 
       - name: Check Go module tidiness

--- a/src/OpenClaw.Core/Models/ToolingPolicyModels.cs
+++ b/src/OpenClaw.Core/Models/ToolingPolicyModels.cs
@@ -1,3 +1,6 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace OpenClaw.Core.Models;
 
 public sealed class ToolsetConfig
@@ -28,8 +31,49 @@ public sealed class ResolvedToolPreset
     public string Surface { get; init; } = "";
     public string EffectiveAutonomyMode { get; init; } = "";
     public bool RequireToolApproval { get; init; }
+
+    [JsonConverter(typeof(ReadOnlyStringSetJsonConverter))]
     public IReadOnlySet<string> AllowedTools { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    [JsonConverter(typeof(ReadOnlyStringSetJsonConverter))]
     public IReadOnlySet<string> ApprovalRequiredTools { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+}
+
+internal sealed class ReadOnlyStringSetJsonConverter : JsonConverter<IReadOnlySet<string>>
+{
+    public override bool HandleNull => true;
+
+    public override IReadOnlySet<string> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (reader.TokenType != JsonTokenType.StartArray)
+            throw new JsonException($"Expected a JSON array for {typeToConvert}.");
+
+        var values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndArray)
+                return values;
+            if (reader.TokenType == JsonTokenType.Null)
+                continue;
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException("Expected a string value in the tool set.");
+
+            values.Add(reader.GetString()!);
+        }
+
+        throw new JsonException("Unexpected end of JSON while reading the tool set.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, IReadOnlySet<string> value, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray();
+        foreach (var item in value)
+            writer.WriteStringValue(item);
+        writer.WriteEndArray();
+    }
 }
 
 public sealed class ToolActionDescriptor

--- a/src/OpenClaw.Core/Models/ToolingPolicyModels.cs
+++ b/src/OpenClaw.Core/Models/ToolingPolicyModels.cs
@@ -67,8 +67,14 @@ internal sealed class ReadOnlyStringSetJsonConverter : JsonConverter<IReadOnlySe
         throw new JsonException("Unexpected end of JSON while reading the tool set.");
     }
 
-    public override void Write(Utf8JsonWriter writer, IReadOnlySet<string> value, JsonSerializerOptions options)
+    public override void Write(Utf8JsonWriter writer, IReadOnlySet<string>? value, JsonSerializerOptions options)
     {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
         writer.WriteStartArray();
         foreach (var item in value)
             writer.WriteStringValue(item);

--- a/src/OpenClaw.Tests/EndpointConformanceTests.cs
+++ b/src/OpenClaw.Tests/EndpointConformanceTests.cs
@@ -47,4 +47,37 @@ public class EndpointConformanceTests
         Assert.True(root.TryGetProperty("uptime", out var uptime));
         Assert.Equal(42, uptime.GetInt64());
     }
+
+    [Fact]
+    public void IntegrationToolPresetsResponse_DeserializesToolCollections_Via_SourceGen()
+    {
+        const string json = """
+            {
+              "items": [
+                {
+                  "presetId": "web",
+                  "description": "Built-in preset 'web'.",
+                  "surface": "web",
+                  "effectiveAutonomyMode": "interactive",
+                  "requireToolApproval": true,
+                  "allowedTools": ["session_search", "profile_read"],
+                  "approvalRequiredTools": ["process", "automation"]
+                }
+              ]
+            }
+            """;
+
+        IntegrationToolPresetsResponse? response = null;
+        var exception = Record.Exception(() =>
+            response = JsonSerializer.Deserialize(json, CoreJsonContext.Default.IntegrationToolPresetsResponse));
+
+        Assert.Null(exception);
+        var preset = Assert.Single(response!.Items);
+        Assert.Contains("session_search", preset.AllowedTools, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("profile_read", preset.AllowedTools, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("process", preset.ApprovalRequiredTools, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("automation", preset.ApprovalRequiredTools, StringComparer.OrdinalIgnoreCase);
+        Assert.True(preset.AllowedTools.Contains("SESSION_SEARCH"));
+        Assert.True(preset.ApprovalRequiredTools.Contains("PROCESS"));
+    }
 }

--- a/src/OpenClaw.Tests/EndpointConformanceTests.cs
+++ b/src/OpenClaw.Tests/EndpointConformanceTests.cs
@@ -74,7 +74,8 @@ public class EndpointConformanceTests
             response = JsonSerializer.Deserialize(json, CoreJsonContext.Default.IntegrationToolPresetsResponse));
 
         Assert.Null(exception);
-        var preset = Assert.Single(response!.Items);
+        Assert.NotNull(response);
+        var preset = Assert.Single(response.Items);
         Assert.Contains("session_search", preset.AllowedTools, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("profile_read", preset.AllowedTools, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("process", preset.ApprovalRequiredTools, StringComparer.OrdinalIgnoreCase);

--- a/src/OpenClaw.Tests/EndpointConformanceTests.cs
+++ b/src/OpenClaw.Tests/EndpointConformanceTests.cs
@@ -1,4 +1,6 @@
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using OpenClaw.Core.Models;
 using Xunit;
 
@@ -79,5 +81,28 @@ public class EndpointConformanceTests
         Assert.Contains("automation", preset.ApprovalRequiredTools, StringComparer.OrdinalIgnoreCase);
         Assert.True(preset.AllowedTools.Contains("SESSION_SEARCH"));
         Assert.True(preset.ApprovalRequiredTools.Contains("PROCESS"));
+    }
+
+    [Fact]
+    public void ReadOnlyStringSetJsonConverter_WritesNullSet_AsNull()
+    {
+        var converter = CreateReadOnlyStringSetConverter();
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+
+        var exception = Record.Exception(() => converter.Write(writer, null!, CoreJsonContext.Default.Options));
+        writer.Flush();
+
+        Assert.Null(exception);
+        Assert.Equal("null", Encoding.UTF8.GetString(stream.ToArray()));
+    }
+
+    private static JsonConverter<IReadOnlySet<string>> CreateReadOnlyStringSetConverter()
+    {
+        var converterType = typeof(ResolvedToolPreset).Assembly.GetType(
+            "OpenClaw.Core.Models.ReadOnlyStringSetJsonConverter",
+            throwOnError: true)!;
+        return Assert.IsAssignableFrom<JsonConverter<IReadOnlySet<string>>>(
+            Activator.CreateInstance(converterType, nonPublic: true));
     }
 }


### PR DESCRIPTION

## Description
Implemented the issue #140 fix.

What changed:

Added a source-gen-compatible JSON converter for IReadOnlySet<string> in [ToolingPolicyModels.cs](vscode-webview://1a0bg72qn2k7fls9c37jn2mv90renbc53q58q3elmf82s65746ir/src/OpenClaw.Core/Models/ToolingPolicyModels.cs).
Deserializes JSON arrays into a case-insensitive HashSet<string>.
Preserves existing AllowedTools.Contains(...) / ApprovalRequiredTools.Contains(...) behavior.
Handles serialization as JSON arrays.
Added a regression test in [EndpointConformanceTests.cs](vscode-webview://1a0bg72qn2k7fls9c37jn2mv90renbc53q58q3elmf82s65746ir/src/OpenClaw.Tests/EndpointConformanceTests.cs).
Reproduces IntegrationToolPresetsResponse deserialization with allowedTools and approvalRequiredTools.
Verifies no exception is thrown.
Verifies the resulting sets retain case-insensitive lookup behavior.
Root cause:

System.Text.Json could serialize IReadOnlySet<string> but could not instantiate/populate it when deserializing IntegrationToolPresetsResponse, causing the NotSupportedException at $.items[0].allowedTools.
TDD evidence:

First ran the new focused regression test and confirmed it failed with the same System.NotSupportedException from issue #140.
Implemented the minimal converter fix.
Re-ran the focused regression test and it passed.

Introduce ReadOnlyStringSetJsonConverter to serialize/deserialize IReadOnlySet<string> as JSON arrays into case-insensitive HashSet instances (handles null as empty, skips null entries, and validates element types). Annotate AllowedTools and ApprovalRequiredTools on ResolvedToolPreset with the converter so System.Text.Json source-gen can correctly handle these properties. Add an integration unit test to verify deserialization via CoreJsonContext and ensure case-insensitive membership. Changes in ToolingPolicyModels.cs and EndpointConformanceTests.cs.

## Related Issues

[Fixes #140.]

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style implementation of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed locally (`dotnet test`)
- [ ] I have updated the documentation (README.md, comments) if required
- [ ] I have checked for security implications (input validation, authorization)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved JSON handling for tool preset collections: robust null handling, stricter validation of array inputs, and case-insensitive tool membership for more reliable imports and API interactions.

* **Tests**
  * Added conformance tests ensuring tool preset collections deserialize/serialize correctly (including null cases) and preserve expected items.

* **Chores**
  * CI workflow updated to accept the newer Go 1.26.x toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->