### PR TITLE
feat(skills): add ScanSubdirectories config for recursive sub-skill d…

### DIFF
--- a/docs/authoring/meta-skills.md
+++ b/docs/authoring/meta-skills.md
@@ -64,6 +64,42 @@ src/OpenClaw.Gateway/skills/<skill-name>/SKILL.md    # Gateway bundled
 Generated proposals are reviewed before installation. After accepting a
 proposal, OpenClaw.NET promotes it and refreshes the skill loader.
 
+## Bundling Sub-Skills
+
+A MetaSkill may delegate to standard skills via `kind: agent` or `kind: skill_exec`.
+These delegated (sub-)skills can be bundled alongside the MetaSkill in nested
+subdirectories:
+
+```
+~/.openclaw/skills/my-meta/
+  SKILL.md                        # kind: meta (my-meta)
+  subskills/
+    fetcher/SKILL.md               # kind: standard (fetcher)
+    reporter/SKILL.md              # kind: standard (reporter)
+    pdf/SKILL.md                   # kind: standard (pdf)
+```
+
+Enable recursive scanning in your config so the loader discovers nested `SKILL.md`
+files:
+
+```json
+{
+  "Skills": {
+    "Load": {
+      "ScanSubdirectories": true
+    }
+  }
+}
+```
+
+When `ScanSubdirectories` is `true`, `SkillLoader` uses `SearchOption.AllDirectories`
+instead of `TopDirectoryOnly`. This makes every nested `SKILL.md` discoverable
+without requiring each sub-skill directory to be registered as a separate
+`ExtraDirs` entry.
+
+Defaults to `false` for backward compatibility. The flag applies to ExtraDirs,
+Bundled, Managed, Plugin, and Workspace skill directories uniformly.
+
 ## Required Frontmatter
 
 ```yaml

--- a/docs/meta-skill-orchestration.md
+++ b/docs/meta-skill-orchestration.md
@@ -172,6 +172,11 @@ than defaulting to a full sub-agent for everything.
 as the system prompt to generate a full agent response. This kind allows the model
 to perform multi-turn reasoning and tool calls.
 
+The referenced skill must be a standard skill (`kind: standard`), not another
+MetaSkill. Sub-skills can be discovered from nested subdirectories (e.g.
+`subskills/docx/SKILL.md`) when `Skills.Load.ScanSubdirectories` is enabled in
+config.
+
 ### `llm_classify` — Constrained Classification
 
 Forces the model to return exactly one label from `output_choices`. Used for routing

--- a/docs/zh-CN/authoring/meta-skills.md
+++ b/docs/zh-CN/authoring/meta-skills.md
@@ -59,6 +59,39 @@ src/OpenClaw.Gateway/skills/<skill-name>/SKILL.md    # Gateway 内置
 生成的提案审查通过后才安装。接受提案后，OpenClaw.NET 将其提升并刷新 Skill
 加载器。
 
+## 打包子 Skill
+
+MetaSkill 可通过 `kind: agent` 或 `kind: skill_exec` 委托标准 Skill。这些被委托的子 Skill
+可以与 MetaSkill 一起打包在嵌套子目录中：
+
+```
+~/.openclaw/skills/my-meta/
+  SKILL.md                        # kind: meta (my-meta)
+  subskills/
+    fetcher/SKILL.md               # kind: standard (fetcher)
+    reporter/SKILL.md              # kind: standard (reporter)
+    pdf/SKILL.md                   # kind: standard (pdf)
+```
+
+在配置中启用递归扫描，使加载器能发现嵌套的 `SKILL.md` 文件：
+
+```json
+{
+  "Skills": {
+    "Load": {
+      "ScanSubdirectories": true
+    }
+  }
+}
+```
+
+当 `ScanSubdirectories` 为 `true` 时，`SkillLoader` 使用 `SearchOption.AllDirectories`
+替代 `TopDirectoryOnly`。这使得每个嵌套的 `SKILL.md` 文件都可被发现，无需将每个子
+Skill 目录单独注册为 `ExtraDirs` 条目。
+
+默认为 `false` 以保持向后兼容。该标志统一应用于 ExtraDirs、Bundled、Managed、Plugin
+和 Workspace 技能目录。
+
 ## 必需的前置元数据
 
 ```yaml

--- a/docs/zh-CN/meta-skill-orchestration.md
+++ b/docs/zh-CN/meta-skill-orchestration.md
@@ -148,6 +148,9 @@ if (!TryValidateMetaPlan(steps, LoadedSkills, out var validationError))
 
 `agent` 是默认类型，通过注入被引用 Skill 的 `SKILL.md` 指令作为 system prompt 来生成完整 Agent 响应。该类型允许模型进行多轮推理和工具调用。
 
+被引用的 Skill 必须是标准 Skill（`kind: standard`），不能是另一个 MetaSkill。当配置中启用
+`Skills.Load.ScanSubdirectories` 时，子 Skill 可从嵌套子目录（如 `subskills/docx/SKILL.md`）中发现。
+
 ### `llm_classify` —— 约束分类
 
 强制模型从 `output_choices` 中返回恰好一个标签。用于路由和分流场景：

--- a/src/OpenClaw.Core/Skills/SkillLoader.cs
+++ b/src/OpenClaw.Core/Skills/SkillLoader.cs
@@ -30,10 +30,11 @@ public static class SkillLoader
         var allSkills = new Dictionary<string, SkillDefinition>(StringComparer.OrdinalIgnoreCase);
 
         // 1. Extra dirs (lowest precedence — added first, overwritten by higher)
+        var scanSubdirectories = config.Load.ScanSubdirectories;
         foreach (var dir in config.Load.ExtraDirs)
         {
             if (Directory.Exists(dir))
-                ScanDirectory(dir, SkillSource.Extra, allSkills, logger);
+                ScanDirectory(dir, SkillSource.Extra, allSkills, logger, scanSubdirectories);
         }
 
         // 2. Bundled skills
@@ -41,7 +42,7 @@ public static class SkillLoader
         {
             var bundledDir = Path.Combine(AppContext.BaseDirectory, "skills");
             if (Directory.Exists(bundledDir))
-                ScanDirectory(bundledDir, SkillSource.Bundled, allSkills, logger);
+                ScanDirectory(bundledDir, SkillSource.Bundled, allSkills, logger, scanSubdirectories);
         }
 
         // 3. Managed/local skills
@@ -51,7 +52,7 @@ public static class SkillLoader
                 ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".openclaw", "skills")
                 : NormalizeManagedRootPath(config.Load.ManagedRoot, logger);
             if (managedDir is not null && TryDirectoryExists(managedDir))
-                ScanDirectory(managedDir, SkillSource.Managed, allSkills, logger);
+                ScanDirectory(managedDir, SkillSource.Managed, allSkills, logger, scanSubdirectories);
         }
 
         // 4. Plugin-packaged skills
@@ -60,7 +61,7 @@ public static class SkillLoader
             foreach (var pluginDir in pluginSkillDirs)
             {
                 if (Directory.Exists(pluginDir))
-                    ScanDirectory(pluginDir, SkillSource.Plugin, allSkills, logger);
+                    ScanDirectory(pluginDir, SkillSource.Plugin, allSkills, logger, scanSubdirectories);
             }
         }
 
@@ -69,7 +70,7 @@ public static class SkillLoader
         {
             var wsSkillsDir = Path.Combine(workspacePath, "skills");
             if (Directory.Exists(wsSkillsDir))
-                ScanDirectory(wsSkillsDir, SkillSource.Workspace, allSkills, logger);
+                ScanDirectory(wsSkillsDir, SkillSource.Workspace, allSkills, logger, scanSubdirectories);
         }
 
         // Filter by config and requirements
@@ -157,12 +158,16 @@ public static class SkillLoader
 
     /// <summary>
     /// Scan a directory for subdirectories containing SKILL.md.
+    /// When <paramref name="scanSubdirectories"/> is true, descends into nested
+    /// subdirectories (e.g. subskills/docx/SKILL.md) so that parent skill
+    /// directories can bundle sub-skills.
     /// </summary>
     private static void ScanDirectory(
         string rootDir,
         SkillSource source,
         Dictionary<string, SkillDefinition> results,
-        ILogger logger)
+        ILogger logger,
+        bool scanSubdirectories = false)
     {
         try
         {
@@ -186,7 +191,11 @@ public static class SkillLoader
                 }
             }
 
-            foreach (var skillDir in Directory.GetDirectories(rootDir))
+            var searchOption = scanSubdirectories
+                ? SearchOption.AllDirectories
+                : SearchOption.TopDirectoryOnly;
+
+            foreach (var skillDir in Directory.GetDirectories(rootDir, "*", searchOption))
             {
                 var skillFile = Path.Combine(skillDir, "SKILL.md");
                 if (!File.Exists(skillFile))

--- a/src/OpenClaw.Core/Skills/SkillModels.cs
+++ b/src/OpenClaw.Core/Skills/SkillModels.cs
@@ -80,6 +80,14 @@ public sealed class SkillLoadConfig
 
     /// <summary>Debounce interval for the watcher (ms).</summary>
     public int WatchDebounceMs { get; set; } = 250;
+
+    /// <summary>
+    /// When true, ExtraDirs and ManagedRoot are scanned recursively (all nested
+    /// subdirectories) for SKILL.md files. This allows a parent skill directory
+    /// to bundle sub-skills in nested folders (e.g. subskills/docx/SKILL.md).
+    /// Defaults to false for backward compatibility.
+    /// </summary>
+    public bool ScanSubdirectories { get; set; } = false;
 }
 
 /// <summary>

--- a/src/OpenClaw.Tests/SkillTests.cs
+++ b/src/OpenClaw.Tests/SkillTests.cs
@@ -1360,6 +1360,105 @@ public class SkillLoaderTests
     }
 
     [Fact]
+    public void LoadAll_DefaultScanSubdirectories_DoesNotLoadNestedSkills()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-test-skills-shallow-{Guid.NewGuid():N}");
+        var rootSkillDir = Path.Combine(tempDir, "skills", "meta-skill");
+        var nestedSkillDir = Path.Combine(rootSkillDir, "subskills", "reporter");
+        Directory.CreateDirectory(nestedSkillDir);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(rootSkillDir, "SKILL.md"), """
+                ---
+                name: meta-skill
+                description: Root meta skill
+                kind: meta
+                composition: {"steps":[{"id":"collect","kind":"user_input","with":{"prompt":"ok?"}}]}
+                ---
+                Root instructions.
+                """);
+
+            File.WriteAllText(Path.Combine(nestedSkillDir, "SKILL.md"), """
+                ---
+                name: reporter
+                description: Nested reporter skill
+                ---
+                Reporter instructions.
+                """);
+
+            var config = new SkillsConfig
+            {
+                Enabled = true,
+                Load = new SkillLoadConfig { IncludeBundled = false, IncludeManaged = false }
+            };
+            var logger = new TestLogger();
+
+            var skills = SkillLoader.LoadAll(config, tempDir, logger);
+
+            Assert.Contains(skills, skill => skill.Name == "meta-skill");
+            Assert.DoesNotContain(skills, skill => skill.Name == "reporter");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void LoadAll_ScanSubdirectories_LoadsNestedWorkspaceSkills()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-test-skills-recursive-{Guid.NewGuid():N}");
+        var rootSkillDir = Path.Combine(tempDir, "skills", "meta-skill");
+        var nestedSkillDir = Path.Combine(rootSkillDir, "subskills", "reporter");
+        Directory.CreateDirectory(nestedSkillDir);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(rootSkillDir, "SKILL.md"), """
+                ---
+                name: meta-skill
+                description: Root meta skill
+                kind: meta
+                composition: {"steps":[{"id":"collect","kind":"user_input","with":{"prompt":"ok?"}}]}
+                ---
+                Root instructions.
+                """);
+
+            File.WriteAllText(Path.Combine(nestedSkillDir, "SKILL.md"), """
+                ---
+                name: reporter
+                description: Nested reporter skill
+                ---
+                Reporter instructions.
+                """);
+
+            var config = new SkillsConfig
+            {
+                Enabled = true,
+                Load = new SkillLoadConfig
+                {
+                    IncludeBundled = false,
+                    IncludeManaged = false,
+                    ScanSubdirectories = true
+                }
+            };
+            var logger = new TestLogger();
+
+            var skills = SkillLoader.LoadAll(config, tempDir, logger);
+
+            Assert.Contains(skills, skill => skill.Name == "meta-skill");
+            var nestedSkill = Assert.Single(skills, skill => skill.Name == "reporter");
+            Assert.Equal(SkillSource.Workspace, nestedSkill.Source);
+            Assert.Equal(nestedSkillDir, nestedSkill.Location);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void LoadAll_MetaPolicy_FiltersRiskAndCapabilities()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-test-skills-meta-policy-{Guid.NewGuid():N}");


### PR DESCRIPTION
## Description

 - Add ScanSubdirectories flag to SkillLoadConfig (default false, backward compatible)
- SkillLoader.ScanDirectory uses SearchOption.AllDirectories when enabled
- Enables nested sub-skill layouts (e.g. subskills/docx/SKILL.md) without registering each sub-directory as a separate ExtraDirs entry
- Flag applies uniformly to ExtraDirs, Bundled, Managed, Plugin, and Workspace
- Docs: Bundling Sub-Skills section in EN/zh-CN authoring guides
- Docs: ScanSubdirectories note in EN/zh-CN orchestration architecture

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Tests
- [ ] Build/CI
- [ ] Governance/process
- [ ] Refactoring (no functional changes)

## Validation

- [x] `dotnet restore OpenClaw.Net.slnx`
- [x] `dotnet build OpenClaw.Net.slnx --configuration Release --no-restore`
- [x] `dotnet test OpenClaw.Net.slnx --configuration Release --no-build`
- [x] `dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build`

## Review Notes

- [x] I considered NativeAOT compatibility
- [x] I considered security posture and unsafe defaults
- [x] I updated docs/tests where needed
- [x] This PR is scoped and does not mix unrelated changes

 
## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style implementation of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed locally (`dotnet test`)
- [x] I have updated the documentation (README.md, comments) if required
- [ ] I have checked for security implications (input validation, authorization)
- [x] I have checked the relevant [maintainer review checklist](../docs/maintainers/review-checklist.md)
- [ ] I have disclosed whether this directly supports a company or customer use case
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recursive skill discovery for nested subdirectories. Enable `Skills.Load.ScanSubdirectories` to automatically discover bundled/nested `SKILL.md` files (default: `false`).

* **Documentation**
  * Updated meta-skill authoring and orchestration guides (including Chinese versions) with bundling sub-skills guidance and the new recursion/discovery behavior. Clarified `agent` steps must reference a standard skill, not a meta-skill.

* **Tests**
  * Added coverage for default vs. recursive scanning behavior for workspace skills, including validation of nested skill source and location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->