### PR TITLE
Extract browser protocol tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Maintainers use the scoped review guidance in [docs/maintainers/review-checklist
 
 ## Adding a New Tool or LLM Provider
 
-Tools implement `ITool` in `src/OpenClaw.Agent/Tools/` when they are part of the default agent surface. Protocol-specific optional tools should live in an optional project, as MQTT does in `src/OpenClaw.Protocols.Mqtt`, and be composed through the gateway or another explicit extension seam. Providers plug in through `Microsoft.Extensions.AI` and the gateway composition pipeline — add through the active provider registration path, not a `Program.cs` factory. Both must be wired through the current composition seams (see [docs/architecture-startup-refactor.md](docs/architecture-startup-refactor.md)) and covered by tests in `src/OpenClaw.Tests/`.
+Tools implement `ITool` in `src/OpenClaw.Agent/Tools/` when they are part of the default agent surface. Protocol-specific optional tools should live in an optional project, as Browser does in `src/OpenClaw.Protocols.Browser` and MQTT does in `src/OpenClaw.Protocols.Mqtt`, and be composed through the gateway or another explicit extension seam. Providers plug in through `Microsoft.Extensions.AI` and the gateway composition pipeline — add through the active provider registration path, not a `Program.cs` factory. Both must be wired through the current composition seams (see [docs/architecture-startup-refactor.md](docs/architecture-startup-refactor.md)) and covered by tests in `src/OpenClaw.Tests/`.
 
 ## Reporting Bugs and Feature Requests
 

--- a/OpenClaw.Net.slnx
+++ b/OpenClaw.Net.slnx
@@ -18,6 +18,7 @@
     <Project Path="src/OpenClaw.Payments.Core/OpenClaw.Payments.Core.csproj" />
     <Project Path="src/OpenClaw.Payments.StripeLink/OpenClaw.Payments.StripeLink.csproj" />
     <Project Path="src/OpenClaw.Providers.MicrosoftExtensionsAI/OpenClaw.Providers.MicrosoftExtensionsAI.csproj" />
+    <Project Path="src/OpenClaw.Protocols.Browser/OpenClaw.Protocols.Browser.csproj" />
     <Project Path="src/OpenClaw.Protocols.Mqtt/OpenClaw.Protocols.Mqtt.csproj" />
     <Project Path="src/OpenClaw.Plugins.Payment/OpenClaw.Plugins.Payment.csproj" />
     <Project Path="src/OpenClaw.Plugins.Mempalace/OpenClaw.Plugins.Mempalace.csproj" />

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Capability lanes at a glance:
 | Lane | Examples |
 |-----|----------|
 | Core | Runtime loop, gateway, CLI, NativeAOT-friendly host path, OpenAI-compatible API |
-| Optional | MQTT protocol package, channels, Browser tool, model providers, workflow backends |
+| Optional | Browser and MQTT protocol packages, channels, model providers, workflow backends |
 | Experimental | Embedded local model sidecars and adapter-oriented package paths |
 | JIT-only | Dynamic plugin channels, commands, hooks, providers, and native dynamic .NET plugins |
 

--- a/docs/ARCHITECTURE_BOUNDARIES.md
+++ b/docs/ARCHITECTURE_BOUNDARIES.md
@@ -40,8 +40,8 @@ Optional surfaces should be explicit, documented, and isolated from the core pat
 
 Examples include:
 
-- browser tools
-- protocol-specific packages such as MQTT
+- browser automation through `OpenClaw.Protocols.Browser`
+- protocol-specific packages such as MQTT through `OpenClaw.Protocols.Mqtt`
 - plugin bridge
 - channel adapters
 - model providers

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -28,7 +28,7 @@ This matrix summarizes the current OpenClaw.NET capability lanes. It complements
 | Capability | Lane | Notes |
 | --- | --- | --- |
 | First-party native tools | Core | File, shell, memory, session, web, database, email, calendar, and related tools. |
-| Browser tool | Optional | Conservative defaults; local execution depends on runtime capability and sandbox/backend settings. |
+| Browser tool | Optional | Implemented in `OpenClaw.Protocols.Browser`; conservative defaults; local execution depends on runtime capability and sandbox/backend settings. |
 | MQTT tools and event bridge | Optional | Implemented in `OpenClaw.Protocols.Mqtt` and composed by the gateway when native MQTT config is enabled. |
 | Home Assistant tools and event bridge | Optional | Native home-automation surface under native plugin config. |
 | Plugin bridge tools/services | Optional | Mainstream JS/TS plugin tools and services are supported with explicit diagnostics. |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -55,6 +55,7 @@ These are the directories most people need first:
 | `src/OpenClaw.Client` | Typed .NET client for the integration API and MCP facade. |
 | `src/OpenClaw.SemanticKernelAdapter` | Semantic Kernel integration layer. |
 | `src/OpenClaw.MicrosoftAgentFrameworkAdapter` | Supported optional Microsoft Agent Framework adapter. |
+| `src/OpenClaw.Protocols.Browser` | Optional Playwright-backed browser automation tool, composed by the gateway when browser tooling is enabled and available. |
 | `src/OpenClaw.Protocols.Mqtt` | Optional MQTT native tools and event bridge, composed by the gateway when MQTT is enabled. |
 | `src/OpenClaw.PluginKit` | Support code for plugin authoring and plugin integration. |
 | `src/OpenClaw.Tests` | Unit and integration-style tests for the runtime and services. |

--- a/docs/architecture/optional-dependency-split.md
+++ b/docs/architecture/optional-dependency-split.md
@@ -4,7 +4,7 @@ OpenClaw.NET keeps the default runtime local-first and NativeAOT-friendly. Optio
 
 ## Current Split
 
-MQTT is the first native protocol surface extracted from `OpenClaw.Agent`:
+MQTT is a native protocol surface extracted from `OpenClaw.Agent`:
 
 - project: `src/OpenClaw.Protocols.Mqtt`
 - package dependency: `MQTTnet`
@@ -12,7 +12,17 @@ MQTT is the first native protocol surface extracted from `OpenClaw.Agent`:
 - composition owner: `OpenClaw.Gateway` registers MQTT tools through `NativePluginRegistry.RegisterExternalTool(...)`
 - behavior: existing `OpenClaw:Plugins:Native:Mqtt` config remains unchanged
 
-This keeps the protocol package optional while preserving the gateway behavior operators already use.
+Browser automation is also split from `OpenClaw.Agent`:
+
+- project: `src/OpenClaw.Protocols.Browser`
+- package dependency: `Microsoft.Playwright`
+- config owner: `OpenClaw.Core` still owns `Tooling.EnableBrowserTool` and browser tooling options
+- composition owner: `OpenClaw.Gateway` registers the browser tool as part of the built-in gateway tool surface when browser availability checks pass
+- behavior: existing `OpenClaw:Tooling:EnableBrowserTool` config and local/sandbox/backend fallback behavior remain unchanged
+
+The agent executor no longer depends on browser-specific types for sandbox fallback. Tools that cannot safely fall back to local execution implement the protocol-neutral `IToolLocalExecutionPolicy` contract in `OpenClaw.Core`.
+
+These splits keep protocol packages optional while preserving the gateway behavior operators already use.
 
 ## Remaining Boundaries
 
@@ -20,7 +30,6 @@ The following dependencies intentionally remain in `OpenClaw.Agent` for now:
 
 | Surface | Current blocker | Next seam |
 | --- | --- | --- |
-| Browser tool / Playwright | `OpenClawToolExecutor` handles browser-specific sandbox fallback and local-execution diagnostics directly. | Move browser availability and sandbox-fallback behavior behind a protocol-neutral tool capability seam. |
 | MCP tool registry | MCP registration participates in gateway startup and native registry composition. | Separate MCP registration contracts from Agent-owned tool registry implementation. |
 | Plugin bridge | Plugin host, bridge process, dynamic native host, hooks, skills, providers, and diagnostics share runtime startup state. | Split bridge contracts and host lifecycle before moving transport-specific code. |
 | OpenAI-specific provider packages | Provider construction still flows through current agent/runtime composition. | Keep provider-specific SDK use in provider projects or gateway composition before removing package weight from Agent. |

--- a/src/OpenClaw.Agent/OpenClaw.Agent.csproj
+++ b/src/OpenClaw.Agent/OpenClaw.Agent.csproj
@@ -8,7 +8,6 @@
     <InternalsVisibleTo Include="OpenClaw.Tests" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Playwright" Version="1.58.0" />
     <ProjectReference Include="..\OpenClaw.Core\OpenClaw.Core.csproj" />
     <ProjectReference Include="..\OpenClaw.PluginKit\OpenClaw.PluginKit.csproj" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.3.0" />

--- a/src/OpenClaw.Agent/OpenClawToolExecutor.cs
+++ b/src/OpenClaw.Agent/OpenClawToolExecutor.cs
@@ -4,7 +4,6 @@ using System.Text.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using OpenClaw.Agent.Execution;
-using OpenClaw.Agent.Tools;
 using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Governance;
 using OpenClaw.Core.Models;
@@ -481,7 +480,7 @@ public sealed class OpenClawToolExecutor
             result = ex.Message;
             toolFailed = true;
             resultStatus = ToolResultStatuses.Blocked;
-            failureCode = ClassifyToolFailureCode(tool.Name, ex.Message);
+            failureCode = ex.FailureCode ?? ClassifyToolFailureCode(tool, ex.Message);
             failureMessage = ex.Message;
             nextStep = BuildFailureNextStep(tool.Name, failureCode);
             _metrics?.IncrementToolFailures();
@@ -489,7 +488,7 @@ public sealed class OpenClawToolExecutor
         }
         catch (Exception ex)
         {
-            failureCode = ClassifyToolFailureCode(tool.Name, ex.Message);
+            failureCode = ClassifyToolFailureCode(tool, ex.Message);
             failureMessage = ex.Message;
             toolFailed = true;
             if (failureCode is ToolFailureCodes.OperatorAuthRequired or ToolFailureCodes.BrowserBackendMissing or ToolFailureCodes.RuntimeCapabilityUnavailable)
@@ -835,7 +834,7 @@ public sealed class OpenClawToolExecutor
         if (!_executionRouter.TryResolveRoute(tool, out var route, out var template, out var legacySandboxRoute, out var sandboxMode))
         {
             if (IsLocalExecutionDisabled(tool))
-                throw new ToolSandboxException(BrowserTool.LocalExecutionUnavailableMessage);
+                throw CreateLocalExecutionUnavailableException(tool);
 
             return await ExecuteToolWithTimeoutAsync(tool, argsJson, session, turnCtx, ct);
         }
@@ -853,7 +852,7 @@ public sealed class OpenClawToolExecutor
         }
 
         if (string.Equals(backendName, "local", StringComparison.OrdinalIgnoreCase) && IsLocalExecutionDisabled(tool))
-            throw new ToolSandboxException(BrowserTool.LocalExecutionUnavailableMessage);
+            throw CreateLocalExecutionUnavailableException(tool);
 
         if (string.Equals(backendName, "local", StringComparison.OrdinalIgnoreCase) && !legacySandboxRoute)
             return await ExecuteToolWithTimeoutAsync(tool, argsJson, session, turnCtx, ct);
@@ -944,7 +943,22 @@ public sealed class OpenClawToolExecutor
     }
 
     private static bool IsLocalExecutionDisabled(ITool tool)
-        => tool is BrowserTool { LocalExecutionSupported: false };
+        => tool is IToolLocalExecutionPolicy { LocalExecutionSupported: false };
+
+    private static ToolSandboxException CreateLocalExecutionUnavailableException(ITool tool)
+        => new(
+            GetLocalExecutionUnavailableMessage(tool),
+            GetLocalExecutionUnavailableFailureCode(tool));
+
+    private static string GetLocalExecutionUnavailableMessage(ITool tool)
+        => tool is IToolLocalExecutionPolicy { LocalExecutionSupported: false } policy
+            ? policy.LocalExecutionUnavailableMessage
+            : $"Error: Tool '{tool.Name}' requires a configured execution backend or sandbox in this runtime. Local execution is unavailable.";
+
+    private static string GetLocalExecutionUnavailableFailureCode(ITool tool)
+        => tool is IToolLocalExecutionPolicy { LocalExecutionSupported: false } policy
+            ? policy.LocalExecutionUnavailableFailureCode
+            : ToolFailureCodes.RuntimeCapabilityUnavailable;
 
     private async Task<string> ExecuteToolWithTimeoutAsync(
         ITool tool,
@@ -996,11 +1010,18 @@ public sealed class OpenClawToolExecutor
            !string.Equals(decision, PlanExecuteVerifyDecisionKinds.Proceed, StringComparison.OrdinalIgnoreCase) &&
            !string.Equals(decision, PlanExecuteVerifyDecisionKinds.RequireApproval, StringComparison.OrdinalIgnoreCase);
 
-    private static string ClassifyToolFailureCode(string toolName, string message)
+    private static string ClassifyToolFailureCode(ITool tool, string message)
     {
         if (LooksLikeOperatorAuthFailure(message))
             return ToolFailureCodes.OperatorAuthRequired;
 
+        if (tool is IToolLocalExecutionPolicy { LocalExecutionSupported: false } policy &&
+            string.Equals(message, policy.LocalExecutionUnavailableMessage, StringComparison.Ordinal))
+        {
+            return policy.LocalExecutionUnavailableFailureCode;
+        }
+
+        var toolName = tool.Name;
         if (toolName.Equals("browser", StringComparison.OrdinalIgnoreCase))
         {
             return message.Contains("execution backend", StringComparison.OrdinalIgnoreCase) ||

--- a/src/OpenClaw.Core/Abstractions/IToolLocalExecutionPolicy.cs
+++ b/src/OpenClaw.Core/Abstractions/IToolLocalExecutionPolicy.cs
@@ -1,0 +1,13 @@
+namespace OpenClaw.Core.Abstractions;
+
+/// <summary>
+/// Describes whether a sandbox-capable tool may fall back to local execution.
+/// </summary>
+public interface IToolLocalExecutionPolicy
+{
+    bool LocalExecutionSupported { get; }
+
+    string LocalExecutionUnavailableFailureCode { get; }
+
+    string LocalExecutionUnavailableMessage { get; }
+}

--- a/src/OpenClaw.Core/Abstractions/ToolSandboxException.cs
+++ b/src/OpenClaw.Core/Abstractions/ToolSandboxException.cs
@@ -3,14 +3,28 @@ namespace OpenClaw.Core.Abstractions;
 public class ToolSandboxException : Exception
 {
     public ToolSandboxException(string message)
-        : base(message)
+        : this(message, failureCode: null)
     {
     }
 
+    public ToolSandboxException(string message, string? failureCode)
+        : base(message)
+    {
+        FailureCode = failureCode;
+    }
+
     public ToolSandboxException(string message, Exception innerException)
-        : base(message, innerException)
+        : this(message, innerException, failureCode: null)
     {
     }
+
+    public ToolSandboxException(string message, Exception innerException, string? failureCode)
+        : base(message, innerException)
+    {
+        FailureCode = failureCode;
+    }
+
+    public string? FailureCode { get; }
 }
 
 public sealed class ToolSandboxUnavailableException : ToolSandboxException
@@ -25,4 +39,3 @@ public sealed class ToolSandboxUnavailableException : ToolSandboxException
     {
     }
 }
-

--- a/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.RuntimeFactories.cs
+++ b/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.RuntimeFactories.cs
@@ -17,6 +17,7 @@ using OpenClaw.Gateway.Extensions;
 using OpenClaw.Gateway.Models;
 using OpenClaw.Gateway.Tools;
 using OpenClaw.Plugins.Payment;
+using OpenClaw.Protocols.Browser.Tools;
 using OpenClaw.Protocols.Mqtt.Integrations;
 
 namespace OpenClaw.Gateway.Composition;

--- a/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
+++ b/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
@@ -18,16 +18,14 @@
     <DebuggerSupport>false</DebuggerSupport>
     <MetricsSupport>true</MetricsSupport>
     <HttpActivityPropagationSupport>false</HttpActivityPropagationSupport>
-    <!-- Playwright is not AOT-compatible (deep reflection usage); keep package-level warnings suppressed while surfacing project-owned trim diagnostics. -->
+    <!-- Optional protocol packages can carry transitive AOT warnings; keep package-level warnings suppressed while surfacing project-owned trim diagnostics. -->
     <NoWarn>$(NoWarn);IL2104;IL3000;IL3002;IL3053</NoWarn>
   </PropertyGroup>
-  <ItemGroup>
-    <TrimmerRootAssembly Include="Microsoft.Playwright" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenClaw.Core\OpenClaw.Core.csproj" />
     <ProjectReference Include="..\OpenClaw.Agent\OpenClaw.Agent.csproj" />
     <ProjectReference Include="..\OpenClaw.Channels\OpenClaw.Channels.csproj" />
+    <ProjectReference Include="..\OpenClaw.Protocols.Browser\OpenClaw.Protocols.Browser.csproj" />
     <ProjectReference Include="..\OpenClaw.Protocols.Mqtt\OpenClaw.Protocols.Mqtt.csproj" />
     <ProjectReference Include="..\OpenClaw.Payments.Abstractions\OpenClaw.Payments.Abstractions.csproj" />
     <ProjectReference Include="..\OpenClaw.Payments.Core\OpenClaw.Payments.Core.csproj" />

--- a/src/OpenClaw.Protocols.Browser/OpenClaw.Protocols.Browser.csproj
+++ b/src/OpenClaw.Protocols.Browser/OpenClaw.Protocols.Browser.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>OpenClaw.Protocols.Browser</RootNamespace>
+    <!-- Playwright uses reflection/dynamic loading; keep this optional protocol dependency out of Agent's dependency surface. -->
+    <NoWarn>$(NoWarn);IL2104;IL3000;IL3002;IL3053</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="OpenClaw.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OpenClaw.Core\OpenClaw.Core.csproj" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.58.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <TrimmerRootAssembly Include="Microsoft.Playwright" />
+  </ItemGroup>
+</Project>

--- a/src/OpenClaw.Protocols.Browser/Tools/BrowserTool.cs
+++ b/src/OpenClaw.Protocols.Browser/Tools/BrowserTool.cs
@@ -8,16 +8,16 @@ using OpenClaw.Core.Models;
 using OpenClaw.Core.Observability;
 using OpenClaw.Core.Security;
 
-namespace OpenClaw.Agent.Tools;
+namespace OpenClaw.Protocols.Browser.Tools;
 
 /// <summary>
 /// A native interactive headless browser tool leveraging Microsoft.Playwright.
 /// Allows agents to query dynamic SPAs, fill forms, and click elements.
 /// </summary>
-public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
+public sealed class BrowserTool : ITool, ISandboxCapableTool, IToolLocalExecutionPolicy, IAsyncDisposable
 {
     private const string SandboxProfileDir = "/tmp/openclaw-browser-profile";
-    internal const string LocalExecutionUnavailableMessage =
+    private const string BrowserLocalExecutionUnavailableMessage =
         "Error: Browser tool requires a configured execution backend or sandbox in this runtime. Local Playwright execution is unavailable.";
     private const string SandboxRunnerScript = """
         const { chromium } = require('playwright');
@@ -275,6 +275,10 @@ public sealed class BrowserTool : ITool, ISandboxCapableTool, IAsyncDisposable
     }
 
     public string Name => "browser";
+
+    public string LocalExecutionUnavailableFailureCode => ToolFailureCodes.BrowserBackendMissing;
+
+    public string LocalExecutionUnavailableMessage => BrowserLocalExecutionUnavailableMessage;
     
     public string Description => 
         "An interactive headless browser. Enables navigation to JS-heavy sites, " +

--- a/src/OpenClaw.Tests/BrowserToolTests.cs
+++ b/src/OpenClaw.Tests/BrowserToolTests.cs
@@ -6,14 +6,33 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using OpenClaw.Agent.Tools;
+using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Models;
+using OpenClaw.Protocols.Browser.Tools;
 
 namespace OpenClaw.Tests;
 
 [Collection(EnvironmentVariableCollection.Name)]
 public class BrowserToolTests
 {
+    [Fact]
+    public async Task BrowserTool_LocalExecutionPolicy_ReportsBrowserBackendFailure()
+    {
+        await using var browser = new BrowserTool(
+            new ToolingConfig { EnableBrowserTool = true },
+            localExecutionSupported: false);
+
+        var policy = Assert.IsAssignableFrom<IToolLocalExecutionPolicy>(browser);
+        Assert.False(policy.LocalExecutionSupported);
+        Assert.Equal(ToolFailureCodes.BrowserBackendMissing, policy.LocalExecutionUnavailableFailureCode);
+        Assert.Equal(
+            "Error: Browser tool requires a configured execution backend or sandbox in this runtime. Local Playwright execution is unavailable.",
+            policy.LocalExecutionUnavailableMessage);
+
+        var result = await browser.ExecuteAsync("""{"action":"get_text"}""", CancellationToken.None);
+        Assert.Equal(policy.LocalExecutionUnavailableMessage, result);
+    }
+
     [Fact]
     public async Task BrowserTool_CanNavigateAndGetText()
     {

--- a/src/OpenClaw.Tests/OpenClaw.Tests.csproj
+++ b/src/OpenClaw.Tests/OpenClaw.Tests.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\OpenClaw.Payments.Core\OpenClaw.Payments.Core.csproj" />
     <ProjectReference Include="..\OpenClaw.Payments.StripeLink\OpenClaw.Payments.StripeLink.csproj" />
     <ProjectReference Include="..\OpenClaw.Providers.MicrosoftExtensionsAI\OpenClaw.Providers.MicrosoftExtensionsAI.csproj" />
+    <ProjectReference Include="..\OpenClaw.Protocols.Browser\OpenClaw.Protocols.Browser.csproj" />
     <ProjectReference Include="..\OpenClaw.Protocols.Mqtt\OpenClaw.Protocols.Mqtt.csproj" />
     <ProjectReference Include="..\OpenClaw.Plugins.Payment\OpenClaw.Plugins.Payment.csproj" />
     <ProjectReference Include="..\OpenClaw.SemanticKernelAdapter\OpenClaw.SemanticKernelAdapter.csproj" />

--- a/src/OpenClaw.Tests/OpenClawToolExecutorTests.cs
+++ b/src/OpenClaw.Tests/OpenClawToolExecutorTests.cs
@@ -303,6 +303,29 @@ public sealed class OpenClawToolExecutorTests
         Assert.Contains("Configure the required execution backend or sandbox", result.NextStep ?? string.Empty, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_LocalExecutionPolicyFailure_UsesStructuredFailureCode()
+    {
+        var tool = new LocalExecutionDisabledTool();
+        var executor = CreateExecutor([tool]);
+
+        var result = await executor.ExecuteAsync(
+            tool.Name,
+            """{"action":"restricted"}""",
+            callId: null,
+            CreateSession(),
+            CreateTurnContext(),
+            isStreaming: false,
+            approvalCallback: null,
+            CancellationToken.None);
+
+        Assert.Equal(ToolResultStatuses.Blocked, result.ResultStatus);
+        Assert.Equal(ToolFailureCodes.RuntimeCapabilityUnavailable, result.FailureCode);
+        Assert.Equal(ToolFailureCodes.RuntimeCapabilityUnavailable, result.Invocation.FailureCode);
+        Assert.Equal(tool.LocalExecutionUnavailableMessage, result.ResultText);
+        Assert.Contains("Configure the required execution backend or sandbox", result.NextStep ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static OpenClawToolExecutor CreateExecutor(
         IReadOnlyList<ITool> tools,
         IToolSandbox? toolSandbox = null,
@@ -392,6 +415,19 @@ public sealed class OpenClawToolExecutorTests
 
         public ValueTask<string> ExecuteAsync(string argumentsJson, CancellationToken ct)
             => throw new InvalidOperationException(message);
+    }
+
+    private sealed class LocalExecutionDisabledTool : ITool, IToolLocalExecutionPolicy
+    {
+        public string Name => "policy_blocked";
+        public string Description => "Tool that cannot run locally.";
+        public string ParameterSchema => """{"type":"object","properties":{"action":{"type":"string"}}}""";
+        public bool LocalExecutionSupported => false;
+        public string LocalExecutionUnavailableFailureCode => ToolFailureCodes.RuntimeCapabilityUnavailable;
+        public string LocalExecutionUnavailableMessage => "Error: Local execution is unavailable for this policy tool.";
+
+        public ValueTask<string> ExecuteAsync(string argumentsJson, CancellationToken ct)
+            => throw new InvalidOperationException("Local execution should not be invoked.");
     }
 
     private sealed class ListLogger : ILogger

--- a/src/OpenClaw.Tests/SandboxToolContractTests.cs
+++ b/src/OpenClaw.Tests/SandboxToolContractTests.cs
@@ -2,6 +2,7 @@ using OpenClaw.Agent.Tools;
 using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Models;
 using OpenClaw.Core.Plugins;
+using OpenClaw.Protocols.Browser.Tools;
 using Xunit;
 
 namespace OpenClaw.Tests;

--- a/src/OpenClaw.Tests/UrlSafetyValidatorTests.cs
+++ b/src/OpenClaw.Tests/UrlSafetyValidatorTests.cs
@@ -3,6 +3,7 @@ using OpenClaw.Core.Abstractions;
 using OpenClaw.Core.Models;
 using OpenClaw.Core.Plugins;
 using OpenClaw.Core.Security;
+using OpenClaw.Protocols.Browser.Tools;
 using Xunit;
 
 namespace OpenClaw.Tests;


### PR DESCRIPTION
## Summary
- Add a neutral Core tool local-execution fallback policy so the agent executor no longer depends on BrowserTool-specific logic.
- Move the Playwright-backed browser tool into the new OpenClaw.Protocols.Browser project and remove Microsoft.Playwright from OpenClaw.Agent.
- Wire Gateway/tests/docs to the new browser protocol assembly while preserving Tooling.EnableBrowserTool behavior and fallback diagnostics.

## Validation
- dotnet restore OpenClaw.Net.slnx
- dotnet build OpenClaw.Net.slnx -c Release --no-restore
- dotnet test src/OpenClaw.Tests -c Release --no-build
- dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build
- dotnet list src/OpenClaw.Agent/OpenClaw.Agent.csproj package
- dotnet list src/OpenClaw.Protocols.Browser/OpenClaw.Protocols.Browser.csproj package
- dotnet publish src/OpenClaw.Gateway/OpenClaw.Gateway.csproj -c Release -r osx-arm64 --self-contained true -p:OpenClawSkipDashboardBuild=true -o /tmp/openclaw-gateway-browser-extract-publish
- git diff --check

Note: the Gateway NativeAOT publish completed successfully with only macOS linker/debug-info warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional browser automation protocol package added, with explicit local-execution policy and structured failure reporting.

* **Documentation**
  * Docs and README updated to show browser automation alongside other optional protocol packages and clarify composition guidance.

* **Chores**
  * Reorganized protocol integrations to decouple browser support from core agent/runtime composition.

* **Tests**
  * Added tests confirming local-execution unavailability returns structured failure codes and user-facing messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->