### PR TITLE
[codex] Polish architecture boundaries and MQTT split

### DIFF
--- a/.github/ISSUE_TEMPLATE/aot_compatibility.md
+++ b/.github/ISSUE_TEMPLATE/aot_compatibility.md
@@ -35,11 +35,19 @@ paste command here
 - PublishAot enabled: yes / no
 - Project or package affected:
 - Core surface or optional extension surface:
+- Dynamic/plugin-heavy surface involved: yes / no
+- Dashboard asset build skipped with `OpenClawSkipDashboardBuild=true`: yes / no
 
 ## Linker or trim warnings
 
 ```text
 paste warnings here
+```
+
+## Runtime error or startup diagnostic
+
+```text
+paste runtime error, startup diagnostic, or doctor output here
 ```
 
 ## Expected result
@@ -52,4 +60,4 @@ paste error output here
 
 ## Notes
 
-Please include whether this affects the default NativeAOT-friendly path or only an optional JIT/dynamic/plugin-heavy surface.
+Please include whether this affects the default NativeAOT-friendly path or only an optional protocol, provider, JIT, dynamic, or plugin-heavy surface.

--- a/.github/ISSUE_TEMPLATE/first_run_failure.md
+++ b/.github/ISSUE_TEMPLATE/first_run_failure.md
@@ -22,8 +22,19 @@ assignees: ""
 - OS:
 - Architecture:
 - .NET SDK version:
+- Node.js version, if a dashboard or plugin step failed:
 - Shell/terminal:
 - Commit SHA:
+
+## Runtime path
+
+- [ ] `samples/OpenClaw.HelloAgent`
+- [ ] `openclaw setup`
+- [ ] `openclaw start`
+- [ ] Direct Gateway run
+- [ ] Desktop Companion
+- [ ] Dashboard asset build
+- [ ] Optional plugin/extension path
 
 ## Command run
 

--- a/.github/ISSUE_TEMPLATE/industrial_adapter_proposal.md
+++ b/.github/ISSUE_TEMPLATE/industrial_adapter_proposal.md
@@ -19,6 +19,15 @@ What manufacturing, edge monitoring, operations, or industrial workflow should t
 - [ ] PLC-specific
 - [ ] Other
 
+## Deployment shape
+
+- [ ] Local loopback
+- [ ] Edge device
+- [ ] Factory network
+- [ ] Cloud gateway
+- [ ] Hybrid edge/cloud
+- [ ] Simulation or sample only
+
 ## Reuse boundary
 
 - [ ] Reusable infrastructure
@@ -32,6 +41,10 @@ If this is product/customer-specific, describe what should stay downstream inste
 ## Vendor neutrality
 
 Does this introduce a vendor-specific default, proprietary dependency, or customer-specific workflow?
+
+## Safety and security considerations
+
+Does this touch machine control, safety-critical signals, privileged network zones, credentials, or regulated operational data?
 
 ## Proposed shape
 

--- a/.github/ISSUE_TEMPLATE/plugin_compatibility.md
+++ b/.github/ISSUE_TEMPLATE/plugin_compatibility.md
@@ -1,0 +1,61 @@
+---
+name: Plugin compatibility
+about: Report a plugin, skill package, bridge, or optional extension compatibility issue
+title: "[Plugin Compatibility]: "
+labels: ["plugin-compatibility", "compatibility", "bug"]
+assignees: ""
+---
+
+## What failed?
+
+- [ ] Plugin/package discovery
+- [ ] `SKILL.md` loading
+- [ ] `api.registerTool()`
+- [ ] `api.registerService()`
+- [ ] JIT-only channel/command/hook/provider surface
+- [ ] Native dynamic .NET plugin
+- [ ] Optional protocol/provider package
+- [ ] Other
+
+## Runtime mode
+
+- `OpenClaw:Runtime:Mode`: `auto` / `aot` / `jit`
+- Dynamic code available: yes / no / unsure
+- NativeAOT publish: yes / no
+
+## Environment
+
+- OS:
+- Architecture:
+- .NET SDK version:
+- Node.js version, if using JS/TS plugins:
+- Commit SHA:
+
+## Plugin or package
+
+- Name:
+- Version or commit:
+- Source path or package URL:
+- Uses TypeScript: yes / no
+- Requires `jiti`: yes / no / unsure
+
+## Command or startup path
+
+```bash
+paste command here
+```
+
+## Expected result
+
+## Actual result
+
+```text
+paste diagnostics, logs, or error output here
+```
+
+## Scope and disclosure
+
+- Does this directly support a company, customer, or downstream commercial product use case?
+- Does this request introduce a vendor-specific default, proprietary dependency, or customer-specific workflow?
+
+Please redact secrets, tokens, private URLs, internal hostnames, and customer-identifying details.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: dotnet restore OpenClaw.Net.slnx
 
       - name: Build solution
-        run: dotnet build OpenClaw.Net.slnx --no-restore -c Release ${{ env.FAST_BUILD_PROPERTIES }}
+        run: dotnet build OpenClaw.Net.slnx --no-restore -c Release
 
       - name: Test standard targets
         run: dotnet test --no-build -c Release --verbosity normal --logger "trx;LogFileName=results.trx" src/OpenClaw.Tests
@@ -85,7 +85,7 @@ jobs:
         run: dotnet restore OpenClaw.Net.slnx -p:OpenClawEnableOpenSandbox=true
 
       - name: Build sandbox-enabled solution
-        run: dotnet build OpenClaw.Net.slnx --no-restore -c Release -p:OpenClawEnableOpenSandbox=true ${{ env.FAST_BUILD_PROPERTIES }}
+        run: dotnet build OpenClaw.Net.slnx --no-restore -c Release -p:OpenClawEnableOpenSandbox=true
 
       - name: Test sandbox-enabled targets
         run: dotnet test --no-build -c Release -p:OpenClawEnableOpenSandbox=true --verbosity normal --logger "trx;LogFileName=results-sandbox.trx" src/OpenClaw.Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ env:
   DOTNET_VERSION: "10.0.x"
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+  FAST_BUILD_PROPERTIES: "-p:OpenClawSkipDashboardBuild=true"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   go-whatsapp-security:
@@ -50,6 +56,14 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('OpenClaw.Net.slnx', '**/*.csproj', '**/*.props', '**/*.targets') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -59,7 +73,7 @@ jobs:
         run: dotnet restore OpenClaw.Net.slnx
 
       - name: Build solution
-        run: dotnet build OpenClaw.Net.slnx --no-restore -c Release
+        run: dotnet build OpenClaw.Net.slnx --no-restore -c Release ${{ env.FAST_BUILD_PROPERTIES }}
 
       - name: Test standard targets
         run: dotnet test --no-build -c Release --verbosity normal --logger "trx;LogFileName=results.trx" src/OpenClaw.Tests
@@ -71,7 +85,7 @@ jobs:
         run: dotnet restore OpenClaw.Net.slnx -p:OpenClawEnableOpenSandbox=true
 
       - name: Build sandbox-enabled solution
-        run: dotnet build OpenClaw.Net.slnx --no-restore -c Release -p:OpenClawEnableOpenSandbox=true
+        run: dotnet build OpenClaw.Net.slnx --no-restore -c Release -p:OpenClawEnableOpenSandbox=true ${{ env.FAST_BUILD_PROPERTIES }}
 
       - name: Test sandbox-enabled targets
         run: dotnet test --no-build -c Release -p:OpenClawEnableOpenSandbox=true --verbosity normal --logger "trx;LogFileName=results-sandbox.trx" src/OpenClaw.Tests
@@ -94,6 +108,14 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('OpenClaw.Net.slnx', '**/*.csproj', '**/*.props', '**/*.targets') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
 
       - name: Ensure AOT prerequisites
         timeout-minutes: 8
@@ -136,6 +158,14 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('OpenClaw.Net.slnx', '**/*.csproj', '**/*.props', '**/*.targets') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
 
       - name: Configure macOS Swift library path
         shell: bash
@@ -201,6 +231,14 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('OpenClaw.Net.slnx', '**/*.csproj', '**/*.props', '**/*.targets') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
 
       - name: Publish and smoke-test JIT binaries
         run: |
@@ -268,6 +306,14 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('OpenClaw.Net.slnx', '**/*.csproj', '**/*.props', '**/*.targets') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -277,7 +323,7 @@ jobs:
         run: dotnet restore src/OpenClaw.Tests
 
       - name: Build
-        run: dotnet build --no-restore -c Release src/OpenClaw.Tests
+        run: dotnet build --no-restore -c Release src/OpenClaw.Tests ${{ env.FAST_BUILD_PROPERTIES }}
 
       - name: Run Public Compatibility Smoke
         run: dotnet test --no-build -c Release --filter "Category=PublicSmoke" --verbosity normal --logger "trx;LogFileName=public-smoke.trx" src/OpenClaw.Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
   go-whatsapp-security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: "1.26.4"
           cache-dependency-path: src/whatsapp-whatsmeow-worker/go.sum
@@ -49,15 +49,15 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.NUGET_PACKAGES }}
           key: nuget-${{ runner.os }}-${{ hashFiles('OpenClaw.Net.slnx', '**/*.csproj', '**/*.props', '**/*.targets') }}
@@ -65,7 +65,7 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "20"
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: test-results
           path: "**/*.trx"
@@ -102,15 +102,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.NUGET_PACKAGES }}
           key: nuget-${{ runner.os }}-${{ hashFiles('OpenClaw.Net.slnx', '**/*.csproj', '**/*.props', '**/*.targets') }}
@@ -134,14 +134,14 @@ jobs:
 
       - name: Upload gateway artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: gateway-aot-linux-x64
           path: ./artifacts/aot/gateway/
 
       - name: Upload CLI artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: openclaw-cli-aot-linux-x64
           path: ./artifacts/aot/cli/
@@ -152,15 +152,15 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.NUGET_PACKAGES }}
           key: nuget-${{ runner.os }}-${{ hashFiles('OpenClaw.Net.slnx', '**/*.csproj', '**/*.props', '**/*.targets') }}
@@ -216,7 +216,7 @@ jobs:
 
       - name: Upload linker probe log
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: macos-gateway-linker-probe
           path: artifacts/linker-probe/
@@ -225,15 +225,15 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.NUGET_PACKAGES }}
           key: nuget-${{ runner.os }}-${{ hashFiles('OpenClaw.Net.slnx', '**/*.csproj', '**/*.props', '**/*.targets') }}
@@ -249,14 +249,14 @@ jobs:
 
       - name: Upload gateway artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: gateway-jit-linux-x64
           path: ./artifacts/jit/gateway/
 
       - name: Upload CLI artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: openclaw-cli-jit-linux-x64
           path: ./artifacts/jit/cli/
@@ -268,20 +268,20 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           push: true
@@ -299,15 +299,15 @@ jobs:
     env:
       OPENCLAW_PUBLIC_SMOKE: "1"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.NUGET_PACKAGES }}
           key: nuget-${{ runner.os }}-${{ hashFiles('OpenClaw.Net.slnx', '**/*.csproj', '**/*.props', '**/*.targets') }}
@@ -315,7 +315,7 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "20"
 
@@ -330,7 +330,7 @@ jobs:
 
       - name: Upload smoke results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: public-smoke-results
           path: "**/public-smoke.trx"

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -21,10 +21,10 @@ jobs:
     env:
       PACKAGE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -45,7 +45,7 @@ jobs:
           dotnet pack src/OpenClaw.SemanticKernelAdapter/OpenClaw.SemanticKernelAdapter.csproj -c Release --no-restore -p:PackageVersion=${PACKAGE_VERSION} -o ./artifacts/nuget
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: nuget-packages-${{ env.PACKAGE_VERSION }}
           path: ./artifacts/nuget

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,10 @@ jobs:
             rid: osx-arm64
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -198,7 +198,7 @@ jobs:
           }
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-${{ matrix.rid }}
           path: artifacts/release-archives/*
@@ -211,10 +211,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Download release artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           path: release-assets
           merge-multiple: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing! This guide covers the contributor workflow. For the project shape, repository map, and how the runtime fits together, start with [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md). If you are evaluating the project for the first time, read [docs/START_HERE.md](docs/START_HERE.md). For a first local run, follow [docs/QUICKSTART.md](docs/QUICKSTART.md).
 
-For project governance, maintainer roles, sponsorship boundaries, branch protection, and architecture scope, see [docs/project/governance.md](docs/project/governance.md), [docs/project/maintainers.md](docs/project/maintainers.md), [docs/project/sponsors.md](docs/project/sponsors.md), [docs/project/branch-protection.md](docs/project/branch-protection.md), and [docs/ARCHITECTURE_BOUNDARIES.md](docs/ARCHITECTURE_BOUNDARIES.md).
+For project governance, maintainer roles, sponsorship boundaries, branch protection, and architecture scope, see [docs/project/governance.md](docs/project/governance.md), [docs/project/maintainers.md](docs/project/maintainers.md), [docs/project/sponsors.md](docs/project/sponsors.md), [docs/project/branch-protection.md](docs/project/branch-protection.md), [docs/ARCHITECTURE_BOUNDARIES.md](docs/ARCHITECTURE_BOUNDARIES.md), [docs/CAPABILITY_MATRIX.md](docs/CAPABILITY_MATRIX.md), and [docs/architecture/optional-dependency-split.md](docs/architecture/optional-dependency-split.md).
 
 ## Prerequisites
 
@@ -56,6 +56,7 @@ dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build
 - Small CLI/help-text improvements that make failures more actionable.
 - Compatibility catalog additions that exercise a real upstream package or intentionally unsupported case.
 - Sample improvements that demonstrate existing behavior without adding new runtime architecture.
+- Optional protocol or provider work that follows the split guidance in [docs/architecture/optional-dependency-split.md](docs/architecture/optional-dependency-split.md).
 
 ## Pull Request Review
 
@@ -71,7 +72,7 @@ Maintainers use the scoped review guidance in [docs/maintainers/review-checklist
 
 ## Adding a New Tool or LLM Provider
 
-Tools implement `ITool` in `src/OpenClaw.Agent/Tools/` and register their JSON types in `CoreJsonContext`. Providers plug in through `Microsoft.Extensions.AI` and the gateway composition pipeline — add through the active provider registration path, not a `Program.cs` factory. Both must be wired through the current composition seams (see [docs/architecture-startup-refactor.md](docs/architecture-startup-refactor.md)) and covered by tests in `src/OpenClaw.Tests/`.
+Tools implement `ITool` in `src/OpenClaw.Agent/Tools/` when they are part of the default agent surface. Protocol-specific optional tools should live in an optional project, as MQTT does in `src/OpenClaw.Protocols.Mqtt`, and be composed through the gateway or another explicit extension seam. Providers plug in through `Microsoft.Extensions.AI` and the gateway composition pipeline — add through the active provider registration path, not a `Program.cs` factory. Both must be wired through the current composition seams (see [docs/architecture-startup-refactor.md](docs/architecture-startup-refactor.md)) and covered by tests in `src/OpenClaw.Tests/`.
 
 ## Reporting Bugs and Feature Requests
 

--- a/OpenClaw.Net.slnx
+++ b/OpenClaw.Net.slnx
@@ -18,6 +18,7 @@
     <Project Path="src/OpenClaw.Payments.Core/OpenClaw.Payments.Core.csproj" />
     <Project Path="src/OpenClaw.Payments.StripeLink/OpenClaw.Payments.StripeLink.csproj" />
     <Project Path="src/OpenClaw.Providers.MicrosoftExtensionsAI/OpenClaw.Providers.MicrosoftExtensionsAI.csproj" />
+    <Project Path="src/OpenClaw.Protocols.Mqtt/OpenClaw.Protocols.Mqtt.csproj" />
     <Project Path="src/OpenClaw.Plugins.Payment/OpenClaw.Plugins.Payment.csproj" />
     <Project Path="src/OpenClaw.Plugins.Mempalace/OpenClaw.Plugins.Mempalace.csproj" />
     <Project Path="src/OpenClaw.Dashboard/OpenClaw.Dashboard.csproj" />

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ The public documentation site is **[AgentQi.dev](https://agentqi.dev)**. The sou
 | [docs/USER_GUIDE.md](docs/USER_GUIDE.md) | Providers, tools, skills, memory, channels, and day-to-day operation |
 | [docs/RELEASES.md](docs/RELEASES.md) | Desktop downloads, release assets, and signing status |
 | [docs/ARCHITECTURE_BOUNDARIES.md](docs/ARCHITECTURE_BOUNDARIES.md) | Core, gateway, extension, AOT/JIT, and Industrial Pack boundaries |
+| [docs/CAPABILITY_MATRIX.md](docs/CAPABILITY_MATRIX.md) | Core, optional, experimental, and JIT-only capability lanes |
+| [docs/build/dashboard-assets.md](docs/build/dashboard-assets.md) | Gateway Dashboard asset build and publish behavior |
 | [docs/TOOLS_GUIDE.md](docs/TOOLS_GUIDE.md) | Native tool catalog and configuration |
 | [docs/LOCAL_MODELS.md](docs/LOCAL_MODELS.md) | Embedded local models, frame-based video, and experimental LiteRT-LM adapter notes |
 | [docs/mempalace-memory.md](docs/mempalace-memory.md) | Optional MemPalace.NET memory provider and temporal knowledge graph |
@@ -213,7 +215,17 @@ The public documentation site is **[AgentQi.dev](https://agentqi.dev)**. The sou
 | [docs/MODEL_PROFILES.md](docs/MODEL_PROFILES.md) | Provider-agnostic named model profiles (including Gemma) |
 | [docs/deployment/TAILSCALE.md](docs/deployment/TAILSCALE.md) | Optional Tailscale Serve private access |
 | [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md) | Supported upstream skill, plugin, and channel surface |
+| [docs/zh-CN/START_HERE.md](docs/zh-CN/START_HERE.md) | Simplified Chinese first-run orientation |
 | [SECURITY.md](SECURITY.md) | Hardening guidance for public deployments |
+
+Capability lanes at a glance:
+
+| Lane | Examples |
+|-----|----------|
+| Core | Runtime loop, gateway, CLI, NativeAOT-friendly host path, OpenAI-compatible API |
+| Optional | MQTT protocol package, channels, Browser tool, model providers, workflow backends |
+| Experimental | Embedded local model sidecars and adapter-oriented package paths |
+| JIT-only | Dynamic plugin channels, commands, hooks, providers, and native dynamic .NET plugins |
 
 ## Contributing
 

--- a/docs/ARCHITECTURE_BOUNDARIES.md
+++ b/docs/ARCHITECTURE_BOUNDARIES.md
@@ -41,6 +41,7 @@ Optional surfaces should be explicit, documented, and isolated from the core pat
 Examples include:
 
 - browser tools
+- protocol-specific packages such as MQTT
 - plugin bridge
 - channel adapters
 - model providers

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -1,0 +1,77 @@
+# Capability Matrix
+
+This matrix summarizes the current OpenClaw.NET capability lanes. It complements [COMPATIBILITY.md](COMPATIBILITY.md), which remains the canonical detailed compatibility guide.
+
+## Status Legend
+
+- `Core`: available in the default runtime path.
+- `Optional`: available when the related config, package, provider, or host is enabled.
+- `Experimental`: usable for evaluation, but not a committed stable surface.
+- `JIT-only`: requires the `jit` runtime lane and fails fast in `aot`.
+
+## Runtime And Host Capabilities
+
+| Capability | Lane | Notes |
+| --- | --- | --- |
+| Agent runtime loop | Core | Tool calls, streaming, cancellation, retries, sessions, memory, and hooks. |
+| Gateway HTTP host | Core | Local/self-hosted host for chat, admin, health, diagnostics, OpenAI-compatible APIs, MCP, and websockets. |
+| CLI setup and launch | Core | Source checkout, managed local config, diagnostics, model/profile tools, plugin/skill commands. |
+| NativeAOT publish | Core | Runtime and gateway are designed for the strict AOT lane. |
+| Desktop Companion | Optional | Included in desktop bundles and solution builds; release managers should still run manual smoke checks. |
+| TUI | Optional | Terminal UI surface for operator workflows. |
+| OpenAI-compatible endpoints | Core | Hosted by the gateway. |
+| MCP endpoint | Core | Hosted by the gateway. |
+| Public-bind hardening | Core | Gateway refuses unsafe public-bind configurations until required settings are hardened. |
+
+## Tools And Extensions
+
+| Capability | Lane | Notes |
+| --- | --- | --- |
+| First-party native tools | Core | File, shell, memory, session, web, database, email, calendar, and related tools. |
+| Browser tool | Optional | Conservative defaults; local execution depends on runtime capability and sandbox/backend settings. |
+| MQTT tools and event bridge | Optional | Implemented in `OpenClaw.Protocols.Mqtt` and composed by the gateway when native MQTT config is enabled. |
+| Home Assistant tools and event bridge | Optional | Native home-automation surface under native plugin config. |
+| Plugin bridge tools/services | Optional | Mainstream JS/TS plugin tools and services are supported with explicit diagnostics. |
+| Dynamic plugin channels | JIT-only | Fails fast outside the JIT lane. |
+| Dynamic plugin commands | JIT-only | Registered as dynamic chat commands in JIT mode. |
+| Dynamic plugin hooks | JIT-only | `tool:before` / `tool:after` hooks with timeout protections. |
+| Dynamic plugin providers | JIT-only | Plugin-provided model providers through the dynamic provider seam. |
+| Native dynamic .NET plugins | JIT-only | Loaded through `OpenClaw:Plugins:DynamicNative`. |
+| Payment tools | Optional | Native payment runtime owns live secrets; bridge payment plugins are diagnostic/test-only unless explicitly sandboxed. |
+
+## Providers, Models, And Workflows
+
+| Capability | Lane | Notes |
+| --- | --- | --- |
+| OpenAI provider | Optional | Enabled through provider config and secret refs. |
+| Claude provider | Optional | Enabled through provider config and secret refs. |
+| Gemini provider | Optional | Enabled through provider config and secret refs. |
+| Azure OpenAI provider | Optional | Enabled through provider config and secret refs. |
+| Ollama provider | Optional | Local provider path with model profile diagnostics. |
+| OpenAI-compatible provider | Optional | Provider-neutral path for compatible endpoints. |
+| Embedded local model sidecar | Experimental | Supervised local model packages, including multimodal frame-based video handling. |
+| Microsoft Agent Framework adapter | Optional | Select with `Runtime.Orchestrator=maf`; native runtime remains the default. |
+| Durable workflow backend | Optional | Delegates long-running runs to supported workflow hosts without making normal turns durable. |
+| Fractal Memory MCP integration | Optional | MCP-first structured memory integration. |
+| Mempalace memory provider | Optional | Optional temporal knowledge graph memory provider. |
+
+## Channels And Clients
+
+| Capability | Lane | Notes |
+| --- | --- | --- |
+| Web chat | Core | Gateway-hosted local UI. |
+| Admin UI | Core | Gateway-hosted diagnostics and operator surface. |
+| Typed .NET client | Optional | Integration API and MCP facade client. |
+| Telegram channel | Optional | Operator DM policy, allowlists, diagnostics, and recent sender support. |
+| SMS channel | Optional | Twilio-backed channel surface. |
+| WhatsApp channel | Optional | Worker-backed integration paths. |
+| Teams channel | Optional | Microsoft Teams setup path. |
+| Slack channel | Optional | Channel adapter with shared operator model. |
+| Discord channel | Optional | Includes slash-command ingress parity. |
+| Signal channel | Optional | Channel adapter with shared operator model. |
+| Email channel | Optional | Separate operational surface from chat-channel allowlists. |
+| Generic webhooks | Optional | Authenticated inbound triggers. |
+
+## Contributor Rule
+
+When a capability adds provider SDK weight, dynamic loading, vendor-specific defaults, or protocol-specific behavior, prefer an optional project or extension boundary over adding it to `OpenClaw.Core` or the default agent path.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -55,6 +55,7 @@ These are the directories most people need first:
 | `src/OpenClaw.Client` | Typed .NET client for the integration API and MCP facade. |
 | `src/OpenClaw.SemanticKernelAdapter` | Semantic Kernel integration layer. |
 | `src/OpenClaw.MicrosoftAgentFrameworkAdapter` | Supported optional Microsoft Agent Framework adapter. |
+| `src/OpenClaw.Protocols.Mqtt` | Optional MQTT native tools and event bridge, composed by the gateway when MQTT is enabled. |
 | `src/OpenClaw.PluginKit` | Support code for plugin authoring and plugin integration. |
 | `src/OpenClaw.Tests` | Unit and integration-style tests for the runtime and services. |
 | `src/OpenClaw.WhatsApp.BaileysWorker` | .NET-facing WhatsApp worker integration project. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@ Use this page as the map. If you are unsure where to go next, the groups below a
 | [GLOSSARY.md](GLOSSARY.md) | A term in another doc is unfamiliar — *gateway*, *runtime*, *skill*, *plugin*, *profile*, *posture*, `aot` / `jit` / `auto`, etc. |
 | [../README.md](../README.md) | High-level overview, feature list, and headline capabilities. |
 | [ARCHITECTURE_BOUNDARIES.md](ARCHITECTURE_BOUNDARIES.md) | Core, gateway, extension, AOT/JIT, and Industrial Pack boundaries. |
+| [CAPABILITY_MATRIX.md](CAPABILITY_MATRIX.md) | Core, optional, experimental, and JIT-only capability lanes. |
+| [zh-CN/START_HERE.md](zh-CN/START_HERE.md) | Simplified Chinese first-run orientation. |
 
 ## Using It
 
@@ -78,6 +80,7 @@ Use this page as the map. If you are unsure where to go next, the groups below a
 | [COMPATIBILITY.md](COMPATIBILITY.md) | Supported upstream skill, plugin, and channel surface. |
 | [sandboxing.md](sandboxing.md) | Optional sandbox execution backends. |
 | [DOCKERHUB.md](DOCKERHUB.md) | Official container image reference. |
+| [build/dashboard-assets.md](build/dashboard-assets.md) | Gateway Dashboard asset build and publish behavior. |
 | [deployment/TAILSCALE.md](deployment/TAILSCALE.md) | Tailscale Serve/Funnel patterns and private runtime access security notes. |
 | [PRODUCTION_FIXES.md](PRODUCTION_FIXES.md) | Known production-readiness fixes and their verification. |
 
@@ -93,6 +96,7 @@ Use this page as the map. If you are unsure where to go next, the groups below a
 | [maintainers/review-checklist.md](maintainers/review-checklist.md) | Maintainer checklist for runtime, gateway, extension, industrial, documentation, security, AOT, and commercial review. |
 | [ai-contributor-guide.md](ai-contributor-guide.md) | Guidance for AI-assisted contribution workflows. |
 | [architecture-startup-refactor.md](architecture-startup-refactor.md) | Current gateway startup layout and composition seams. |
+| [architecture/optional-dependency-split.md](architecture/optional-dependency-split.md) | Optional dependency split guidance and follow-up seams. |
 | [proposals/industrial-pack-preview.md](proposals/industrial-pack-preview.md) | Proposal for a reusable, vendor-neutral Industrial Pack preview. |
 | [ROADMAP.md](ROADMAP.md) | Planned direction and priorities. |
 

--- a/docs/SITE_MAP.md
+++ b/docs/SITE_MAP.md
@@ -26,6 +26,7 @@ Use this map when turning the Markdown docs into a documentation website. It kee
 | Guides | Shared Harness State | [SHARED_HARNESS_STATE.md](SHARED_HARNESS_STATE.md) |
 | Guides | Codebase Harness Map | [CODEBASE_HARNESS_MAP.md](CODEBASE_HARNESS_MAP.md) |
 | Reference | Compatibility | [COMPATIBILITY.md](COMPATIBILITY.md) |
+| Reference | Capability Matrix | [CAPABILITY_MATRIX.md](CAPABILITY_MATRIX.md) |
 | Reference | Architecture Boundaries | [ARCHITECTURE_BOUNDARIES.md](ARCHITECTURE_BOUNDARIES.md) |
 | Reference | Sessions | [SESSIONS.md](SESSIONS.md) |
 | Reference | Canvas and A2UI | [CANVAS_A2UI.md](CANVAS_A2UI.md) |
@@ -43,6 +44,7 @@ Use this map when turning the Markdown docs into a documentation website. It kee
 | Operations | Tool Governance Sidecar | [governance/sidecar-pattern.md](governance/sidecar-pattern.md) |
 | Operations | Microsoft Agent Governance | [governance/microsoft-agent-governance.md](governance/microsoft-agent-governance.md) |
 | Operations | Releases | [RELEASES.md](RELEASES.md) |
+| Operations | Dashboard Asset Build | [build/dashboard-assets.md](build/dashboard-assets.md) |
 | Operations | Docker Hub | [DOCKERHUB.md](DOCKERHUB.md) |
 | Operations | Optional Sandboxing | [sandboxing.md](sandboxing.md) |
 | Project | Contributing | [CONTRIBUTING.md](../CONTRIBUTING.md) |
@@ -51,9 +53,11 @@ Use this map when turning the Markdown docs into a documentation website. It kee
 | Project | Sponsors | [project/sponsors.md](project/sponsors.md) |
 | Project | Branch Protection | [project/branch-protection.md](project/branch-protection.md) |
 | Project | Maintainer Review Checklist | [maintainers/review-checklist.md](maintainers/review-checklist.md) |
+| Project | Optional Dependency Split | [architecture/optional-dependency-split.md](architecture/optional-dependency-split.md) |
 | Project | Industrial Pack Preview Proposal | [proposals/industrial-pack-preview.md](proposals/industrial-pack-preview.md) |
 | Project | Roadmap | [ROADMAP.md](ROADMAP.md) |
 | Project | AI Contributor Guide | [ai-contributor-guide.md](ai-contributor-guide.md) |
+| International | Simplified Chinese Start Here | [zh-CN/START_HERE.md](zh-CN/START_HERE.md) |
 
 ## Suggested Landing Path
 
@@ -91,6 +95,7 @@ Guides
 
 Reference
   Compatibility
+  Capability Matrix
   Architecture Boundaries
   Sessions
   Canvas and A2UI
@@ -112,6 +117,7 @@ Operations
   Tool Governance Sidecar
   Microsoft Agent Governance
   Releases
+  Dashboard Asset Build
   Docker Hub
   Optional Sandboxing
 
@@ -122,9 +128,13 @@ Project
   Sponsors
   Branch Protection
   Maintainer Review Checklist
+  Optional Dependency Split
   Industrial Pack Preview Proposal
   Roadmap
   AI Contributor Guide
+
+International
+  Simplified Chinese Start Here
 ```
 
 ## Build Notes

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -99,7 +99,7 @@ OpenClaw.NET supports practical OpenClaw ecosystem reuse:
 - mainstream `api.registerTool()` and `api.registerService()` plugin surfaces
 - explicit diagnostics for unsupported plugin APIs
 
-OpenClaw.NET is not a full upstream OpenClaw clone. Unsupported or JIT-only surfaces fail fast instead of loading partially. See [COMPATIBILITY.md](COMPATIBILITY.md) for the canonical matrix.
+OpenClaw.NET is not a full upstream OpenClaw clone. Unsupported or JIT-only surfaces fail fast instead of loading partially. See [COMPATIBILITY.md](COMPATIBILITY.md) for the canonical compatibility guide and [CAPABILITY_MATRIX.md](CAPABILITY_MATRIX.md) for the compact core, optional, experimental, and JIT-only lane summary.
 
 ## Known Limitations
 
@@ -116,6 +116,7 @@ OpenClaw.NET is not a full upstream OpenClaw clone. Unsupported or JIT-only surf
 | --- | --- |
 | Run a real local gateway | [QUICKSTART.md](QUICKSTART.md) |
 | Understand repository shape | [GETTING_STARTED.md](GETTING_STARTED.md) |
+| Check capability lanes | [CAPABILITY_MATRIX.md](CAPABILITY_MATRIX.md) |
 | Check compatibility | [COMPATIBILITY.md](COMPATIBILITY.md) |
 | Use tools and skills | [USER_GUIDE.md](USER_GUIDE.md) and [TOOLS_GUIDE.md](TOOLS_GUIDE.md) |
 | Download desktop bundles | [RELEASES.md](RELEASES.md) |

--- a/docs/architecture/optional-dependency-split.md
+++ b/docs/architecture/optional-dependency-split.md
@@ -1,0 +1,32 @@
+# Optional Dependency Split
+
+OpenClaw.NET keeps the default runtime local-first and NativeAOT-friendly. Optional integrations should live behind clear project or package boundaries when they add protocol-specific dependencies, provider SDKs, dynamic loading, or browser automation weight.
+
+## Current Split
+
+MQTT is the first native protocol surface extracted from `OpenClaw.Agent`:
+
+- project: `src/OpenClaw.Protocols.Mqtt`
+- package dependency: `MQTTnet`
+- config owner: `OpenClaw.Core` still owns `MqttConfig`
+- composition owner: `OpenClaw.Gateway` registers MQTT tools through `NativePluginRegistry.RegisterExternalTool(...)`
+- behavior: existing `OpenClaw:Plugins:Native:Mqtt` config remains unchanged
+
+This keeps the protocol package optional while preserving the gateway behavior operators already use.
+
+## Remaining Boundaries
+
+The following dependencies intentionally remain in `OpenClaw.Agent` for now:
+
+| Surface | Current blocker | Next seam |
+| --- | --- | --- |
+| Browser tool / Playwright | `OpenClawToolExecutor` handles browser-specific sandbox fallback and local-execution diagnostics directly. | Move browser availability and sandbox-fallback behavior behind a protocol-neutral tool capability seam. |
+| MCP tool registry | MCP registration participates in gateway startup and native registry composition. | Separate MCP registration contracts from Agent-owned tool registry implementation. |
+| Plugin bridge | Plugin host, bridge process, dynamic native host, hooks, skills, providers, and diagnostics share runtime startup state. | Split bridge contracts and host lifecycle before moving transport-specific code. |
+| OpenAI-specific provider packages | Provider construction still flows through current agent/runtime composition. | Keep provider-specific SDK use in provider projects or gateway composition before removing package weight from Agent. |
+
+## Contributor Rule
+
+Do not create empty optional projects to imply separation. Move a dependency only when the target project owns the implementation and the default runtime behavior can be validated with build, tests, and the HelloAgent smoke.
+
+If a split requires changing public runtime semantics, document the needed seam first and keep the dependency in place until the seam is reviewed.

--- a/docs/build/dashboard-assets.md
+++ b/docs/build/dashboard-assets.md
@@ -27,7 +27,7 @@ dotnet build OpenClaw.Net.slnx -c Release -p:OpenClawSkipDashboardBuild=true
 dotnet build src/OpenClaw.Gateway/OpenClaw.Gateway.csproj -c Release -p:OpenClawSkipDashboardBuild=true
 ```
 
-The CI `build-and-test` job uses this for build/test speed. Do not use it for release publish validation or any check that needs to inspect served Dashboard assets.
+The skip path removes `wwwroot/dashboard` from the Gateway build output so stale Dashboard files are not served accidentally from an old build. Do not use it for release publish validation or any check that needs to inspect served Dashboard assets.
 
 ## Publish Behavior
 

--- a/docs/build/dashboard-assets.md
+++ b/docs/build/dashboard-assets.md
@@ -1,0 +1,46 @@
+# Dashboard Asset Build
+
+The gateway serves Dashboard static assets from `wwwroot/dashboard`, but the Dashboard project is not a normal Gateway `ProjectReference` for static web assets. The manual copy targets in `src/OpenClaw.Gateway/OpenClaw.Gateway.csproj` avoid Static Web Assets conflicts while still materializing Blazor WASM files for local builds and publish outputs.
+
+## Default Behavior
+
+`CopyDashboardFiles` runs after a normal Gateway build and publishes `src/OpenClaw.Dashboard` into the Gateway output folder:
+
+```bash
+dotnet build src/OpenClaw.Gateway/OpenClaw.Gateway.csproj -c Release
+```
+
+The target copies Dashboard `wwwroot` files into:
+
+```text
+src/OpenClaw.Gateway/bin/<Configuration>/<TFM>/wwwroot/dashboard
+```
+
+It also creates non-fingerprinted `blazor.webassembly.js` and `dotnet.js` copies so the Dashboard `index.html` resolves correctly when served by `UseStaticFiles`.
+
+## Fast Build Loops
+
+Set `OpenClawSkipDashboardBuild=true` when a build only needs Gateway code and tests, not materialized Dashboard assets:
+
+```bash
+dotnet build OpenClaw.Net.slnx -c Release -p:OpenClawSkipDashboardBuild=true
+dotnet build src/OpenClaw.Gateway/OpenClaw.Gateway.csproj -c Release -p:OpenClawSkipDashboardBuild=true
+```
+
+The CI `build-and-test` job uses this for build/test speed. Do not use it for release publish validation or any check that needs to inspect served Dashboard assets.
+
+## Publish Behavior
+
+`CopyDashboardFilesPublish` runs after Gateway publish and always includes Dashboard assets in the publish directory:
+
+```bash
+dotnet publish src/OpenClaw.Gateway/OpenClaw.Gateway.csproj -c Release
+```
+
+This keeps release artifacts and smoke scripts on the full asset path even when ordinary build loops opt into the skip property.
+
+## Troubleshooting
+
+- If `/dashboard` returns missing `_framework` files, rebuild or publish Gateway without `OpenClawSkipDashboardBuild=true`.
+- If static web asset resolution fails during Gateway builds, keep Dashboard out of a normal static-web-asset `ProjectReference`; update the manual copy targets instead.
+- If the Blazor boot script name changes, update the non-fingerprinted copy patterns in the Gateway project file.

--- a/docs/zh-CN/START_HERE.md
+++ b/docs/zh-CN/START_HERE.md
@@ -1,0 +1,56 @@
+# OpenClaw.NET 入门
+
+OpenClaw.NET 是一个面向 .NET 的本地优先、自托管 AI Agent 运行时和网关。它强调 NativeAOT 友好、清晰诊断、可选扩展隔离，以及对 OpenClaw 生态中实用部分的兼容。
+
+如果你刚克隆仓库，建议先验证最小样例，而不是直接启动完整网关。
+
+## 最小验证路径
+
+```bash
+git clone https://github.com/clawdotnet/openclaw.net
+cd openclaw.net
+
+dotnet restore OpenClaw.Net.slnx
+dotnet build OpenClaw.Net.slnx --configuration Release --no-restore
+dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build
+```
+
+期望输出：
+
+```text
+OpenClaw.HelloAgent
+User: hello
+Agent: hello from OpenClaw.NET
+Tool: echo(hello): ok
+```
+
+这个样例不需要模型密钥、Ollama、Docker 或浏览器。它证明运行时可以构建、调用工具、完成 Agent 循环，并输出确定结果。
+
+## 项目组成
+
+| 部分 | 作用 |
+| --- | --- |
+| `OpenClaw.Core` | 配置、会话、内存、安全、诊断、序列化和共享模型。 |
+| `OpenClaw.Agent` | Agent 循环、工具执行、插件桥接、委派和运行时逻辑。 |
+| `OpenClaw.Gateway` | 本地或自托管 HTTP 网关，提供聊天、管理、健康检查、MCP、WebSocket 和 OpenAI 兼容接口。 |
+| `OpenClaw.Cli` | 设置、启动、诊断、模型配置、插件和技能命令。 |
+| `OpenClaw.Companion` | 桌面伴侣应用，用于本地操作流程。 |
+
+## 能力边界
+
+- 默认路径保持本地优先和 NativeAOT 友好。
+- 浏览器、MQTT、动态插件、部分 provider、工作流后端和工业适配都属于可选能力。
+- JIT-only 能力不会在 AOT 模式下静默部分加载；不支持时应快速失败并给出诊断。
+- OpenClaw.NET 不是完整上游 OpenClaw 克隆；兼容范围以英文文档 [COMPATIBILITY.md](../COMPATIBILITY.md) 和 [CAPABILITY_MATRIX.md](../CAPABILITY_MATRIX.md) 为准。
+
+## 下一步
+
+| 目标 | 文档 |
+| --- | --- |
+| 快速启动本地网关 | [QUICKSTART.md](../QUICKSTART.md) |
+| 理解仓库结构 | [GETTING_STARTED.md](../GETTING_STARTED.md) |
+| 查看能力矩阵 | [CAPABILITY_MATRIX.md](../CAPABILITY_MATRIX.md) |
+| 查看兼容性说明 | [COMPATIBILITY.md](../COMPATIBILITY.md) |
+| 参与贡献 | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
+
+中文文档目前是入门路径。完整参考资料仍以英文文档为主。

--- a/src/OpenClaw.Agent/OpenClaw.Agent.csproj
+++ b/src/OpenClaw.Agent/OpenClaw.Agent.csproj
@@ -13,7 +13,6 @@
     <ProjectReference Include="..\OpenClaw.PluginKit\OpenClaw.PluginKit.csproj" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.3.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
-    <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
     <PackageReference Include="ModelContextProtocol" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenClaw.Agent/Plugins/NativePluginRegistry.cs
+++ b/src/OpenClaw.Agent/Plugins/NativePluginRegistry.cs
@@ -57,12 +57,6 @@ public sealed class NativePluginRegistry : IDisposable
             RegisterTool(new HomeAssistantWriteTool(config.HomeAssistant, null, toolingConfig), "home-assistant");
         }
 
-        if (config.Mqtt.Enabled)
-        {
-            RegisterTool(new MqttTool(config.Mqtt), "mqtt");
-            RegisterTool(new MqttPublishTool(config.Mqtt, toolingConfig), "mqtt");
-        }
-
         if (config.Notion.Enabled)
         {
             RegisterTool(new NotionTool(config.Notion), "notion");

--- a/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.RuntimeFactories.cs
+++ b/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.RuntimeFactories.cs
@@ -17,6 +17,7 @@ using OpenClaw.Gateway.Extensions;
 using OpenClaw.Gateway.Models;
 using OpenClaw.Gateway.Tools;
 using OpenClaw.Plugins.Payment;
+using OpenClaw.Protocols.Mqtt.Integrations;
 
 namespace OpenClaw.Gateway.Composition;
 

--- a/src/OpenClaw.Gateway/Composition/ToolServicesExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/ToolServicesExtensions.cs
@@ -1,5 +1,6 @@
 using OpenClaw.Agent.Plugins;
 using OpenClaw.Gateway.Bootstrap;
+using OpenClaw.Protocols.Mqtt.Tools;
 
 namespace OpenClaw.Gateway.Composition;
 
@@ -8,10 +9,20 @@ internal static class ToolServicesExtensions
     public static IServiceCollection AddOpenClawToolServices(this IServiceCollection services, GatewayStartupContext startup)
     {
         services.AddSingleton(sp =>
-            new NativePluginRegistry(
+        {
+            var registry = new NativePluginRegistry(
                 startup.Config.Plugins.Native,
                 sp.GetRequiredService<ILoggerFactory>().CreateLogger<NativePluginRegistry>(),
-                startup.Config.Tooling));
+                startup.Config.Tooling);
+
+            if (startup.Config.Plugins.Native.Mqtt.Enabled)
+            {
+                registry.RegisterExternalTool(new MqttTool(startup.Config.Plugins.Native.Mqtt), "mqtt");
+                registry.RegisterExternalTool(new MqttPublishTool(startup.Config.Plugins.Native.Mqtt, startup.Config.Tooling), "mqtt");
+            }
+
+            return registry;
+        });
         services.AddSingleton(sp =>
             new McpServerToolRegistry(
                 startup.Config.Plugins.Mcp,

--- a/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
+++ b/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
@@ -119,6 +119,10 @@
           Condition="'@(_DotNetBootScript)' != ''" />
   </Target>
 
+  <Target Name="CleanDashboardFilesWhenSkipped" AfterTargets="Build" Condition="'$(OpenClawSkipDashboardBuild)' == 'true'">
+    <RemoveDir Directories="$(OutputPath)wwwroot\dashboard" />
+  </Target>
+
   <!-- Copy Dashboard publish output to Gateway publish dir -->
   <Target Name="CopyDashboardFilesPublish" AfterTargets="Publish">
     <PropertyGroup>

--- a/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
+++ b/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
@@ -81,15 +81,19 @@
     </Content>
   </ItemGroup>
 
+  <Target Name="CleanDashboardFiles" AfterTargets="Build">
+    <RemoveDir Directories="$(OutputPath)wwwroot\dashboard" />
+  </Target>
+
   <!-- Publish Dashboard WASM so all assets (_framework/, _content/, css/) are materialized on disk.
        CI build/test loops can set OpenClawSkipDashboardBuild=true; publish still copies Dashboard assets below. -->
-  <Target Name="CopyDashboardFiles" AfterTargets="Build" Condition="'$(OpenClawSkipDashboardBuild)' != 'true'">
+  <Target Name="CopyDashboardFiles" AfterTargets="CleanDashboardFiles" Condition="'$(OpenClawSkipDashboardBuild)' != 'true'">
     <PropertyGroup>
       <_DashboardProject>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'OpenClaw.Dashboard', 'OpenClaw.Dashboard.csproj'))</_DashboardProject>
       <_DashboardPublishDir>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'OpenClaw.Dashboard', 'bin', 'publish'))</_DashboardPublishDir>
       <_DashboardPublishWwwroot>$(_DashboardPublishDir)\wwwroot</_DashboardPublishWwwroot>
     </PropertyGroup>
-    <RemoveDir Directories="$(_DashboardPublishDir);$(OutputPath)wwwroot\dashboard" />
+    <RemoveDir Directories="$(_DashboardPublishDir)" />
     <Exec Command="dotnet publish &quot;$(_DashboardProject)&quot; -c $(Configuration) -o &quot;$(_DashboardPublishDir)&quot; --nologo -v q" />
     <ItemGroup>
       <_DashboardPublishFiles Include="$(_DashboardPublishWwwroot)\**\*" />

--- a/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
+++ b/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
@@ -3,6 +3,7 @@
     <RootNamespace>OpenClaw.Gateway</RootNamespace>
     <OutputType>Exe</OutputType>
     <OpenClawEnableOpenSandbox Condition="'$(OpenClawEnableOpenSandbox)' == ''">false</OpenClawEnableOpenSandbox>
+    <OpenClawSkipDashboardBuild Condition="'$(OpenClawSkipDashboardBuild)' == ''">false</OpenClawSkipDashboardBuild>
     <PublishAot>true</PublishAot>
     <StripSymbols>true</StripSymbols>
     <OptimizationPreference>Size</OptimizationPreference>
@@ -27,6 +28,7 @@
     <ProjectReference Include="..\OpenClaw.Core\OpenClaw.Core.csproj" />
     <ProjectReference Include="..\OpenClaw.Agent\OpenClaw.Agent.csproj" />
     <ProjectReference Include="..\OpenClaw.Channels\OpenClaw.Channels.csproj" />
+    <ProjectReference Include="..\OpenClaw.Protocols.Mqtt\OpenClaw.Protocols.Mqtt.csproj" />
     <ProjectReference Include="..\OpenClaw.Payments.Abstractions\OpenClaw.Payments.Abstractions.csproj" />
     <ProjectReference Include="..\OpenClaw.Payments.Core\OpenClaw.Payments.Core.csproj" />
     <ProjectReference Include="..\OpenClaw.Payments.StripeLink\OpenClaw.Payments.StripeLink.csproj" />
@@ -80,8 +82,8 @@
   </ItemGroup>
 
   <!-- Publish Dashboard WASM so all assets (_framework/, _content/, css/) are materialized on disk.
-       Runs AfterTargets=Build so the ProjectReference build of Dashboard completes first. -->
-  <Target Name="CopyDashboardFiles" AfterTargets="Build">
+       CI build/test loops can set OpenClawSkipDashboardBuild=true; publish still copies Dashboard assets below. -->
+  <Target Name="CopyDashboardFiles" AfterTargets="Build" Condition="'$(OpenClawSkipDashboardBuild)' != 'true'">
     <PropertyGroup>
       <_DashboardProject>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'OpenClaw.Dashboard', 'OpenClaw.Dashboard.csproj'))</_DashboardProject>
       <_DashboardPublishDir>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'OpenClaw.Dashboard', 'bin', 'publish'))</_DashboardPublishDir>

--- a/src/OpenClaw.Protocols.Mqtt/Integrations/MqttEventBridge.cs
+++ b/src/OpenClaw.Protocols.Mqtt/Integrations/MqttEventBridge.cs
@@ -112,10 +112,7 @@ public sealed class MqttEventBridge : BackgroundService
         if (!GlobMatcher.IsAllowed(_config.Policy.AllowSubscribeTopicGlobs, _config.Policy.DenySubscribeTopicGlobs, topic))
             return;
 
-        var payloadBytes = PayloadToArray(e.ApplicationMessage.Payload);
-        if (payloadBytes.Length > _config.MaxPayloadBytes)
-            payloadBytes = payloadBytes[.._config.MaxPayloadBytes];
-
+        var payloadBytes = PayloadToArray(e.ApplicationMessage.Payload, Math.Max(0, _config.MaxPayloadBytes));
         var payload = Encoding.UTF8.GetString(payloadBytes);
         MqttMessageCache.Set(topic, payload);
 
@@ -175,14 +172,22 @@ public sealed class MqttEventBridge : BackgroundService
         return true;
     }
 
-    private static byte[] PayloadToArray(System.Buffers.ReadOnlySequence<byte> payload)
+    private static byte[] PayloadToArray(System.Buffers.ReadOnlySequence<byte> payload, int maxPayloadBytes)
     {
-        if (payload.IsSingleSegment)
-            return payload.FirstSpan.ToArray();
+        var payloadLength = Math.Min(payload.Length, maxPayloadBytes);
+        if (payloadLength <= 0)
+            return [];
 
-        var bytes = new byte[(int)payload.Length];
+        var boundedPayload = payloadLength == payload.Length
+            ? payload
+            : payload.Slice(0, payloadLength);
+
+        if (boundedPayload.IsSingleSegment)
+            return boundedPayload.FirstSpan.ToArray();
+
+        var bytes = new byte[(int)boundedPayload.Length];
         var offset = 0;
-        foreach (var segment in payload)
+        foreach (var segment in boundedPayload)
         {
             segment.Span.CopyTo(bytes.AsSpan(offset));
             offset += segment.Length;

--- a/src/OpenClaw.Protocols.Mqtt/Integrations/MqttEventBridge.cs
+++ b/src/OpenClaw.Protocols.Mqtt/Integrations/MqttEventBridge.cs
@@ -4,12 +4,12 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using MQTTnet;
 using MQTTnet.Protocol;
-using OpenClaw.Agent.Tools;
 using OpenClaw.Core.Models;
 using OpenClaw.Core.Plugins;
 using OpenClaw.Core.Security;
+using OpenClaw.Protocols.Mqtt.Tools;
 
-namespace OpenClaw.Agent.Integrations;
+namespace OpenClaw.Protocols.Mqtt.Integrations;
 
 public sealed class MqttEventBridge : BackgroundService
 {

--- a/src/OpenClaw.Protocols.Mqtt/OpenClaw.Protocols.Mqtt.csproj
+++ b/src/OpenClaw.Protocols.Mqtt/OpenClaw.Protocols.Mqtt.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>OpenClaw.Protocols.Mqtt</RootNamespace>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="OpenClaw.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OpenClaw.Core\OpenClaw.Core.csproj" />
+    <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
+  </ItemGroup>
+</Project>

--- a/src/OpenClaw.Protocols.Mqtt/Tools/MqttClientFactory.cs
+++ b/src/OpenClaw.Protocols.Mqtt/Tools/MqttClientFactory.cs
@@ -3,7 +3,7 @@ using MQTTnet.Formatter;
 using OpenClaw.Core.Plugins;
 using OpenClaw.Core.Security;
 
-namespace OpenClaw.Agent.Tools;
+namespace OpenClaw.Protocols.Mqtt.Tools;
 
 internal static class OpenClawMqttClientFactory
 {

--- a/src/OpenClaw.Protocols.Mqtt/Tools/MqttMessageCache.cs
+++ b/src/OpenClaw.Protocols.Mqtt/Tools/MqttMessageCache.cs
@@ -1,6 +1,6 @@
 using System.Collections.Concurrent;
 
-namespace OpenClaw.Agent.Tools;
+namespace OpenClaw.Protocols.Mqtt.Tools;
 
 internal static class MqttMessageCache
 {

--- a/src/OpenClaw.Protocols.Mqtt/Tools/MqttPublishTool.cs
+++ b/src/OpenClaw.Protocols.Mqtt/Tools/MqttPublishTool.cs
@@ -7,7 +7,7 @@ using OpenClaw.Core.Models;
 using OpenClaw.Core.Plugins;
 using OpenClaw.Core.Security;
 
-namespace OpenClaw.Agent.Tools;
+namespace OpenClaw.Protocols.Mqtt.Tools;
 
 public sealed class MqttPublishTool : ITool
 {

--- a/src/OpenClaw.Protocols.Mqtt/Tools/MqttTool.cs
+++ b/src/OpenClaw.Protocols.Mqtt/Tools/MqttTool.cs
@@ -6,7 +6,7 @@ using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Plugins;
 using OpenClaw.Core.Security;
 
-namespace OpenClaw.Agent.Tools;
+namespace OpenClaw.Protocols.Mqtt.Tools;
 
 public sealed class MqttTool : ITool
 {

--- a/src/OpenClaw.Protocols.Mqtt/Tools/MqttTool.cs
+++ b/src/OpenClaw.Protocols.Mqtt/Tools/MqttTool.cs
@@ -96,12 +96,23 @@ public sealed class MqttTool : ITool
         {
             try
             {
-                var payloadBytes = e.ApplicationMessage is null
-                    ? Array.Empty<byte>()
-                    : PayloadToArray(e.ApplicationMessage.Payload);
+                if (e.ApplicationMessage is null)
+                {
+                    tcs.TrySetResult((topic, ""));
+                    return Task.CompletedTask;
+                }
+
+                var maxPayloadBytes = Math.Max(0, _config.MaxPayloadBytes);
+                if (!TryPayloadToArray(e.ApplicationMessage.Payload, maxPayloadBytes, out var payloadBytes))
+                {
+                    tcs.TrySetResult((
+                        e.ApplicationMessage.Topic ?? topic,
+                        $"Error: payload exceeds configured limit ({maxPayloadBytes} bytes)."));
+                    return Task.CompletedTask;
+                }
 
                 var text = Encoding.UTF8.GetString(payloadBytes);
-                tcs.TrySetResult((e.ApplicationMessage?.Topic ?? topic, text));
+                tcs.TrySetResult((e.ApplicationMessage.Topic ?? topic, text));
             }
             catch (Exception ex)
             {
@@ -132,6 +143,18 @@ public sealed class MqttTool : ITool
         {
             try { await client.DisconnectAsync(new MQTTnet.MqttClientDisconnectOptions(), cts.Token); } catch { /* ignore */ }
         }
+    }
+
+    private static bool TryPayloadToArray(System.Buffers.ReadOnlySequence<byte> payload, int maxPayloadBytes, out byte[] payloadBytes)
+    {
+        if (payload.Length > maxPayloadBytes)
+        {
+            payloadBytes = [];
+            return false;
+        }
+
+        payloadBytes = PayloadToArray(payload);
+        return true;
     }
 
     private static byte[] PayloadToArray(System.Buffers.ReadOnlySequence<byte> payload)

--- a/src/OpenClaw.Tests/HomeAutomationToolSchemaTests.cs
+++ b/src/OpenClaw.Tests/HomeAutomationToolSchemaTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using OpenClaw.Agent.Tools;
 using OpenClaw.Core.Plugins;
+using OpenClaw.Protocols.Mqtt.Tools;
 using Xunit;
 
 namespace OpenClaw.Tests;
@@ -53,4 +54,3 @@ public sealed class HomeAutomationToolSchemaTests
         Assert.True(props.TryGetProperty("payload", out _));
     }
 }
-

--- a/src/OpenClaw.Tests/MqttToolTests.cs
+++ b/src/OpenClaw.Tests/MqttToolTests.cs
@@ -1,5 +1,5 @@
-using OpenClaw.Agent.Tools;
 using OpenClaw.Core.Plugins;
+using OpenClaw.Protocols.Mqtt.Tools;
 using Xunit;
 
 namespace OpenClaw.Tests;
@@ -36,4 +36,3 @@ public sealed class MqttToolTests
         Assert.Contains("hello", result);
     }
 }
-

--- a/src/OpenClaw.Tests/NativePluginTests.cs
+++ b/src/OpenClaw.Tests/NativePluginTests.cs
@@ -2,6 +2,7 @@ using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Plugins;
 using OpenClaw.Agent.Plugins;
 using OpenClaw.Agent.Tools;
+using OpenClaw.Protocols.Mqtt.Tools;
 using Xunit;
 
 namespace OpenClaw.Tests;
@@ -52,7 +53,7 @@ public class NativePluginRegistryTests
     }
 
     [Fact]
-    public void Constructor_MqttEnabled_RegistersReadAndWriteTools()
+    public void RegisterExternalTool_MqttEnabled_RegistersReadAndWriteTools()
     {
         var config = new NativePluginsConfig
         {
@@ -64,6 +65,8 @@ public class NativePluginRegistryTests
         };
 
         var registry = new NativePluginRegistry(config, NullLogger.Instance);
+        registry.RegisterExternalTool(new MqttTool(config.Mqtt), "mqtt");
+        registry.RegisterExternalTool(new MqttPublishTool(config.Mqtt), "mqtt");
 
         Assert.Contains(registry.Tools, t => t.Name == "mqtt");
         Assert.Contains(registry.Tools, t => t.Name == "mqtt_publish");

--- a/src/OpenClaw.Tests/NativePluginTests.cs
+++ b/src/OpenClaw.Tests/NativePluginTests.cs
@@ -1,7 +1,12 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Models;
 using OpenClaw.Core.Plugins;
 using OpenClaw.Agent.Plugins;
 using OpenClaw.Agent.Tools;
+using OpenClaw.Gateway.Bootstrap;
+using OpenClaw.Gateway.Composition;
 using OpenClaw.Protocols.Mqtt.Tools;
 using Xunit;
 
@@ -70,6 +75,48 @@ public class NativePluginRegistryTests
 
         Assert.Contains(registry.Tools, t => t.Name == "mqtt");
         Assert.Contains(registry.Tools, t => t.Name == "mqtt_publish");
+    }
+
+    [Fact]
+    public void AddOpenClawToolServices_MqttEnabled_RegistersReadAndWriteTools()
+    {
+        var config = new GatewayConfig
+        {
+            Plugins = new PluginsConfig
+            {
+                Native = new NativePluginsConfig
+                {
+                    Mqtt = new MqttConfig
+                    {
+                        Enabled = true,
+                        Host = "127.0.0.1"
+                    }
+                }
+            }
+        };
+        var startup = new GatewayStartupContext
+        {
+            Config = config,
+            RuntimeState = new GatewayRuntimeState
+            {
+                RequestedMode = "jit",
+                EffectiveMode = GatewayRuntimeMode.Jit,
+                DynamicCodeSupported = true
+            },
+            IsNonLoopbackBind = false
+        };
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOpenClawToolServices(startup);
+
+        using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<NativePluginRegistry>();
+
+        Assert.Contains(registry.Tools, t => t.Name == "mqtt");
+        Assert.Contains(registry.Tools, t => t.Name == "mqtt_publish");
+        Assert.True(registry.IsNativeTool("mqtt"));
+        Assert.True(registry.IsNativeTool("mqtt_publish"));
     }
 
     [Fact]

--- a/src/OpenClaw.Tests/OpenClaw.Tests.csproj
+++ b/src/OpenClaw.Tests/OpenClaw.Tests.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\OpenClaw.Payments.Core\OpenClaw.Payments.Core.csproj" />
     <ProjectReference Include="..\OpenClaw.Payments.StripeLink\OpenClaw.Payments.StripeLink.csproj" />
     <ProjectReference Include="..\OpenClaw.Providers.MicrosoftExtensionsAI\OpenClaw.Providers.MicrosoftExtensionsAI.csproj" />
+    <ProjectReference Include="..\OpenClaw.Protocols.Mqtt\OpenClaw.Protocols.Mqtt.csproj" />
     <ProjectReference Include="..\OpenClaw.Plugins.Payment\OpenClaw.Plugins.Payment.csproj" />
     <ProjectReference Include="..\OpenClaw.SemanticKernelAdapter\OpenClaw.SemanticKernelAdapter.csproj" />
     <ProjectReference Include="..\OpenClaw.SkillKit.Abstractions\OpenClaw.SkillKit.Abstractions.csproj" />


### PR DESCRIPTION
## Summary

- Extracts MQTT tools and event bridge into a new optional `OpenClaw.Protocols.Mqtt` project while preserving existing gateway config and runtime behavior.
- Removes `MQTTnet` from `OpenClaw.Agent` and registers MQTT tools through the existing `NativePluginRegistry.RegisterExternalTool(...)` seam.
- Adds dashboard asset build documentation plus `OpenClawSkipDashboardBuild=true` for faster CI build/test loops while keeping publish asset copying intact.
- Adds capability matrix, optional dependency split guidance, Chinese first-run orientation, navigation links, CI cache/concurrency updates, and issue template polish.

## Validation

- `dotnet restore OpenClaw.Net.slnx`
- `dotnet build OpenClaw.Net.slnx -c Release --no-restore`
- `dotnet test src/OpenClaw.Tests -c Release --no-build --verbosity normal` (`1618 passed`)
- `dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build`
- `dotnet build src/OpenClaw.Gateway/OpenClaw.Gateway.csproj -c Release --no-restore -p:OpenClawSkipDashboardBuild=true`
- `dotnet build OpenClaw.Net.slnx -c Release --no-restore -p:OpenClawSkipDashboardBuild=true`
- targeted MQTT/native registry/gateway lifecycle tests (`27 passed`)
- `dotnet list` package verification for Agent and MQTT project
- `git diff --check`
- YAML parse check for `.github/workflows/ci.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional MQTT protocol integration with native tooling and an event bridge.
  * Option to skip dashboard asset build (OpenClawSkipDashboardBuild=true) for faster iterations.

* **Documentation**
  * Added capability matrix and expanded architecture/optional-dependency guidance.
  * Simplified Chinese getting-started guide and expanded docs navigation.
  * New docs on dashboard asset build behavior.

* **Improvements**
  * CI NuGet caching for faster builds.
  * Enhanced issue templates with richer compatibility and runtime diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->