### PR TITLE
Fix DynamicNative plugin entry Config JSON not loading

### DIFF
--- a/src/OpenClaw.Gateway/Bootstrap/GatewayBootstrapExtensions.cs
+++ b/src/OpenClaw.Gateway/Bootstrap/GatewayBootstrapExtensions.cs
@@ -263,13 +263,23 @@ internal static class GatewayBootstrapExtensions
 
     private static void HydratePluginEntryConfigJson(GatewayConfig config, IConfiguration configuration)
     {
-        var entriesSection = configuration.GetSection("OpenClaw").GetSection("Plugins").GetSection("Entries");
+        var pluginsSection = configuration.GetSection("OpenClaw").GetSection("Plugins");
+        HydrateEntryConfigJson(pluginsSection.GetSection("Entries"), config.Plugins.Entries);
+        HydrateEntryConfigJson(
+            pluginsSection.GetSection("DynamicNative").GetSection("Entries"),
+            config.Plugins.DynamicNative.Entries);
+    }
+
+    private static void HydrateEntryConfigJson(
+        IConfigurationSection entriesSection,
+        Dictionary<string, PluginEntryConfig> entries)
+    {
         foreach (var pluginSection in entriesSection.GetChildren())
         {
-            if (!config.Plugins.Entries.TryGetValue(pluginSection.Key, out var entry))
+            if (!entries.TryGetValue(pluginSection.Key, out var entry))
             {
                 entry = new PluginEntryConfig();
-                config.Plugins.Entries[pluginSection.Key] = entry;
+                entries[pluginSection.Key] = entry;
             }
 
             var pluginConfigSection = pluginSection.GetSection("Config");

--- a/src/OpenClaw.Tests/GatewayBootstrapExtensionsTests.cs
+++ b/src/OpenClaw.Tests/GatewayBootstrapExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using OpenClaw.Gateway.Bootstrap;
 using OpenClaw.Gateway.Extensions;
@@ -27,6 +28,51 @@ public sealed class GatewayBootstrapExtensionsTests
         Assert.Equal(["/app/workspace"], config.Tooling.AllowedReadRoots);
         Assert.Equal(["/app/workspace"], config.Tooling.AllowedWriteRoots);
         GatewaySecurityExtensions.EnforcePublicBindHardening(config, isNonLoopbackBind: true);
+    }
+
+    [Fact]
+    public void LoadGatewayConfig_HydratesPluginEntryConfigJson()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["OpenClaw:Plugins:Entries:bridge-plugin:Enabled"] = "true",
+                ["OpenClaw:Plugins:Entries:bridge-plugin:Config:apiKey"] = "secret",
+                ["OpenClaw:Plugins:Entries:bridge-plugin:Config:retries"] = "3"
+            })
+            .Build();
+
+        var config = GatewayBootstrapExtensions.LoadGatewayConfig(configuration);
+
+        Assert.True(config.Plugins.Entries.TryGetValue("bridge-plugin", out var entry));
+        Assert.NotNull(entry!.Config);
+        var element = entry.Config!.Value;
+        Assert.Equal("secret", element.GetProperty("apiKey").GetString());
+        Assert.Equal(3, element.GetProperty("retries").GetInt32());
+    }
+
+    [Fact]
+    public void LoadGatewayConfig_HydratesDynamicNativePluginEntryConfigJson()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["OpenClaw:Plugins:DynamicNative:Enabled"] = "true",
+                ["OpenClaw:Plugins:DynamicNative:Entries:native-plugin:Enabled"] = "true",
+                ["OpenClaw:Plugins:DynamicNative:Entries:native-plugin:Config:endpoint"] = "https://example.com",
+                ["OpenClaw:Plugins:DynamicNative:Entries:native-plugin:Config:maxItems"] = "42"
+            })
+            .Build();
+
+        var config = GatewayBootstrapExtensions.LoadGatewayConfig(configuration);
+
+        Assert.True(config.Plugins.DynamicNative.Entries.TryGetValue("native-plugin", out var entry));
+        Assert.True(entry!.Enabled);
+        Assert.NotNull(entry.Config);
+        var element = entry.Config!.Value;
+        Assert.Equal(JsonValueKind.Object, element.ValueKind);
+        Assert.Equal("https://example.com", element.GetProperty("endpoint").GetString());
+        Assert.Equal(42, element.GetProperty("maxItems").GetInt32());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #161 — `GatewayConfig.Plugins.DynamicNative.Entries[*].Config` was always `null` after `LoadGatewayConfig`.

## Root cause

`PluginEntryConfig.Config` is a `JsonElement?`. The default `Microsoft.Extensions.Configuration` binder (`IConfiguration.Get<GatewayConfig>()`) cannot populate `JsonElement` properties, so the gateway hydrates them manually in `HydratePluginEntryConfigJson`.

That manual hydration only walked `OpenClaw:Plugins:Entries` and never touched `OpenClaw:Plugins:DynamicNative:Entries` — even though `NativeDynamicPluginsConfig.Entries` uses the exact same `Dictionary<string, PluginEntryConfig>` shape. As a result, dynamic native plugins loaded with an empty `Config`.

## Fix

- Extracted the per-section hydration logic into a reusable `HydrateEntryConfigJson(section, entries)` helper.
- Applied it to **both** `Plugins:Entries` and `Plugins:DynamicNative:Entries`.

## Tests

Added two tests to `GatewayBootstrapExtensionsTests`:
- `LoadGatewayConfig_HydratesPluginEntryConfigJson` — confirms bridge plugin entry `Config` still hydrates (regression guard).
- `LoadGatewayConfig_HydratesDynamicNativePluginEntryConfigJson` — confirms dynamic native entry `Config` now hydrates.

> Note: the .NET SDK was not available in this environment, so the build/tests were not executed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iv3zAcGDzTvxWu46ZUeUF

---
_Generated by [Claude Code](https://claude.ai/code/session_012iv3zAcGDzTvxWu46ZUeUF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved plugin configuration entry hydration through centralized helper logic, now properly handling both standard and dynamic native plugin entries.

* **Tests**
  * Added test coverage validating plugin configuration loading and JSON parsing for both standard and dynamic native plugin configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->