### PR TITLE
feat: add ArtifactContract + Projection systems

### DIFF
--- a/docs/RUNTIME_ARTIFACT_CONTRACT.md
+++ b/docs/RUNTIME_ARTIFACT_CONTRACT.md
@@ -105,7 +105,7 @@ public sealed record SkillStageGateEvent
 
 ### 2.4 Projection Models (14 Classes)
 
-```
+```text
 SkillProjectionContractSet      — Bound projection contract set
 SkillProjectionDiscovery        — Load diagnostics
 SkillProjectionResolution       — Single resolution result
@@ -132,7 +132,7 @@ ProjectionDeliveryArtifact      — Output artifact
 
 ### 3.1 Disk Layout
 
-```
+```text
 skills/<skill-name>/
 ├── SKILL.md
 └── contracts/
@@ -276,7 +276,7 @@ skills/<skill-name>/
 
 ### 3.5 Loading Flow
 
-```
+```text
 SkillLoader.ParseSkillContent()
   │
   ├─ ParseSkillFile(filePath, skillDir, source)
@@ -299,7 +299,7 @@ SkillLoader.ParseSkillContent()
 
 ### 4.1 Runtime Landscape
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────┐
 │                     Gateway Startup                           │
 │                                                              │
@@ -324,7 +324,7 @@ SkillLoader.ParseSkillContent()
 
 ### 4.2 Per-Turn Complete Data Flow
 
-```
+```text
 User Message arrives
   │
   ├─ Gateway ReceiveMessage
@@ -419,7 +419,7 @@ User Message arrives
 
 ### 5.1 Two-Level Matching Algorithm
 
-```
+```text
 Model Input                      | Contract State          | Result
 ─────────────────────────────────────────────────────────────────
 Explicit stage + artifactType    | Both match              | ✅ Success
@@ -435,7 +435,7 @@ No SkillName                     | —                       | ✅ Skip validati
 
 The model only needs to provide minimal fields; the runtime auto-fills the rest:
 
-```
+```text
 Model provides:             Runtime fills:
   artifact_type (required) → Label       ← artifactType.Label
   stage (optional)         → Stage       ← auto-inferred or used directly
@@ -445,7 +445,7 @@ Model provides:             Runtime fills:
 
 ### 5.3 Stage Gate State Machine
 
-```
+```text
 Current Stage Terminal Artifact emitted
   │
   ├─ Is last stage → null (no gate event)
@@ -479,7 +479,7 @@ Current Stage Terminal Artifact emitted
 
 ### 6.2 Signal Scoring Algorithm
 
-```
+```text
 Topic Scoring:
   Score = Σ PrimaryIntentSignals × 5
         + Σ SupportingSignals × 1
@@ -499,7 +499,7 @@ View Scoring:
 
 ### 6.3 Decision Chain
 
-```
+```text
 ResolveForRequest(skill, requestText)
   │
   ├─ For each ProjectionContractSet:
@@ -528,7 +528,7 @@ ResolveForRequest(skill, requestText)
 
 ### 6.4 BuildPromptPatch Output Format
 
-```
+```text
 [Projection Route]
 Selected topic: task-execution
 Selected target view: prompt-constraint

--- a/docs/RUNTIME_ARTIFACT_CONTRACT.md
+++ b/docs/RUNTIME_ARTIFACT_CONTRACT.md
@@ -3,6 +3,7 @@
 ## 1. Overview
 
 **ArtifactContract** and **Projection** are two orthogonal extensions to the OpenClaw Skill system:
+<!-- markdownlint-disable MD040 -->
 
 | System | Responsibility | Trigger |
 |--------|---------------|---------|

--- a/docs/RUNTIME_ARTIFACT_CONTRACT.md
+++ b/docs/RUNTIME_ARTIFACT_CONTRACT.md
@@ -1,0 +1,679 @@
+# Runtime ArtifactContract + Projection Technical Document
+
+## 1. Overview
+
+**ArtifactContract** and **Projection** are two orthogonal extensions to the OpenClaw Skill system:
+
+| System | Responsibility | Trigger |
+|--------|---------------|---------|
+| **ArtifactContract** | Defines the whitelist of allowed artifact types for a Skill's multi-stage workflow; validates `emit_artifact` calls at runtime | When the LLM calls the `emit_artifact` tool |
+| **Projection** | Matches the optimal Skill projection view based on user request signal scoring; dynamically tailors Skill instructions and injects them into the system prompt | Every user turn |
+
+Both systems share the data model layer (`SkillArtifactContractModels.cs`), declare contract rules via JSON files under the `contracts/` directory, and use a null-safe design — silently degrading when no contract file exists, never blocking Skill loading or normal inference.
+
+### 1.1 Key Files
+
+| File | Project | Responsibility |
+|------|---------|---------------|
+| `src/OpenClaw.Core/Models/SkillArtifact.cs` | Core | `SkillArtifact` record — runtime artifact message carrier |
+| `src/OpenClaw.Core/Models/SkillArtifactContractModels.cs` | Core | 4 Artifact contract classes + 14 Projection model classes |
+| `src/OpenClaw.Core/Models/WebSocketEnvelopes.cs` | Core | `WsServerEnvelope` extensions + `SkillStageGateEvent` record |
+| `src/OpenClaw.Core/Skills/SkillModels.cs` | Core | `SkillDefinition` extended properties |
+| `src/OpenClaw.Core/Skills/SkillLoader.cs` | Core | `TryLoadArtifactContract` + `TryLoadProjectionContracts` |
+| `src/OpenClaw.Core/Skills/LoadSkillTool.cs` | Core | ArtifactContract XML injection into prompt |
+| `src/OpenClaw.Core/Skills/SkillPromptBuilder.cs` | Core | `BuildSkillBody` Projection overload |
+| `src/OpenClaw.Core/Skills/SkillProjectionResolver.cs` | Core | Projection routing engine: Topic/View signal matching + scoring + JSON loading |
+| `src/OpenClaw.Core/Skills/SkillProjectionArtifactTerms.cs` | Core | Explicit artifact keyword mappings for four projection views |
+| `src/OpenClaw.Gateway/Tools/EmitArtifactTool.cs` | Gateway | `emit_artifact` tool implementation |
+| `src/OpenClaw.Gateway/Tools/SkillArtifactRuntime.cs` | Gateway | Runtime validation engine + stage state machine |
+| `src/OpenClaw.Agent/AgentRuntime.cs` | Agent | Per-turn Projection resolution + `ResolveSkillsForTurn` + `CloneSkill` |
+| `src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs` | MAF Adapter | Projection resolution equivalent to AgentRuntime |
+
+---
+
+## 2. Core Data Models
+
+### 2.1 SkillArtifact (Runtime Message Carrier)
+
+```csharp
+// SkillArtifact.cs
+public sealed record SkillArtifact
+{
+    public required string Kind { get; init; }          // "file" | "data"
+    public string ArtifactType { get; init; } = "generic";
+    public string? Label { get; init; }
+    public string? SkillName { get; init; }
+    public string? Stage { get; init; }
+    public bool IsTerminal { get; init; }
+    // File fields (kind = "file")
+    public string? FileUrl { get; init; }
+    public string? FileName { get; init; }
+    public string? MimeType { get; init; }
+    public long? FileSizeBytes { get; init; }
+    // Data fields (kind = "data")
+    public JsonElement? Data { get; init; }
+    public string? DisplayHint { get; init; }
+}
+```
+
+### 2.2 SkillArtifactContract (Top-Level Contract)
+
+```csharp
+// SkillArtifactContractModels.cs
+public sealed class SkillArtifactContract
+{
+    public int SchemaVersion { get; init; } = 1;
+    public IReadOnlyList<SkillArtifactStageContract> Stages { get; init; } = [];
+}
+
+public sealed class SkillArtifactStageContract
+{
+    public required string Name { get; init; }
+    public string? Label { get; init; }
+    public SkillArtifactStageGateContract? Gate { get; init; }
+    public IReadOnlyList<SkillArtifactTypeContract> Artifacts { get; init; } = [];
+}
+
+public sealed class SkillArtifactStageGateContract
+{
+    public string? RequiresStage { get; init; }
+}
+
+public sealed class SkillArtifactTypeContract
+{
+    public required string Type { get; init; }
+    public string? Label { get; init; }
+    public string? Display { get; init; }
+    public bool? Terminal { get; init; }
+}
+```
+
+### 2.3 Stage Gate Model (SkillStageGateEvent)
+
+```csharp
+// WebSocketEnvelopes.cs
+public sealed record SkillStageGateEvent
+{
+    public required string SkillName { get; init; }
+    public required string CompletedStage { get; init; }
+    public required string NextStage { get; init; }
+    public required bool CanProceed { get; init; }
+    public string? BlockedReason { get; init; }
+}
+```
+
+### 2.4 Projection Models (14 Classes)
+
+```
+SkillProjectionContractSet      — Bound projection contract set
+SkillProjectionDiscovery        — Load diagnostics
+SkillProjectionResolution       — Single resolution result
+ProjectionContractIndex         — Index: Topics + Views + Scoring
+ProjectionSelectionPolicy       — Selection policy
+ProjectionTopicScoring          — Topic-level scoring config
+ProjectionTargetViewScoring     — View-level scoring config
+ProjectionScoreDimension        — Score dimension
+ProjectionTopicSignals          — Topic signal keywords
+ProjectionViewSignals           — View signal keywords
+ProjectionTopicViewOverride     — Within-topic View weight override
+ProjectionTopicViewBonus        — Bonus weight item
+ProjectionTopicRecord           — Topic definition
+ProjectionViewRecord            — View definition
+ProjectionDocument              — Projection file content
+ProjectionMappingPolicy         — Mapping policy
+ProjectionPromptPayload         — Prompt constraint payload
+ProjectionDeliveryArtifact      — Output artifact
+```
+
+---
+
+## 3. Loading Mechanism
+
+### 3.1 Disk Layout
+
+```
+skills/<skill-name>/
+├── SKILL.md
+└── contracts/
+    ├── artifacts.json                ← ArtifactContract
+    └── projections/                  ← Projection index root
+        └── <producer-name>/
+            ├── contract-index.json   ← Index definition
+            └── <view-path>.json      ← Concrete projection file
+```
+
+### 3.2 artifacts.json Example
+
+```json
+{
+  "schemaVersion": 1,
+  "stages": [
+    {
+      "name": "stage1_collect",
+      "label": "Stage 1: Collection",
+      "artifacts": [
+        {
+          "type": "progress_update",
+          "label": "Progress",
+          "display": "progress",
+          "terminal": false
+        },
+        {
+          "type": "collection_summary",
+          "label": "Summary",
+          "display": "tree",
+          "terminal": true
+        }
+      ]
+    },
+    {
+      "name": "stage2_analysis",
+      "label": "Stage 2: Analysis",
+      "gate": { "requiresStage": "stage1_collect" },
+      "artifacts": [
+        { "type": "analysis_result", "label": "Result", "display": "tree", "terminal": true }
+      ]
+    }
+  ]
+}
+```
+
+### 3.3 contract-index.json Example
+
+```json
+{
+  "producer_skill": "ontology-extraction",
+  "producer_priority": 10,
+  "default_selection_policy": {
+    "prefer_ready_only": true,
+    "block_on_open_questions": false,
+    "fallback_order_by_target_view": ["domain-model", "json-schema"]
+  },
+  "topic_scoring": {
+    "clarify_when_score_gap_below": 2,
+    "score_dimensions": [
+      { "dimension": "primary_intent_match", "score": 5 },
+      { "dimension": "explicit_artifact_bonus", "score": 4 }
+    ],
+    "topics": [
+      {
+        "domain_slug": "skill-loading",
+        "primary_intent_signals": ["load skill", "skill loading"],
+        "supporting_signals": ["skill"],
+        "explicit_artifact_signals": ["skill definition"],
+        "demote_when_competing_topic_signals": []
+      }
+    ]
+  },
+  "target_view_scoring": {
+    "score_dimensions": [
+      { "dimension": "explicit_output_match", "score": 5 },
+      { "dimension": "strong_signal_match", "score": 3 }
+    ],
+    "views": [
+      {
+        "target_view": "json-schema",
+        "explicit_output_signals": ["json schema", "schema file"],
+        "strong_signals": ["schema", "structure"],
+        "supporting_signals": [],
+        "demote_when_competing_view_signals": []
+      }
+    ],
+    "within_topic_overrides": [
+      {
+        "domain_slug": "skill-loading",
+        "bonuses": [
+          {
+            "target_view": "json-schema",
+            "when_request_signals": ["validate"],
+            "score": 3
+          }
+        ]
+      }
+    ]
+  },
+  "topics": [
+    {
+      "domain_slug": "skill-loading",
+      "default_target_view": "domain-model",
+      "views": [
+        { "target_view": "domain-model", "status": "READY", "path": "domain-model/projection.json" },
+        { "target_view": "json-schema", "status": "DRAFT", "path": "json-schema/projection.json" }
+      ]
+    }
+  ]
+}
+```
+
+### 3.4 projection.json Example
+
+```json
+{
+  "mapping_policy": {
+    "unresolved_item_policy": "allow_unmapped_terms",
+    "prompt_assumption_policy": "disallow_unmapped_terms"
+  },
+  "prompt_projection": {
+    "allowed_terms": ["skill_config", "model_provider"],
+    "forbidden_assumptions": ["API key is embedded"],
+    "required_clarifications": ["Identify the target deployment provider"],
+    "reasoning_paths": ["Provider → Model → Config → Deploy"],
+    "source_digest": ["Extracted from SkillsConfigModel"]
+  },
+  "delivery_artifacts": [
+    {
+      "artifact_name": "SkillsConfig",
+      "artifact_type": "json_schema",
+      "path": "artifacts/SkillsConfig.schema.json",
+      "status": "planned"
+    }
+  ],
+  "dropped_items": [],
+  "open_questions": []
+}
+```
+
+### 3.5 Loading Flow
+
+```
+SkillLoader.ParseSkillContent()
+  │
+  ├─ ParseSkillFile(filePath, skillDir, source)
+  │   └─ ReadAllText → ParseSkillContent
+  │
+  ├─ ScanSkillResources(skillDir)    ← scan references/scripts/
+  ├─ TryLoadArtifactContract(skillDir, logger)
+  │   └─ Read contracts/artifacts.json → SkillArtifactContract
+  │   └─ File missing / parse error → null (silent degrade)
+  │
+  └─ TryLoadProjectionContracts(skillDir, logger)
+      └─ Scan contracts/projections/*/contract-index.json
+      └─ Dir missing → ProjectionContracts = [], Discovery.Status = "none"
+      └─ Parse error → Discovery.Status = "partial" / "parse-failed"
+```
+
+---
+
+## 4. Runtime Architecture
+
+### 4.1 Runtime Landscape
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                     Gateway Startup                           │
+│                                                              │
+│   new SkillArtifactRuntime()                                  │
+│   skills = SkillLoader.LoadAll(...)                            │
+│   artifactRuntime.ReplaceSkills(skills)   ← initial register  │
+│                                                              │
+│   ┌─ Native AgentRuntime ─┐  ┌─ MAF AgentRuntime ─┐         │
+│   │ (OpenClaw.Agent)      │  │ (MicrosoftAgent-    │         │
+│   │                       │  │  FrameworkAdapter)  │         │
+│   │ AgentRuntime.cs       │  │ MafAgentRuntime.cs  │         │
+│   └───────────────────────┘  └─────────────────────┘         │
+│                                                              │
+│   ┌─ Shared Tool Layer ────────────────────────────┐        │
+│   │ EmitArtifactTool  ←─ SkillArtifactRuntime       │        │
+│   │ LoadSkillTool     ←─ SkillDefinition (Contract) │        │
+│   │ ReadSkillResourceTool                           │        │
+│   │ MetaInvokeTool                                  │        │
+│   └─────────────────────────────────────────────────┘        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 Per-Turn Complete Data Flow
+
+```
+User Message arrives
+  │
+  ├─ Gateway ReceiveMessage
+  │
+  ├─ AgentRuntime.GetSystemPrompt(session, userMessage)   ← new: userMessage param
+  │   │
+  │   ├─ Check hasProjectionSkills?
+  │   │   │
+  │   │   ├─ YES (any Skill has ProjectionContracts):
+  │   │   │   └─ ResolveSkillsForTurn(_loadedSkills, userMessage, out blockedRoutes)
+  │   │   │       │
+  │   │   │       ├─ For each Skill:
+  │   │   │       │   ├─ No ProjectionContracts → keep as-is
+  │   │   │       │   │
+  │   │   │       │   └─ Has ProjectionContracts:
+  │   │   │       │       └─ SkillProjectionResolver.ResolveForRequest(skill, userMessage)
+  │   │   │       │           ├─ SelectTopic(index, requestText)   ← signal scoring
+  │   │   │       │           │   ├─ PrimaryIntentSignals weight 5
+  │   │   │       │           │   ├─ SupportingSignals weight 1
+  │   │   │       │           │   ├─ ExplicitArtifactSignals bonus +4
+  │   │   │       │           │   └─ DemoteWhenCompeting penalty -2
+  │   │   │       │           │
+  │   │   │       │           ├─ SelectView(index, topic, requestText)  ← view match
+  │   │   │       │           │   ├─ ExplicitOutputSignals weight 5
+  │   │   │       │           │   ├─ StrongSignals weight 3
+  │   │   │       │           │   ├─ SupportingSignals weight 1
+  │   │   │       │           │   ├─ CrossViewPenalty -2
+  │   │   │       │           │   ├─ DefaultViewBonus +1
+  │   │   │       │           │   └─ TopicOverrideBonuses variable
+  │   │   │       │           │
+  │   │   │       │           ├─ LoadProjection(filePath)            ← load projection.json
+  │   │   │       │           │
+  │   │   │       │           ├─ Check PreferReadyOnly / BlockOnOpenQuestions / BlockOrEscalate
+  │   │   │       │           │
+  │   │   │       │           └─ Multi-producer ranking: Score → ProducerPriority
+  │   │   │       │
+  │   │   │       ├─ IsBlocked?
+  │   │   │       │   └─ CloneSkill(skill, originalInstructions, disableModel: true)
+  │   │   │       │       Record in [Blocked Skill Routes]
+  │   │   │       │
+  │   │   │       └─ HasPatch?
+  │   │   │           └─ CloneSkill(skill, patchedInstructions, disableModel: false)
+  │   │   │               Instructions += "\n\n[Projection Route]\n<projection-patch>"
+  │   │   │
+  │   │   └─ BuildIndex(effectiveSkills) → Patched Skill Index
+  │   │   └─ [Blocked Skill Routes] injected
+  │   │
+  │   └─ NO:
+  │       └─ Use cached _systemPrompt (zero overhead)
+  │
+  ├─ BuildMessages(session, userMessage)
+  │   └─ List<ChatMessage> { System(patchedPrompt), History... }
+  │
+  ├─ LLM Inference (sees patched skill index)
+  │   │
+  │   ├─ LLM calls load_skill({ skill: "xxx" })
+  │   │   └─ LoadSkillTool.ExecuteAsync()
+  │   │       ├─ BuildSkillBody(match)           ← full skill instructions
+  │   │       ├─ if ArtifactContract:            ← inject <skill-artifact-contract> XML
+  │   │       ├─ if Resources:                   ← inject <skill-resources> manifest
+  │   │       └─ return body
+  │   │
+  │   └─ LLM calls emit_artifact({ kind, artifact_type, stage, ... })
+  │       └─ EmitArtifactTool.ExecuteAsync()
+  │           ├─ kind=file → ExecuteFileAsync()
+  │           │   ├─ ResolveRealPath → IsReadAllowed
+  │           │   ├─ ReadFile → MediaCache.Save → /media/{id}
+  │           │   ├─ _artifactRuntime.NormalizeAndRecord(sessionId, artifact)
+  │           │   │   ├─ No SkillName → skip validation, pass through
+  │           │   │   ├─ SkillName not in registry → reject
+  │           │   │   ├─ No contract → skip validation, pass through
+  │           │   │   ├─ TryResolveArtifactContract()
+  │           │   │   │   ├─ Explicit stage → exact match
+  │           │   │   │   └─ Inferred stage → global unique match
+  │           │   │   ├─ Normalize: Label/DisplayHint/IsTerminal/Stage
+  │           │   │   ├─ if Terminal → MarkStageTerminal() + BuildGateEvent()
+  │           │   │   └─ return SkillArtifactResult
+  │           │   ├─ WebSocket → { type: "artifact", artifact: ... }
+  │           │   └─ if StageGate → { type: "skill_stage_gate", stage_gate: ... }
+  │           │
+  │           └─ kind=data → ExecuteDataAsync()
+  │               └─ Same flow without file operations
+  │
+  └─ WebSocket → Frontend
+      ├─ "artifact" envelope → render (progress/tree/badge/file/text)
+      └─ "skill_stage_gate" envelope → update stage capsule state
+```
+
+---
+
+## 5. Contract Validation Engine (SkillArtifactRuntime)
+
+### 5.1 Two-Level Matching Algorithm
+
+```
+Model Input                      | Contract State          | Result
+─────────────────────────────────────────────────────────────────
+Explicit stage + artifactType    | Both match              | ✅ Success
+Explicit stage + artifactType    | Stage exists, type not  | ❌ "not declared for stage"
+Explicit stage + artifactType    | Stage not found         | ❌ "not declared"
+Only artifactType                | Globally unique         | ✅ Auto-infer stage
+Only artifactType                | Zero matches            | ❌ "not declared in contracts"
+Only artifactType                | Multi-stage ambiguous   | ❌ "appears in multiple stages"
+No SkillName                     | —                       | ✅ Skip validation
+```
+
+### 5.2 Normalization Logic
+
+The model only needs to provide minimal fields; the runtime auto-fills the rest:
+
+```
+Model provides:             Runtime fills:
+  artifact_type (required) → Label       ← artifactType.Label
+  stage (optional)         → Stage       ← auto-inferred or used directly
+  label (optional)         → DisplayHint ← artifactType.Display
+  terminal (optional)      → IsTerminal  ← artifactType.Terminal
+```
+
+### 5.3 Stage Gate State Machine
+
+```
+Current Stage Terminal Artifact emitted
+  │
+  ├─ Is last stage → null (no gate event)
+  │
+  └─ Has next stage
+      ├─ No gate.requiresStage → CanProceed = true
+      │
+      └─ Has gate.requiresStage = "stageX"
+          ├─ stageX completed (IsTerminal) → CanProceed = true
+          └─ stageX not completed          → CanProceed = false + BlockedReason
+```
+
+### 5.4 Concurrency Safety
+
+- `_skills`: `ConcurrentDictionary<string, SkillDefinition>` — `ReplaceSkills` clears and rebuilds
+- `_stageStates`: `ConcurrentDictionary<string, StageState>` — independent state per session+skill+stage
+- Key format: `$"{sessionId}:{skillName}:{stageName}"`
+
+---
+
+## 6. Projection Resolution Engine (SkillProjectionResolver)
+
+### 6.1 Four Projection Views
+
+| View | ViewKey | Explicit Artifact Signals |
+|------|---------|--------------------------|
+| JSON Schema | `json-schema` | "json schema", "schema file", "schema definition" |
+| Workflow Contract | `workflow-contract` | "workflow contract", "工作流契约" |
+| Domain Model | `domain-model` | "domain model", "领域模型" |
+| Prompt Constraint | `prompt-constraint` | "prompt policy", "prompt constraint" |
+
+### 6.2 Signal Scoring Algorithm
+
+```
+Topic Scoring:
+  Score = Σ PrimaryIntentSignals × 5
+        + Σ SupportingSignals × 1
+        + ExplicitArtifact hit bonus +4
+        + PrimaryIntent hit bonus +5
+        - DemoteWhenCompeting × 2
+
+View Scoring:
+  Score = Σ ExplicitOutputSignals × 5
+        + Σ StrongSignals × 3
+        + Σ SupportingSignals × 1
+        + DefaultViewBonus +1
+        + ExplicitArtifactRequestBonus +4
+        - DemoteWhenCompeting × 2
+        + TopicOverrideBonuses (variable)
+```
+
+### 6.3 Decision Chain
+
+```
+ResolveForRequest(skill, requestText)
+  │
+  ├─ For each ProjectionContractSet:
+  │   ├─ TryResolveContract()
+  │   │   ├─ SelectTopic(index, requestText)
+  │   │   │   ├─ Score > 0? → Continue
+  │   │   │   ├─ Top-2 Score Gap ≥ Threshold? → Select Top-1
+  │   │   │   └─ Gap < Threshold → Ambiguous
+  │   │   │
+  │   │   ├─ SelectView(index, topic, requestText)
+  │   │   │   ├─ PreferReadyOnly? → Only consider READY Views
+  │   │   │   ├─ Score > 0? → Continue
+  │   │   │   └─ Top-2 Score Gap ≥ Threshold? → Select Top-1
+  │   │   │
+  │   │   ├─ LoadProjection(file)
+  │   │   │   └─ File not found → Block
+  │   │   │
+  │   │   ├─ BlockOnOpenQuestions ∧ OpenQuestions.Count > 0 → Block
+  │   │   └─ BlockOrEscalate ∧ OpenQuestions.Count > 0 → Block
+  │   │
+  │   └─ matchedAttempts (ordered by Score → ProducerPriority desc)
+  │
+  ├─ Top-1 vs Top-2 tied score & priority? → Block (ambiguous)
+  └─ Return Top-1 SkillProjectionResolution
+```
+
+### 6.4 BuildPromptPatch Output Format
+
+```
+[Projection Route]
+Selected topic: task-execution
+Selected target view: prompt-constraint
+Projection source: /skills/.../contracts/projections/.../projection.json
+Prompt constraint: Do not use unmapped terms or invent terminology beyond this projection.
+
+Allowed terms:
+- approved term
+
+Forbidden assumptions:
+- API key is embedded
+
+Required clarifications:
+- Identify the target deployment provider
+
+Reasoning paths:
+- Provider → Model → Config → Deploy
+
+Delivery artifacts:
+- SkillsConfig (json_schema) -> artifacts/SkillsConfig.schema.json [planned]
+```
+
+---
+
+## 7. Runtime Behavioral Alignment
+
+### 7.1 Startup Phase
+
+| Behavior | Native AgentRuntime | MAF MafAgentRuntime |
+|----------|:--:|:--:|
+| SkillLoader loads ArtifactContract | ✅ | ✅ |
+| SkillLoader loads ProjectionContracts | ✅ | ✅ |
+| `SkillArtifactRuntime.ReplaceSkills` | ✅ | ✅ |
+| `EmitArtifactTool` DI registration | ✅ (gated) | ✅ (shared) |
+
+### 7.2 Per-Turn Phase
+
+| Behavior | Native AgentRuntime | MAF MafAgentRuntime |
+|----------|:--:|:--:|
+| `GetSystemPrompt(session, userMessage)` overload | ✅ | ✅ |
+| `ResolveSkillsForTurn` invoked | ✅ | ✅ |
+| `SkillProjectionResolver.ResolveForRequest` | ✅ (shared code) | ✅ (shared code) |
+| `CloneSkill` preserves all 20 fields | ✅ | ✅ |
+| `[Blocked Skill Routes]` injection | ✅ | ✅ |
+| Reuses cached prompt when no Projection (zero overhead) | ✅ | ✅ |
+
+### 7.3 Hot Reload Phase
+
+| Behavior | Native AgentRuntime | MAF MafAgentRuntime |
+|----------|:--:|:--:|
+| `SkillWatcherService` callback fires | ✅ | ✅ |
+| `artifactRuntime.ReplaceSkills(newSkills)` | ✅ | ✅ |
+| `ApplySkills(newSkills)` rebuilds prompt | ✅ | ✅ |
+
+### 7.4 CloneSkill Field Completeness
+
+```csharp
+// Both runtimes' CloneSkill are aligned, copying all 20 fields:
+Name, Description, Instructions, Location, Source, Metadata,
+Kind, Triggers, MetaPriority, FinalTextMode, Composition,
+UserInvocable, DisableModelInvocation,
+CommandDispatch, CommandTool, CommandArgMode,
+Resources, ProjectionContracts, ProjectionDiscovery,
+ArtifactContract
+```
+
+---
+
+## 8. Frontend Protocol
+
+### 8.1 WebSocket Envelopes
+
+**type = "artifact"** (artifact delivery):
+
+```json
+{
+  "type": "artifact",
+  "text": "Requirements Doc",
+  "artifact": {
+    "kind": "data",
+    "artifact_type": "requirements",
+    "label": "Requirements Doc",
+    "skill_name": "pipeline-skill",
+    "stage": "design",
+    "is_terminal": true,
+    "display_hint": "badge",
+    "data": { ... }
+  }
+}
+```
+
+**type = "skill_stage_gate"** (stage gate, only sent after Terminal artifact):
+
+```json
+{
+  "type": "skill_stage_gate",
+  "stage_gate": {
+    "skill_name": "pipeline-skill",
+    "completed_stage": "design",
+    "next_stage": "review",
+    "can_proceed": true,
+    "blocked_reason": null
+  }
+}
+```
+
+### 8.2 Frontend Behavior Mapping
+
+| Contract Field | Frontend Behavior |
+|---------------|-------------------|
+| `display: "progress"` | Stage capsule set to running |
+| `display: "badge"` | Show confirmation gate badge |
+| `display: "tree"` | Render tree data structure |
+| `display: "file"` | Trigger auto-download/import |
+| `terminal: true` | Stage capsule set to completed |
+| `terminal: false` | Update progress without changing stage state |
+| `gate.requiresStage` | Lock next stage until prerequisite is complete |
+
+---
+
+## 9. Configuration
+
+### 9.1 GatewayConfig
+
+```jsonc
+{
+  "Tooling": {
+    "EnableEmitArtifact": true   // default true, can disable emit_artifact tool
+  }
+}
+```
+
+### 9.2 Contract File Conventions
+
+- `contracts/artifacts.json` — present → validation enabled; absent → silently skipped
+- `contracts/projections/*/contract-index.json` — present → Projection enabled; absent → `Status = "none"`
+- Both systems are fully independent; either can be enabled or disabled individually
+
+---
+
+## 10. Design Principles
+
+1. **Null-safe**: No contract file → silent degrade, no errors, no blocking
+2. **Minimal model constraint**: Model only provides `artifact_type`; runtime auto-fills label/display/stage/terminal
+3. **Deterministic signal matching**: Projection resolution uses strict scoring rules; deterministic routing when unambiguous
+4. **Concurrency-safe**: `ConcurrentDictionary` ensures thread safety for `ReplaceSkills` + `NormalizeAndRecord`
+5. **Progressive disclosure**: ArtifactContract XML block only injected on `load_skill`, not fully expanded in system prompt
+6. **Per-turn projection**: Dynamically resolve Projection each user turn, ensuring instructions always align with the current request
+7. **Zero-overhead path**: When no Projection contracts exist, reuse cached `_systemPrompt` with no additional computation

--- a/docs/zh-CN/RUNTIME_ARTIFACT_CONTRACT.md
+++ b/docs/zh-CN/RUNTIME_ARTIFACT_CONTRACT.md
@@ -105,7 +105,7 @@ public sealed record SkillStageGateEvent
 
 ### 2.4 Projection 模型（14 个类）
 
-```
+```text
 SkillProjectionContractSet      — 绑定的投影契约集
 SkillProjectionDiscovery        — 加载诊断信息
 SkillProjectionResolution       — 单次解析结果
@@ -132,7 +132,7 @@ ProjectionDeliveryArtifact      — 产出 Artifact
 
 ### 3.1 磁盘文件布局
 
-```
+```text
 skills/<skill-name>/
 ├── SKILL.md
 └── contracts/
@@ -276,7 +276,7 @@ skills/<skill-name>/
 
 ### 3.5 加载流程
 
-```
+```text
 SkillLoader.ParseSkillContent()
   │
   ├─ ParseSkillFile(filePath, skillDir, source)
@@ -299,7 +299,7 @@ SkillLoader.ParseSkillContent()
 
 ### 4.1 两个 Runtime 全景图
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────┐
 │                     Gateway 启动                              │
 │                                                              │
@@ -324,7 +324,7 @@ SkillLoader.ParseSkillContent()
 
 ### 4.2 每 Turn 完整数据流
 
-```
+```text
 User Message 到达
   │
   ├─ Gateway ReceiveMessage
@@ -419,7 +419,7 @@ User Message 到达
 
 ### 5.1 两级匹配算法
 
-```
+```text
 模型传参                        | 契约状态                | 结果
 ─────────────────────────────────────────────────────────────────
 指定 stage + artifactType      | 均匹配                  | ✅ 成功
@@ -435,7 +435,7 @@ User Message 到达
 
 模型只需提供最低限度的字段，运行时自动补齐：
 
-```
+```text
 模型提供:                   运行时补齐:
   artifact_type (必填)  →    Label       ← artifactType.Label
   stage (可选)          →    Stage       ← 自动推断或直接使用
@@ -445,7 +445,7 @@ User Message 到达
 
 ### 5.3 阶段门控状态机
 
-```
+```text
 Current Stage Terminal Artifact 发出
   │
   ├─ 是最后一个阶段 → null (无门控事件)
@@ -479,7 +479,7 @@ Current Stage Terminal Artifact 发出
 
 ### 6.2 信号评分算法
 
-```
+```text
 Topic 评分:
   Score = Σ PrimaryIntentSignals × 5
         + Σ SupportingSignals × 1
@@ -499,7 +499,7 @@ View 评分:
 
 ### 6.3 决策链
 
-```
+```text
 ResolveForRequest(skill, requestText)
   │
   ├─ 对每个 ProjectionContractSet:
@@ -528,7 +528,7 @@ ResolveForRequest(skill, requestText)
 
 ### 6.4 BuildPromptPatch 输出格式
 
-```
+```text
 [Projection Route]
 Selected topic: task-execution
 Selected target view: prompt-constraint

--- a/docs/zh-CN/RUNTIME_ARTIFACT_CONTRACT.md
+++ b/docs/zh-CN/RUNTIME_ARTIFACT_CONTRACT.md
@@ -3,6 +3,7 @@
 ## 1. 概述
 
 **ArtifactContract** 和 **Projection** 是 OpenClaw Skill 系统的两个正交扩展：
+<!-- markdownlint-disable MD040 -->
 
 | 系统 | 职责 | 触发时机 |
 |------|------|---------|

--- a/docs/zh-CN/RUNTIME_ARTIFACT_CONTRACT.md
+++ b/docs/zh-CN/RUNTIME_ARTIFACT_CONTRACT.md
@@ -1,0 +1,679 @@
+# Runtime ArtifactContract + Projection 技术文档
+
+## 1. 概述
+
+**ArtifactContract** 和 **Projection** 是 OpenClaw Skill 系统的两个正交扩展：
+
+| 系统 | 职责 | 触发时机 |
+|------|------|---------|
+| **ArtifactContract** | 定义 Skill 多阶段工作流中允许发出的产物白名单，运行时校验 `emit_artifact` 调用合法性 | LLM 调用 `emit_artifact` 工具时 |
+| **Projection** | 基于用户请求信号匹配最优的 Skill 投影视图，动态裁剪 Skill 指令并注入到系统 Prompt | 每次用户 Turn 时 |
+
+两系统共享数据模型层（`SkillArtifactContractModels.cs`），通过 `contracts/` 目录下的 JSON 文件声明契约规则，采用 `null` 安全设计——无契约文件时静默降级，不阻塞 Skill 加载和正常推理。
+
+### 1.1 关键文件
+
+| 文件 | 项目 | 职责 |
+|------|------|------|
+| `src/OpenClaw.Core/Models/SkillArtifact.cs` | Core | `SkillArtifact` record — Artifact 运行时消息载体 |
+| `src/OpenClaw.Core/Models/SkillArtifactContractModels.cs` | Core | 4 个 Artifact 契约类 + 14 个 Projection 模型类 |
+| `src/OpenClaw.Core/Models/WebSocketEnvelopes.cs` | Core | `WsServerEnvelope` 扩展 + `SkillStageGateEvent` record |
+| `src/OpenClaw.Core/Skills/SkillModels.cs` | Core | `SkillDefinition` 扩展属性 |
+| `src/OpenClaw.Core/Skills/SkillLoader.cs` | Core | `TryLoadArtifactContract` + `TryLoadProjectionContracts` |
+| `src/OpenClaw.Core/Skills/LoadSkillTool.cs` | Core | ArtifactContract XML 注入 Prompt |
+| `src/OpenClaw.Core/Skills/SkillPromptBuilder.cs` | Core | `BuildSkillBody` Projection 重载 |
+| `src/OpenClaw.Core/Skills/SkillProjectionResolver.cs` | Core | 投影路由引擎：Topic/View 信号匹配 + 评分 + JSON 加载 |
+| `src/OpenClaw.Core/Skills/SkillProjectionArtifactTerms.cs` | Core | 四类投影视图的显式 Artifact 关键词映射 |
+| `src/OpenClaw.Gateway/Tools/EmitArtifactTool.cs` | Gateway | `emit_artifact` 工具实现 |
+| `src/OpenClaw.Gateway/Tools/SkillArtifactRuntime.cs` | Gateway | 运行时校验引擎 + 阶段状态机 |
+| `src/OpenClaw.Agent/AgentRuntime.cs` | Agent | 每 Turn Projection 解析 + `ResolveSkillsForTurn` + `CloneSkill` |
+| `src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs` | MAF Adapter | 与 AgentRuntime 等价的 Projection 解析 |
+
+---
+
+## 2. 核心数据模型
+
+### 2.1 SkillArtifact（运行时消息载体）
+
+```csharp
+// SkillArtifact.cs
+public sealed record SkillArtifact
+{
+    public required string Kind { get; init; }          // "file" | "data"
+    public string ArtifactType { get; init; } = "generic";
+    public string? Label { get; init; }
+    public string? SkillName { get; init; }
+    public string? Stage { get; init; }
+    public bool IsTerminal { get; init; }
+    // File fields (kind = "file")
+    public string? FileUrl { get; init; }
+    public string? FileName { get; init; }
+    public string? MimeType { get; init; }
+    public long? FileSizeBytes { get; init; }
+    // Data fields (kind = "data")
+    public JsonElement? Data { get; init; }
+    public string? DisplayHint { get; init; }
+}
+```
+
+### 2.2 SkillArtifactContract（顶层契约）
+
+```csharp
+// SkillArtifactContractModels.cs
+public sealed class SkillArtifactContract
+{
+    public int SchemaVersion { get; init; } = 1;
+    public IReadOnlyList<SkillArtifactStageContract> Stages { get; init; } = [];
+}
+
+public sealed class SkillArtifactStageContract
+{
+    public required string Name { get; init; }
+    public string? Label { get; init; }
+    public SkillArtifactStageGateContract? Gate { get; init; }
+    public IReadOnlyList<SkillArtifactTypeContract> Artifacts { get; init; } = [];
+}
+
+public sealed class SkillArtifactStageGateContract
+{
+    public string? RequiresStage { get; init; }
+}
+
+public sealed class SkillArtifactTypeContract
+{
+    public required string Type { get; init; }
+    public string? Label { get; init; }
+    public string? Display { get; init; }
+    public bool? Terminal { get; init; }
+}
+```
+
+### 2.3 阶段门控模型（SkillStageGateEvent）
+
+```csharp
+// WebSocketEnvelopes.cs
+public sealed record SkillStageGateEvent
+{
+    public required string SkillName { get; init; }
+    public required string CompletedStage { get; init; }
+    public required string NextStage { get; init; }
+    public required bool CanProceed { get; init; }
+    public string? BlockedReason { get; init; }
+}
+```
+
+### 2.4 Projection 模型（14 个类）
+
+```
+SkillProjectionContractSet      — 绑定的投影契约集
+SkillProjectionDiscovery        — 加载诊断信息
+SkillProjectionResolution       — 单次解析结果
+ProjectionContractIndex         — 索引：Topics + Views + Scoring
+ProjectionSelectionPolicy       — 选择策略
+ProjectionTopicScoring          — Topic 级评分配置
+ProjectionTargetViewScoring     — View 级评分配置
+ProjectionScoreDimension        — 评分维度
+ProjectionTopicSignals          — Topic 信号关键词
+ProjectionViewSignals           — View 信号关键词
+ProjectionTopicViewOverride     — Topic 内 View 加权覆盖
+ProjectionTopicViewBonus        — 加权项
+ProjectionTopicRecord           — Topic 定义
+ProjectionViewRecord            — View 定义
+ProjectionDocument              — 投影文件内容
+ProjectionMappingPolicy         — 映射策略
+ProjectionPromptPayload         — Prompt 约束载荷
+ProjectionDeliveryArtifact      — 产出 Artifact
+```
+
+---
+
+## 3. 加载机制
+
+### 3.1 磁盘文件布局
+
+```
+skills/<skill-name>/
+├── SKILL.md
+└── contracts/
+    ├── artifacts.json                ← ArtifactContract 契约
+    └── projections/                  ← Projection 索引根
+        └── <producer-name>/
+            ├── contract-index.json   ← 索引定义
+            └── <view-path>.json      ← 具体投影文件
+```
+
+### 3.2 artifacts.json 示例
+
+```json
+{
+  "schemaVersion": 1,
+  "stages": [
+    {
+      "name": "stage1_collect",
+      "label": "Stage 1: Collection",
+      "artifacts": [
+        {
+          "type": "progress_update",
+          "label": "Progress",
+          "display": "progress",
+          "terminal": false
+        },
+        {
+          "type": "collection_summary",
+          "label": "Summary",
+          "display": "tree",
+          "terminal": true
+        }
+      ]
+    },
+    {
+      "name": "stage2_analysis",
+      "label": "Stage 2: Analysis",
+      "gate": { "requiresStage": "stage1_collect" },
+      "artifacts": [
+        { "type": "analysis_result", "label": "Result", "display": "tree", "terminal": true }
+      ]
+    }
+  ]
+}
+```
+
+### 3.3 contract-index.json 示例
+
+```json
+{
+  "producer_skill": "ontology-extraction",
+  "producer_priority": 10,
+  "default_selection_policy": {
+    "prefer_ready_only": true,
+    "block_on_open_questions": false,
+    "fallback_order_by_target_view": ["domain-model", "json-schema"]
+  },
+  "topic_scoring": {
+    "clarify_when_score_gap_below": 2,
+    "score_dimensions": [
+      { "dimension": "primary_intent_match", "score": 5 },
+      { "dimension": "explicit_artifact_bonus", "score": 4 }
+    ],
+    "topics": [
+      {
+        "domain_slug": "skill-loading",
+        "primary_intent_signals": ["load skill", "skill loading"],
+        "supporting_signals": ["skill"],
+        "explicit_artifact_signals": ["skill definition"],
+        "demote_when_competing_topic_signals": []
+      }
+    ]
+  },
+  "target_view_scoring": {
+    "score_dimensions": [
+      { "dimension": "explicit_output_match", "score": 5 },
+      { "dimension": "strong_signal_match", "score": 3 }
+    ],
+    "views": [
+      {
+        "target_view": "json-schema",
+        "explicit_output_signals": ["json schema", "schema file"],
+        "strong_signals": ["schema", "structure"],
+        "supporting_signals": [],
+        "demote_when_competing_view_signals": []
+      }
+    ],
+    "within_topic_overrides": [
+      {
+        "domain_slug": "skill-loading",
+        "bonuses": [
+          {
+            "target_view": "json-schema",
+            "when_request_signals": ["validate"],
+            "score": 3
+          }
+        ]
+      }
+    ]
+  },
+  "topics": [
+    {
+      "domain_slug": "skill-loading",
+      "default_target_view": "domain-model",
+      "views": [
+        { "target_view": "domain-model", "status": "READY", "path": "domain-model/projection.json" },
+        { "target_view": "json-schema", "status": "DRAFT", "path": "json-schema/projection.json" }
+      ]
+    }
+  ]
+}
+```
+
+### 3.4 projection.json 示例
+
+```json
+{
+  "mapping_policy": {
+    "unresolved_item_policy": "allow_unmapped_terms",
+    "prompt_assumption_policy": "disallow_unmapped_terms"
+  },
+  "prompt_projection": {
+    "allowed_terms": ["skill_config", "model_provider"],
+    "forbidden_assumptions": ["API key is embedded"],
+    "required_clarifications": ["Identify the target deployment provider"],
+    "reasoning_paths": ["Provider → Model → Config → Deploy"],
+    "source_digest": ["Extracted from SkillsConfigModel"]
+  },
+  "delivery_artifacts": [
+    {
+      "artifact_name": "SkillsConfig",
+      "artifact_type": "json_schema",
+      "path": "artifacts/SkillsConfig.schema.json",
+      "status": "planned"
+    }
+  ],
+  "dropped_items": [],
+  "open_questions": []
+}
+```
+
+### 3.5 加载流程
+
+```
+SkillLoader.ParseSkillContent()
+  │
+  ├─ ParseSkillFile(filePath, skillDir, source)
+  │   └─ ReadAllText → ParseSkillContent
+  │
+  ├─ ScanSkillResources(skillDir)    ← 扫描 references/scripts/
+  ├─ TryLoadArtifactContract(skillDir, logger)
+  │   └─ 读取 contracts/artifacts.json → SkillArtifactContract
+  │   └─ 文件不存在/解析失败 → null（静默降级）
+  │
+  └─ TryLoadProjectionContracts(skillDir, logger)
+      └─ 扫描 contracts/projections/*/contract-index.json
+      └─ 目录不存在 → ProjectionContracts = [], Discovery.Status = "none"
+      └─ 解析失败 → Discovery.Status = "partial" / "parse-failed"
+```
+
+---
+
+## 4. 运行时架构
+
+### 4.1 两个 Runtime 全景图
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                     Gateway 启动                              │
+│                                                              │
+│   new SkillArtifactRuntime()                                  │
+│   skills = SkillLoader.LoadAll(...)                            │
+│   artifactRuntime.ReplaceSkills(skills)   ← 初始注册技能契约  │
+│                                                              │
+│   ┌─ Native AgentRuntime ─┐  ┌─ MAF AgentRuntime ─┐         │
+│   │ (OpenClaw.Agent)      │  │ (MicrosoftAgent-    │         │
+│   │                       │  │  FrameworkAdapter)  │         │
+│   │ AgentRuntime.cs       │  │ MafAgentRuntime.cs  │         │
+│   └───────────────────────┘  └─────────────────────┘         │
+│                                                              │
+│   ┌─ Shared Tool Layer ────────────────────────────┐        │
+│   │ EmitArtifactTool  ←─ SkillArtifactRuntime       │        │
+│   │ LoadSkillTool     ←─ SkillDefinition (Contract) │        │
+│   │ ReadSkillResourceTool                           │        │
+│   │ MetaInvokeTool                                  │        │
+│   └─────────────────────────────────────────────────┘        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 每 Turn 完整数据流
+
+```
+User Message 到达
+  │
+  ├─ Gateway ReceiveMessage
+  │
+  ├─ AgentRuntime.GetSystemPrompt(session, userMessage)   ← 新增：userMessage 参数
+  │   │
+  │   ├─ 检查 hasProjectionSkills?
+  │   │   │
+  │   │   ├─ YES (任何 Skill 有 ProjectionContracts):
+  │   │   │   └─ ResolveSkillsForTurn(_loadedSkills, userMessage, out blockedRoutes)
+  │   │   │       │
+  │   │   │       ├─ 对每个 Skill:
+  │   │   │       │   ├─ 无 ProjectionContracts → 保持原样
+  │   │   │       │   │
+  │   │   │       │   └─ 有 ProjectionContracts:
+  │   │   │       │       └─ SkillProjectionResolver.ResolveForRequest(skill, userMessage)
+  │   │   │       │           ├─ SelectTopic(index, requestText)   ← 信号匹配 + 评分
+  │   │   │       │           │   ├─ PrimaryIntentSignals 权重 5
+  │   │   │       │           │   ├─ SupportingSignals 权重 1
+  │   │   │       │           │   ├─ ExplicitArtifactSignals 额外 +4
+  │   │   │       │           │   └─ DemoteWhenCompeting 惩罚 -2
+  │   │   │       │           │
+  │   │   │       │           ├─ SelectView(index, topic, requestText)  ← View 匹配
+  │   │   │       │           │   ├─ ExplicitOutputSignals 权重 5
+  │   │   │       │           │   ├─ StrongSignals 权重 3
+  │   │   │       │           │   ├─ SupportingSignals 权重 1
+  │   │   │       │           │   ├─ CrossViewPenalty -2
+  │   │   │       │           │   ├─ DefaultViewBonus +1
+  │   │   │       │           │   └─ TopicOverrideBonuses 可变
+  │   │   │       │           │
+  │   │   │       │           ├─ LoadProjection(filePath)            ← 加载 projection.json
+  │   │   │       │           │
+  │   │   │       │           ├─ 检查 PreferReadyOnly / BlockOnOpenQuestions / BlockOrEscalate
+  │   │   │       │           │
+  │   │   │       │           └─ 多 Producer 排序: Score → ProducerPriority
+  │   │   │       │
+  │   │   │       ├─ IsBlocked?
+  │   │   │       │   └─ CloneSkill(skill, originalInstructions, disableModel: true)
+  │   │   │       │       记录到 [Blocked Skill Routes]
+  │   │   │       │
+  │   │   │       └─ HasPatch?
+  │   │   │           └─ CloneSkill(skill, patchedInstructions, disableModel: false)
+  │   │   │               Instructions += "\n\n[Projection Route]\n<projection-patch>"
+  │   │   │
+  │   │   └─ BuildIndex(effectiveSkills) → Patched Skill Index
+  │   │   └─ [Blocked Skill Routes] 注入
+  │   │
+  │   └─ NO:
+  │       └─ 复用缓存的 _systemPrompt（零开销）
+  │
+  ├─ BuildMessages(session, userMessage)
+  │   └─ List<ChatMessage> { System(patchedPrompt), History... }
+  │
+  ├─ LLM 推理 (sees patched skill index)
+  │   │
+  │   ├─ LLM 调用 load_skill({ skill: "xxx" })
+  │   │   └─ LoadSkillTool.ExecuteAsync()
+  │   │       ├─ BuildSkillBody(match)           ← Skill 完整指令
+  │   │       ├─ if ArtifactContract:            ← 注入 <skill-artifact-contract> XML
+  │   │       ├─ if Resources:                   ← 注入 <skill-resources> manifest
+  │   │       └─ return body
+  │   │
+  │   └─ LLM 调用 emit_artifact({ kind, artifact_type, stage, ... })
+  │       └─ EmitArtifactTool.ExecuteAsync()
+  │           ├─ kind=file → ExecuteFileAsync()
+  │           │   ├─ ResolveRealPath → IsReadAllowed
+  │           │   ├─ ReadFile → MediaCache.Save → /media/{id}
+  │           │   ├─ _artifactRuntime.NormalizeAndRecord(sessionId, artifact)
+  │           │   │   ├─ 无 SkillName → 跳过校验，放行
+  │           │   │   ├─ SkillName 不在注册表 → 拒绝
+  │           │   │   ├─ 无契约 → 跳过校验，放行
+  │           │   │   ├─ TryResolveArtifactContract()
+  │           │   │   │   ├─ 显式 stage → 精确匹配
+  │           │   │   │   └─ 推断 stage → 全局唯一匹配
+  │           │   │   ├─ 归一化: Label/DisplayHint/IsTerminal/Stage
+  │           │   │   ├─ if Terminal → MarkStageTerminal() + BuildGateEvent()
+  │           │   │   └─ return SkillArtifactResult
+  │           │   ├─ WebSocket → { type: "artifact", artifact: ... }
+  │           │   └─ if StageGate → { type: "skill_stage_gate", stage_gate: ... }
+  │           │
+  │           └─ kind=data → ExecuteDataAsync()
+  │               └─ 同上，但不涉及文件操作
+  │
+  └─ WebSocket → 前端
+      ├─ "artifact" 信封 → 渲染对应组件（progress/tree/badge/file/text）
+      └─ "skill_stage_gate" 信封 → 更新阶段胶囊状态
+```
+
+---
+
+## 5. 契约校验引擎 (SkillArtifactRuntime)
+
+### 5.1 两级匹配算法
+
+```
+模型传参                        | 契约状态                | 结果
+─────────────────────────────────────────────────────────────────
+指定 stage + artifactType      | 均匹配                  | ✅ 成功
+指定 stage + artifactType      | stage存在但type不匹配    | ❌ "not declared for stage"
+指定 stage + artifactType      | stage不存在             | ❌ "not declared"
+仅 artifactType                | 全局唯一匹配            | ✅ 自动推断 stage
+仅 artifactType                | 零匹配                  | ❌ "not declared in contracts"
+仅 artifactType                | 多阶段匹配（歧义）      | ❌ "appears in multiple stages"
+无 SkillName                   | —                       | ✅ 跳过校验
+```
+
+### 5.2 归一化逻辑
+
+模型只需提供最低限度的字段，运行时自动补齐：
+
+```
+模型提供:                   运行时补齐:
+  artifact_type (必填)  →    Label       ← artifactType.Label
+  stage (可选)          →    Stage       ← 自动推断或直接使用
+  label (可选)          →    DisplayHint ← artifactType.Display
+  terminal (可选)       →    IsTerminal  ← artifactType.Terminal
+```
+
+### 5.3 阶段门控状态机
+
+```
+Current Stage Terminal Artifact 发出
+  │
+  ├─ 是最后一个阶段 → null (无门控事件)
+  │
+  └─ 存在下一阶段
+      ├─ 无 gate.requiresStage → CanProceed = true
+      │
+      └─ 有 gate.requiresStage = "stageX"
+          ├─ stageX 已完成 (IsTerminal) → CanProceed = true
+          └─ stageX 未完成                → CanProceed = false + BlockedReason
+```
+
+### 5.4 并发安全
+
+- `_skills`：`ConcurrentDictionary<string, SkillDefinition>` — `ReplaceSkills` 清空重建
+- `_stageStates`：`ConcurrentDictionary<string, StageState>` — 每个 session+skill+stage 组合独立状态
+- Key 格式：`$"{sessionId}:{skillName}:{stageName}"`
+
+---
+
+## 6. Projection 解析引擎 (SkillProjectionResolver)
+
+### 6.1 四类投影视图
+
+| 视图 | ViewKey | 显式 Artifact 信号 |
+|------|---------|-------------------|
+| JSON Schema | `json-schema` | "json schema", "schema file", "schema definition" |
+| Workflow Contract | `workflow-contract` | "workflow contract", "工作流契约" |
+| Domain Model | `domain-model` | "domain model", "领域模型" |
+| Prompt Constraint | `prompt-constraint` | "prompt policy", "prompt constraint" |
+
+### 6.2 信号评分算法
+
+```
+Topic 评分:
+  Score = Σ PrimaryIntentSignals × 5
+        + Σ SupportingSignals × 1
+        + ExplicitArtifact 命中额外 +4
+        + PrimaryIntent 命中额外 +5
+        - DemoteWhenCompeting × 2
+
+View 评分:
+  Score = Σ ExplicitOutputSignals × 5
+        + Σ StrongSignals × 3
+        + Σ SupportingSignals × 1
+        + DefaultViewBonus +1
+        + ExplicitArtifactRequestBonus +4
+        - DemoteWhenCompeting × 2
+        + TopicOverrideBonuses (可变)
+```
+
+### 6.3 决策链
+
+```
+ResolveForRequest(skill, requestText)
+  │
+  ├─ 对每个 ProjectionContractSet:
+  │   ├─ TryResolveContract()
+  │   │   ├─ SelectTopic(index, requestText)
+  │   │   │   ├─ Score > 0? → Continue
+  │   │   │   ├─ Top-2 Score Gap ≥ Threshold? → Select Top-1
+  │   │   │   └─ Gap < Threshold → Ambiguous
+  │   │   │
+  │   │   ├─ SelectView(index, topic, requestText)
+  │   │   │   ├─ PreferReadyOnly? → 只考虑 READY Views
+  │   │   │   ├─ Score > 0? → Continue
+  │   │   │   └─ Top-2 Score Gap ≥ Threshold? → Select Top-1
+  │   │   │
+  │   │   ├─ LoadProjection(file)
+  │   │   │   └─ 文件不存在 → Block
+  │   │   │
+  │   │   ├─ BlockOnOpenQuestions ∧ OpenQuestions.Count > 0 → Block
+  │   │   └─ BlockOrEscalate ∧ OpenQuestions.Count > 0 → Block
+  │   │
+  │   └─ matchedAttempts (按 Score → ProducerPriority 降序)
+  │
+  ├─ Top-1 vs Top-2 同分同优先级? → Block (ambiguous)
+  └─ 返回 Top-1 的 SkillProjectionResolution
+```
+
+### 6.4 BuildPromptPatch 输出格式
+
+```
+[Projection Route]
+Selected topic: task-execution
+Selected target view: prompt-constraint
+Projection source: /skills/.../contracts/projections/.../projection.json
+Prompt constraint: Do not use unmapped terms or invent terminology beyond this projection.
+
+Allowed terms:
+- approved term
+
+Forbidden assumptions:
+- API key is embedded
+
+Required clarifications:
+- Identify the target deployment provider
+
+Reasoning paths:
+- Provider → Model → Config → Deploy
+
+Delivery artifacts:
+- SkillsConfig (json_schema) -> artifacts/SkillsConfig.schema.json [planned]
+```
+
+---
+
+## 7. 两个 Runtime 行为对齐
+
+### 7.1 启动阶段
+
+| 行为 | Native AgentRuntime | MAF MafAgentRuntime |
+|------|:--:|:--:|
+| SkillLoader 加载 ArtifactContract | ✅ | ✅ |
+| SkillLoader 加载 ProjectionContracts | ✅ | ✅ |
+| `SkillArtifactRuntime.ReplaceSkills` | ✅ | ✅ |
+| `EmitArtifactTool` DI 注册 | ✅ (gated) | ✅ (共享) |
+
+### 7.2 每 Turn 阶段
+
+| 行为 | Native AgentRuntime | MAF MafAgentRuntime |
+|------|:--:|:--:|
+| `GetSystemPrompt(session, userMessage)` 重载 | ✅ | ✅ |
+| `ResolveSkillsForTurn` 调用 | ✅ | ✅ |
+| `SkillProjectionResolver.ResolveForRequest` | ✅ (共享代码) | ✅ (共享代码) |
+| `CloneSkill` 保留全部 20 字段 | ✅ | ✅ |
+| `[Blocked Skill Routes]` 注入 | ✅ | ✅ |
+| 无 Projection 时复用缓存（零开销） | ✅ | ✅ |
+
+### 7.3 热重载阶段
+
+| 行为 | Native AgentRuntime | MAF MafAgentRuntime |
+|------|:--:|:--:|
+| `SkillWatcherService` 回调触发 | ✅ | ✅ |
+| `artifactRuntime.ReplaceSkills(newSkills)` | ✅ | ✅ |
+| `ApplySkills(newSkills)` 重建 Prompt | ✅ | ✅ |
+
+### 7.4 CloneSkill 字段完整性
+
+```csharp
+// 两个 Runtime 的 CloneSkill 保持一致，复制全部 20 个字段：
+Name, Description, Instructions, Location, Source, Metadata,
+Kind, Triggers, MetaPriority, FinalTextMode, Composition,
+UserInvocable, DisableModelInvocation,
+CommandDispatch, CommandTool, CommandArgMode,
+Resources, ProjectionContracts, ProjectionDiscovery,
+ArtifactContract
+```
+
+---
+
+## 8. 前端协议
+
+### 8.1 WebSocket 信封
+
+**type = "artifact"**（产物推送）：
+
+```json
+{
+  "type": "artifact",
+  "text": "Requirements Doc",
+  "artifact": {
+    "kind": "data",
+    "artifact_type": "requirements",
+    "label": "Requirements Doc",
+    "skill_name": "pipeline-skill",
+    "stage": "design",
+    "is_terminal": true,
+    "display_hint": "badge",
+    "data": { ... }
+  }
+}
+```
+
+**type = "skill_stage_gate"**（阶段门控，仅在 Terminal Artifact 后发送）：
+
+```json
+{
+  "type": "skill_stage_gate",
+  "stage_gate": {
+    "skill_name": "pipeline-skill",
+    "completed_stage": "design",
+    "next_stage": "review",
+    "can_proceed": true,
+    "blocked_reason": null
+  }
+}
+```
+
+### 8.2 前端行为映射
+
+| 契约字段 | 前端行为 |
+|---------|---------|
+| `display: "progress"` | 阶段胶囊设为 running 状态 |
+| `display: "badge"` | 显示确认门徽章 |
+| `display: "tree"` | 展示树形数据结构 |
+| `display: "file"` | 触发自动下载/导入 |
+| `terminal: true` | 阶段胶囊设为 completed 状态 |
+| `terminal: false` | 更新进度但不改变阶段状态 |
+| `gate.requiresStage` | 锁住下一阶段直到前置完成 |
+
+---
+
+## 9. 配置
+
+### 9.1 GatewayConfig
+
+```jsonc
+{
+  "Tooling": {
+    "EnableEmitArtifact": true   // 默认 true，可关闭 emit_artifact 工具
+  }
+}
+```
+
+### 9.2 Contract 文件约定
+
+- `contracts/artifacts.json` — 存在 → 启用校验；不存在 → 静默跳过
+- `contracts/projections/*/contract-index.json` — 存在 → 启用 Projection；不存在 → `Status = "none"`
+- 两个契约系统完全独立，可单独启用/关闭
+
+---
+
+## 10. 设计原则
+
+1. **null 安全**：无契约文件 → 静默降级，不报错、不阻塞
+2. **模型约束最小化**：模型只需提供 `artifact_type`，运行时自动补齐 label/display/stage/terminal
+3. **信号匹配确定性**：Projection 解析使用严格的评分规则，无歧义时确定性路由
+4. **并发安全**：`ConcurrentDictionary` 保证 `ReplaceSkills` + `NormalizeAndRecord` 线程安全
+5. **渐进式披露**：ArtifactContract XML 块仅在 `load_skill` 时注入，不在系统 Prompt 中完整展开
+6. **Per-Turn 投影**：每次用户 Turn 动态解析 Projection，确保指令始终与当前请求对齐
+7. **零开销路径**：无 Projection 时直接复用缓存的 `_systemPrompt`，不做额外计算

--- a/src/OpenClaw.Agent/AgentRuntime.cs
+++ b/src/OpenClaw.Agent/AgentRuntime.cs
@@ -2028,10 +2028,13 @@ public sealed class AgentRuntime : IAgentRuntime
 
                 if (hasProjectionSkills)
                 {
-                    var effectiveSkills = ResolveSkillsForTurn(_loadedSkills, userMessage, out blockedRoutes);
+                    var effectiveSkills = ResolveSkillsForTurn(_loadedSkills, userMessage, out blockedRoutes, out var projectionPatches);
                     var skillSection = SkillPromptBuilder.BuildIndex(effectiveSkills, _skillsConfig?.InstructionPrompt);
                     var basePrompt = AgentSystemPromptBuilder.BuildBaseSystemPrompt(_requireToolApproval);
                     systemPrompt = string.IsNullOrEmpty(skillSection) ? basePrompt : basePrompt + "\n" + skillSection;
+
+                    if (!string.IsNullOrWhiteSpace(projectionPatches))
+                        systemPrompt += "\n\n[Skill Projection Patches]\n" + projectionPatches.Trim();
                 }
             }
         }
@@ -2051,9 +2054,17 @@ public sealed class AgentRuntime : IAgentRuntime
         IReadOnlyList<SkillDefinition> skills,
         string userMessage,
         out string blockedRoutes)
+        => ResolveSkillsForTurn(skills, userMessage, out blockedRoutes, out _);
+
+    internal static SkillDefinition[] ResolveSkillsForTurn(
+        IReadOnlyList<SkillDefinition> skills,
+        string userMessage,
+        out string blockedRoutes,
+        out string projectionPatches)
     {
         var resolvedSkills = new List<SkillDefinition>(skills.Count);
         var blocked = new System.Text.StringBuilder();
+        var patches = new System.Text.StringBuilder();
 
         foreach (var skill in skills)
         {
@@ -2086,9 +2097,14 @@ public sealed class AgentRuntime : IAgentRuntime
 
             var patchedInstructions = string.Concat(skill.Instructions.TrimEnd(), "\n\n", patch);
             resolvedSkills.Add(CloneSkill(skill, patchedInstructions, skill.DisableModelInvocation));
+
+            patches.AppendLine($"## {skill.Name}");
+            patches.AppendLine(patch);
+            patches.AppendLine();
         }
 
         blockedRoutes = blocked.ToString();
+        projectionPatches = patches.ToString();
         return [.. resolvedSkills];
     }
 

--- a/src/OpenClaw.Agent/AgentRuntime.cs
+++ b/src/OpenClaw.Agent/AgentRuntime.cs
@@ -317,7 +317,7 @@ public sealed class AgentRuntime : IAgentRuntime
             using var turnRoutingScope = await ApplyTurnRoutingAsync(session, userMessage, resumeCheckpoint is not null, responseSchema, ct);
 
         // Build conversation for LLM
-        var messages = BuildMessages(session, exactLatestToolBatch: resumeCheckpoint is not null);
+        var messages = BuildMessages(session, exactLatestToolBatch: resumeCheckpoint is not null, userMessage: userMessage);
         if (resumeCheckpoint is not null)
         {
             messages.Insert(1, new ChatMessage(ChatRole.System, BuildCheckpointResumeInstruction(resumeCheckpoint)));
@@ -596,7 +596,7 @@ public sealed class AgentRuntime : IAgentRuntime
 
             using var turnRoutingScope = await ApplyTurnRoutingAsync(session, userMessage, resumeCheckpoint is not null, responseSchema: null, ct);
 
-        var messages = BuildMessages(session, exactLatestToolBatch: resumeCheckpoint is not null);
+        var messages = BuildMessages(session, exactLatestToolBatch: resumeCheckpoint is not null, userMessage: userMessage);
         if (resumeCheckpoint is not null)
         {
             messages.Insert(1, new ChatMessage(ChatRole.System, BuildCheckpointResumeInstruction(resumeCheckpoint)));
@@ -1729,11 +1729,11 @@ public sealed class AgentRuntime : IAgentRuntime
         }
     }
 
-    private List<ChatMessage> BuildMessages(Session session, bool exactLatestToolBatch = false)
+    private List<ChatMessage> BuildMessages(Session session, bool exactLatestToolBatch = false, string? userMessage = null)
     {
         var messages = new List<ChatMessage>
         {
-            new(ChatRole.System, GetSystemPrompt(session))
+            new(ChatRole.System, GetSystemPrompt(session, userMessage))
         };
 
         // Add history (bounded to avoid context overflow)
@@ -2003,21 +2003,119 @@ public sealed class AgentRuntime : IAgentRuntime
         }
     }
 
-    private string GetSystemPrompt(Session session)
+    private string GetSystemPrompt(Session session, string? userMessage = null)
     {
         string systemPrompt;
+        string? blockedRoutes = null;
         lock (_skillGate)
         {
             systemPrompt = _systemPrompt;
+
+            // Per-turn projection resolution: when a user message is available and any
+            // loaded skill has projection contracts, resolve them to patch skill instructions
+            // and build a per-turn skill index. Matches kingcrab MafAgentRuntime behavior.
+            if (!string.IsNullOrWhiteSpace(userMessage))
+            {
+                var hasProjectionSkills = false;
+                foreach (var s in _loadedSkills)
+                {
+                    if (s.ProjectionContracts.Count > 0)
+                    {
+                        hasProjectionSkills = true;
+                        break;
+                    }
+                }
+
+                if (hasProjectionSkills)
+                {
+                    var effectiveSkills = ResolveSkillsForTurn(_loadedSkills, userMessage, out blockedRoutes);
+                    var skillSection = SkillPromptBuilder.BuildIndex(effectiveSkills, _skillsConfig?.InstructionPrompt);
+                    var basePrompt = AgentSystemPromptBuilder.BuildBaseSystemPrompt(_requireToolApproval);
+                    systemPrompt = string.IsNullOrEmpty(skillSection) ? basePrompt : basePrompt + "\n" + skillSection;
+                }
+            }
         }
 
         systemPrompt = AgentSystemPromptBuilder.ApplyResponseMode(systemPrompt, session.ResponseMode);
 
-        if (string.IsNullOrWhiteSpace(session.SystemPromptOverride))
-            return systemPrompt;
+        if (!string.IsNullOrWhiteSpace(blockedRoutes))
+            systemPrompt += "\n\n[Blocked Skill Routes]\n" + blockedRoutes.Trim();
 
-        return systemPrompt + "\n\n[Route Instructions]\n" + session.SystemPromptOverride.Trim();
+        if (!string.IsNullOrWhiteSpace(session.SystemPromptOverride))
+            return systemPrompt + "\n\n[Route Instructions]\n" + session.SystemPromptOverride.Trim();
+
+        return systemPrompt;
     }
+
+    internal static SkillDefinition[] ResolveSkillsForTurn(
+        IReadOnlyList<SkillDefinition> skills,
+        string userMessage,
+        out string blockedRoutes)
+    {
+        var resolvedSkills = new List<SkillDefinition>(skills.Count);
+        var blocked = new System.Text.StringBuilder();
+
+        foreach (var skill in skills)
+        {
+            if (skill.ProjectionContracts.Count == 0)
+            {
+                resolvedSkills.Add(skill);
+                continue;
+            }
+
+            var resolution = OpenClaw.Core.Skills.SkillProjectionResolver.ResolveForRequest(
+                skill, userMessage,
+                Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+            if (resolution.IsBlocked)
+            {
+                blocked.Append("- ");
+                blocked.Append(skill.Name);
+                blocked.Append(": ");
+                blocked.AppendLine(resolution.BlockReason ?? "Projection contract resolution blocked this skill for the current request.");
+                resolvedSkills.Add(CloneSkill(skill, skill.Instructions, disableModelInvocation: true));
+                continue;
+            }
+
+            var patch = OpenClaw.Core.Skills.SkillProjectionResolver.BuildPromptPatch(resolution);
+            if (string.IsNullOrWhiteSpace(patch))
+            {
+                resolvedSkills.Add(skill);
+                continue;
+            }
+
+            var patchedInstructions = string.Concat(skill.Instructions.TrimEnd(), "\n\n", patch);
+            resolvedSkills.Add(CloneSkill(skill, patchedInstructions, skill.DisableModelInvocation));
+        }
+
+        blockedRoutes = blocked.ToString();
+        return [.. resolvedSkills];
+    }
+
+    internal static SkillDefinition CloneSkill(SkillDefinition source, string instructions, bool disableModelInvocation)
+        => new()
+        {
+            Name = source.Name,
+            Description = source.Description,
+            Instructions = instructions,
+            Location = source.Location,
+            Source = source.Source,
+            Metadata = source.Metadata,
+            Kind = source.Kind,
+            Triggers = source.Triggers,
+            MetaPriority = source.MetaPriority,
+            FinalTextMode = source.FinalTextMode,
+            Composition = source.Composition,
+            UserInvocable = source.UserInvocable,
+            DisableModelInvocation = disableModelInvocation,
+            CommandDispatch = source.CommandDispatch,
+            CommandTool = source.CommandTool,
+            CommandArgMode = source.CommandArgMode,
+            Resources = source.Resources,
+            ProjectionContracts = source.ProjectionContracts,
+            ProjectionDiscovery = source.ProjectionDiscovery,
+            ArtifactContract = source.ArtifactContract
+        };
 
     private async ValueTask<IDisposable> ApplyTurnRoutingAsync(
         Session session,

--- a/src/OpenClaw.Agent/OpenClaw.Agent.csproj
+++ b/src/OpenClaw.Agent/OpenClaw.Agent.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="OpenClaw.MicrosoftAgentFrameworkAdapter" />
+    <InternalsVisibleTo Include="OpenClaw.Gateway" />
     <InternalsVisibleTo Include="OpenClaw.Tests" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenClaw.Core/Models/GatewayConfig.cs
+++ b/src/OpenClaw.Core/Models/GatewayConfig.cs
@@ -442,6 +442,9 @@ public sealed class ToolingConfig
     /// <summary>Seconds to wait for a tool approval decision before denying. Default: 300 (5 minutes).</summary>
     public int ToolApprovalTimeoutSeconds { get; set; } = 300;
 
+    /// <summary>Enable the emit_artifact tool for multi-stage skill artifact publishing.</summary>
+    public bool EnableEmitArtifact { get; set; } = true;
+
     public bool EnableBrowserTool { get; set; } = true;
     public bool AllowBrowserEvaluate { get; set; } = true;
     public bool BrowserHeadless { get; set; } = true;

--- a/src/OpenClaw.Core/Models/Session.cs
+++ b/src/OpenClaw.Core/Models/Session.cs
@@ -1072,6 +1072,12 @@ public sealed class SessionDelegationChildSummary
 [JsonSerializable(typeof(SkillLoadConfig))]
 [JsonSerializable(typeof(SkillEntryConfig))]
 [JsonSerializable(typeof(Dictionary<string, SkillEntryConfig>))]
+[JsonSerializable(typeof(SkillArtifactContract))]
+[JsonSerializable(typeof(SkillArtifactStageContract))]
+[JsonSerializable(typeof(List<SkillArtifactStageContract>))]
+[JsonSerializable(typeof(SkillArtifactStageGateContract))]
+[JsonSerializable(typeof(SkillArtifactTypeContract))]
+[JsonSerializable(typeof(List<SkillArtifactTypeContract>))]
 [JsonSerializable(typeof(MetricsSnapshot))]
 [JsonSerializable(typeof(SessionBranch))]
 [JsonSerializable(typeof(List<SessionBranch>))]
@@ -1615,6 +1621,8 @@ public sealed class SessionDelegationChildSummary
 [JsonSerializable(typeof(GmailPubSubConfig))]
 [JsonSerializable(typeof(MdnsConfig))]
 [JsonSerializable(typeof(List<ToolDescriptor>))]
+[JsonSerializable(typeof(SkillArtifact))]
+[JsonSerializable(typeof(SkillStageGateEvent))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,

--- a/src/OpenClaw.Core/Models/SkillArtifact.cs
+++ b/src/OpenClaw.Core/Models/SkillArtifact.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenClaw.Core.Models;
+
+/// <summary>
+/// Unified artifact model delivered to the client via WebSocket (envelope type = "artifact").
+/// Covers both file-based artifacts (kind = "file") and structured JSON data artifacts
+/// (kind = "data") such as stage checkpoints, analysis results, or progress payloads.
+/// </summary>
+public sealed record SkillArtifact
+{
+    /// <summary>Discriminator: "file" or "data".</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>
+    /// Semantic artifact type. Well-known values: "template_package", "skill_package",
+    /// "ontology", "analysis", "plan", "progress", "generic".
+    /// </summary>
+    public string ArtifactType { get; init; } = "generic";
+
+    /// <summary>Human-readable label shown in the UI.</summary>
+    public string? Label { get; init; }
+
+    /// <summary>Skill that produced this artifact (optional).</summary>
+    public string? SkillName { get; init; }
+
+    /// <summary>Stage identifier within a multi-stage skill workflow (optional).</summary>
+    public string? Stage { get; init; }
+
+    /// <summary>True when this artifact marks the current stage as complete.</summary>
+    public bool IsTerminal { get; init; }
+
+    // ── File artifact fields (kind = "file") ──────────────────────────────
+
+    /// <summary>URL of the stored file (e.g. /media/{id}). Present when kind = "file".</summary>
+    public string? FileUrl { get; init; }
+
+    /// <summary>Filename shown to the user. Present when kind = "file".</summary>
+    public string? FileName { get; init; }
+
+    /// <summary>MIME type of the file. Present when kind = "file".</summary>
+    public string? MimeType { get; init; }
+
+    /// <summary>File size in bytes. Present when kind = "file".</summary>
+    public long? FileSizeBytes { get; init; }
+
+    // ── Data artifact fields (kind = "data") ──────────────────────────────
+
+    /// <summary>
+    /// Structured JSON payload. Present when kind = "data".
+    /// Omitted from serialization when null to keep the envelope compact.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public JsonElement? Data { get; init; }
+
+    /// <summary>
+    /// Rendering hint for data artifacts.
+    /// Values: "tree" | "table" | "code" | "badge" | "progress" | "text".
+    /// </summary>
+    public string? DisplayHint { get; init; }
+}

--- a/src/OpenClaw.Core/Models/SkillArtifactContractModels.cs
+++ b/src/OpenClaw.Core/Models/SkillArtifactContractModels.cs
@@ -1,0 +1,196 @@
+namespace OpenClaw.Core.Skills;
+
+// ArtifactContract and SkillProjection model types.
+// Migrated from kingcrab (OpenClaw Gateway fork) to openclaw.net upstream.
+// See docs/ArtifactContract-技术文档.md for the design document.
+
+// ────────────────────────────────────────────────────────────
+// Projection discovery / contract set models
+// ────────────────────────────────────────────────────────────
+
+public sealed class SkillProjectionDiscovery
+{
+    public required string Status { get; init; }
+    public int IndexCount { get; init; }
+    public int BoundCount { get; init; }
+    public IReadOnlyList<string> IndexPaths { get; init; } = [];
+    public string? Message { get; init; }
+}
+
+/// <summary>
+/// Bound projection contracts attached to a skill.
+/// </summary>
+public sealed class SkillProjectionContractSet
+{
+    public string? ProducerName { get; init; }
+    public int ProducerPriority { get; init; }
+    public required string RootPath { get; init; }
+    public required ProjectionContractIndex Index { get; init; }
+}
+
+public sealed class SkillProjectionResolution
+{
+    public required string SkillName { get; init; }
+    public bool HasContracts { get; init; }
+    public bool IsBlocked { get; init; }
+    public string? BlockReason { get; init; }
+    public string? SelectedTopic { get; init; }
+    public string? SelectedTargetView { get; init; }
+    public string? ProjectionFilePath { get; init; }
+    public ProjectionDocument? Projection { get; init; }
+}
+
+// ────────────────────────────────────────────────────────────
+// Projection contract index / scoring models
+// ────────────────────────────────────────────────────────────
+
+public sealed class ProjectionContractIndex
+{
+    public string? ProducerSkill { get; init; }
+    public int ProducerPriority { get; init; }
+    public ProjectionSelectionPolicy DefaultSelectionPolicy { get; init; } = new();
+    public ProjectionTopicScoring? TopicScoring { get; init; }
+    public ProjectionTargetViewScoring? TargetViewScoring { get; init; }
+    public IReadOnlyList<ProjectionTopicRecord> Topics { get; init; } = [];
+}
+
+public sealed class ProjectionSelectionPolicy
+{
+    public bool PreferReadyOnly { get; init; }
+    public bool BlockOnOpenQuestions { get; init; }
+    public IReadOnlyList<string> FallbackOrderByTargetView { get; init; } = [];
+}
+
+public sealed class ProjectionTopicScoring
+{
+    public int ClarifyWhenScoreGapBelow { get; init; } = 2;
+    public IReadOnlyList<ProjectionScoreDimension> ScoreDimensions { get; init; } = [];
+    public IReadOnlyList<ProjectionTopicSignals> Topics { get; init; } = [];
+}
+
+public sealed class ProjectionTargetViewScoring
+{
+    public int ClarifyWhenScoreGapBelow { get; init; } = 2;
+    public bool PreferExplicitUserArtifactRequests { get; init; }
+    public IReadOnlyList<ProjectionScoreDimension> ScoreDimensions { get; init; } = [];
+    public IReadOnlyList<ProjectionViewSignals> Views { get; init; } = [];
+    public IReadOnlyList<ProjectionTopicViewOverride> WithinTopicOverrides { get; init; } = [];
+}
+
+public sealed class ProjectionScoreDimension
+{
+    public required string Dimension { get; init; }
+    public int Score { get; init; }
+}
+
+public sealed class ProjectionTopicSignals
+{
+    public required string DomainSlug { get; init; }
+    public IReadOnlyList<string> PrimaryIntentSignals { get; init; } = [];
+    public IReadOnlyList<string> SupportingSignals { get; init; } = [];
+    public IReadOnlyList<string> ExplicitArtifactSignals { get; init; } = [];
+    public IReadOnlyList<string> DemoteWhenCompetingTopicSignals { get; init; } = [];
+}
+
+public sealed class ProjectionViewSignals
+{
+    public required string TargetView { get; init; }
+    public IReadOnlyList<string> ExplicitOutputSignals { get; init; } = [];
+    public IReadOnlyList<string> StrongSignals { get; init; } = [];
+    public IReadOnlyList<string> SupportingSignals { get; init; } = [];
+    public IReadOnlyList<string> DemoteWhenCompetingViewSignals { get; init; } = [];
+}
+
+public sealed class ProjectionTopicViewOverride
+{
+    public required string DomainSlug { get; init; }
+    public IReadOnlyList<ProjectionTopicViewBonus> Bonuses { get; init; } = [];
+}
+
+public sealed class ProjectionTopicViewBonus
+{
+    public required string TargetView { get; init; }
+    public IReadOnlyList<string> WhenRequestSignals { get; init; } = [];
+    public int Score { get; init; }
+}
+
+public sealed class ProjectionTopicRecord
+{
+    public required string DomainSlug { get; init; }
+    public required string DefaultTargetView { get; init; }
+    public IReadOnlyList<ProjectionViewRecord> Views { get; init; } = [];
+}
+
+public sealed class ProjectionViewRecord
+{
+    public required string TargetView { get; init; }
+    public required string Status { get; init; }
+    public required string Path { get; init; }
+}
+
+// ────────────────────────────────────────────────────────────
+// Projection document (loaded from projection.json)
+// ────────────────────────────────────────────────────────────
+
+public sealed class ProjectionDocument
+{
+    public ProjectionMappingPolicy MappingPolicy { get; init; } = new();
+    public ProjectionPromptPayload PromptProjection { get; init; } = new();
+    public IReadOnlyList<ProjectionDeliveryArtifact> DeliveryArtifacts { get; init; } = [];
+    public IReadOnlyList<string> DroppedItems { get; init; } = [];
+    public IReadOnlyList<string> OpenQuestions { get; init; } = [];
+}
+
+public sealed class ProjectionMappingPolicy
+{
+    public string? UnresolvedItemPolicy { get; init; }
+    public string? PromptAssumptionPolicy { get; init; }
+}
+
+public sealed class ProjectionPromptPayload
+{
+    public IReadOnlyList<string> AllowedTerms { get; init; } = [];
+    public IReadOnlyList<string> ForbiddenAssumptions { get; init; } = [];
+    public IReadOnlyList<string> RequiredClarifications { get; init; } = [];
+    public IReadOnlyList<string> ReasoningPaths { get; init; } = [];
+    public IReadOnlyList<string> SourceDigest { get; init; } = [];
+}
+
+public sealed class ProjectionDeliveryArtifact
+{
+    public required string ArtifactName { get; init; }
+    public required string ArtifactType { get; init; }
+    public required string Path { get; init; }
+    public string? Status { get; init; }
+}
+
+// ────────────────────────────────────────────────────────────
+// Artifact contract models
+// ────────────────────────────────────────────────────────────
+
+public sealed class SkillArtifactContract
+{
+    public int SchemaVersion { get; init; } = 1;
+    public IReadOnlyList<SkillArtifactStageContract> Stages { get; init; } = [];
+}
+
+public sealed class SkillArtifactStageContract
+{
+    public required string Name { get; init; }
+    public string? Label { get; init; }
+    public SkillArtifactStageGateContract? Gate { get; init; }
+    public IReadOnlyList<SkillArtifactTypeContract> Artifacts { get; init; } = [];
+}
+
+public sealed class SkillArtifactStageGateContract
+{
+    public string? RequiresStage { get; init; }
+}
+
+public sealed class SkillArtifactTypeContract
+{
+    public required string Type { get; init; }
+    public string? Label { get; init; }
+    public string? Display { get; init; }
+    public bool? Terminal { get; init; }
+}

--- a/src/OpenClaw.Core/Models/WebSocketEnvelopes.cs
+++ b/src/OpenClaw.Core/Models/WebSocketEnvelopes.cs
@@ -97,9 +97,6 @@ public sealed record WsServerEnvelope
     public string? NextStep { get; init; }
 
     // Artifact / stage-gate envelope payloads.
-    /// <summary>Optional semantic type for artifact deliveries emitted by the emit_artifact tool.</summary>
-    public string? ArtifactType { get; init; }
-
     /// <summary>Unified artifact payload (type = "artifact"). Carries the full <see cref="SkillArtifact"/>.</summary>
     public SkillArtifact? Artifact { get; init; }
 

--- a/src/OpenClaw.Core/Models/WebSocketEnvelopes.cs
+++ b/src/OpenClaw.Core/Models/WebSocketEnvelopes.cs
@@ -95,4 +95,36 @@ public sealed record WsServerEnvelope
     public string? FailureCode { get; init; }
     public string? FailureMessage { get; init; }
     public string? NextStep { get; init; }
+
+    // Artifact / stage-gate envelope payloads.
+    /// <summary>Optional semantic type for artifact deliveries emitted by the emit_artifact tool.</summary>
+    public string? ArtifactType { get; init; }
+
+    /// <summary>Unified artifact payload (type = "artifact"). Carries the full <see cref="SkillArtifact"/>.</summary>
+    public SkillArtifact? Artifact { get; init; }
+
+    /// <summary>Stage gate transition event (type = "skill_stage_gate") emitted after a terminal artifact.</summary>
+    public SkillStageGateEvent? StageGate { get; init; }
+
+    // File attachment envelope payloads (type = "file_attachment").
+    /// <summary>Relative URL to download the file (e.g. "/media/{id}").</summary>
+    public string? FileUrl { get; init; }
+
+    /// <summary>Original file name for the attachment.</summary>
+    public string? FileName { get; init; }
+
+    /// <summary>MIME type of the attachment.</summary>
+    public string? MimeType { get; init; }
+
+    /// <summary>File size in bytes.</summary>
+    public long? FileSizeBytes { get; init; }
+}
+
+public sealed record SkillStageGateEvent
+{
+    public required string SkillName { get; init; }
+    public required string CompletedStage { get; init; }
+    public required string NextStage { get; init; }
+    public required bool CanProceed { get; init; }
+    public string? BlockedReason { get; init; }
 }

--- a/src/OpenClaw.Core/Skills/LoadSkillTool.cs
+++ b/src/OpenClaw.Core/Skills/LoadSkillTool.cs
@@ -1,5 +1,6 @@
 using System.Security;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using OpenClaw.Core.Abstractions;
 
 namespace OpenClaw.Core.Skills;
@@ -65,13 +66,26 @@ public sealed class LoadSkillTool : ITool
         if (body.Length == 0)
             return ValueTask.FromResult($"Skill '{match.Name}' has no instructions body.");
 
-        if (match.Resources.Count == 0)
-            return ValueTask.FromResult(body);
+        var sections = new List<string> { body.TrimEnd() };
 
-        // Re-emit the resource manifest alongside the body so the model knows what it can
-        // still reach for via subsequent reads — without re-loading every other skill's index.
-        var withManifest = body.TrimEnd() + "\n\n" + RenderResourceManifest(match) + "\n";
-        return ValueTask.FromResult(withManifest);
+        // Inject artifact contract if the skill declares one.
+        if (match.ArtifactContract is { Stages.Count: > 0 } artifactContract)
+            sections.Add(RenderArtifactContract(artifactContract));
+
+        if (match.Resources.Count > 0)
+        {
+            // Re-emit the resource manifest alongside the body so the model knows what it can
+            // still reach for via subsequent reads — without re-loading every other skill's index.
+            sections.Add(RenderResourceManifest(match));
+        }
+
+        return ValueTask.FromResult(string.Join("\n\n", sections) + "\n");
+    }
+
+    private static string RenderArtifactContract(SkillArtifactContract contract)
+    {
+        var json = JsonSerializer.Serialize(contract, LoadSkillToolJsonContext.Default.SkillArtifactContract);
+        return $"<skill-artifact-contract>\n{json}\n</skill-artifact-contract>";
     }
 
     private static bool TryParseSkillName(string argumentsJson, out string? skillName, out string? error)
@@ -162,3 +176,13 @@ public sealed class LoadSkillTool : ITool
         return sb.ToString();
     }
 }
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = true)]
+[JsonSerializable(typeof(SkillArtifactContract))]
+[JsonSerializable(typeof(SkillArtifactStageContract))]
+[JsonSerializable(typeof(SkillArtifactStageGateContract))]
+[JsonSerializable(typeof(SkillArtifactTypeContract))]
+internal partial class LoadSkillToolJsonContext : JsonSerializerContext;

--- a/src/OpenClaw.Core/Skills/SkillLoader.cs
+++ b/src/OpenClaw.Core/Skills/SkillLoader.cs
@@ -3305,13 +3305,32 @@ public static class SkillLoader
 
     private static bool IsUsableProjectionContractIndex(ProjectionContractIndex index)
     {
-        return index.Topics.Any(topic =>
-            !string.IsNullOrWhiteSpace(topic.DomainSlug) &&
-            !string.IsNullOrWhiteSpace(topic.DefaultTargetView) &&
-            topic.Views.Any(view =>
-                !string.IsNullOrWhiteSpace(view.TargetView) &&
-                !string.IsNullOrWhiteSpace(view.Path)));
+        var usableTopics = index.Topics
+            .Where(static topic =>
+                !string.IsNullOrWhiteSpace(topic.DomainSlug) &&
+                !string.IsNullOrWhiteSpace(topic.DefaultTargetView) &&
+                topic.Views.Any(static view =>
+                    !string.IsNullOrWhiteSpace(view.TargetView) &&
+                    !string.IsNullOrWhiteSpace(view.Path)))
+            .ToList();
+        if (usableTopics.Count == 0)
+            return false;
+
+        var fallbackViews = index.DefaultSelectionPolicy.FallbackOrderByTargetView
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var hasUsableFallback = fallbackViews.Count > 0 &&
+            usableTopics.Any(topic => topic.Views.Any(view => fallbackViews.Contains(view.TargetView)));
+        var hasUsableTopicSignals = index.TopicScoring?.Topics.Any(HasUsableTopicSignals) == true;
+
+        return hasUsableFallback || hasUsableTopicSignals;
     }
+
+    private static bool HasUsableTopicSignals(ProjectionTopicSignals signals)
+        => !string.IsNullOrWhiteSpace(signals.DomainSlug) &&
+           (signals.PrimaryIntentSignals.Any(static value => !string.IsNullOrWhiteSpace(value)) ||
+            signals.SupportingSignals.Any(static value => !string.IsNullOrWhiteSpace(value)) ||
+            signals.ExplicitArtifactSignals.Any(static value => !string.IsNullOrWhiteSpace(value)));
 
     private static ProjectionSelectionPolicy ParseProjectionSelectionPolicy(JsonElement element)
         => new()

--- a/src/OpenClaw.Core/Skills/SkillLoader.cs
+++ b/src/OpenClaw.Core/Skills/SkillLoader.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
@@ -3303,17 +3304,7 @@ public static class SkillLoader
         if (index.Topics.Count == 0)
             return null;
 
-        var hasUsableView = false;
-        foreach (var topic in index.Topics)
-        {
-            if (topic.Views.Count > 0)
-            {
-                hasUsableView = true;
-                break;
-            }
-        }
-
-        return hasUsableView ? index : null;
+        return index.Topics.Any(topic => topic.Views.Count > 0) ? index : null;
     }
 
     private static ProjectionSelectionPolicy ParseProjectionSelectionPolicy(JsonElement element)

--- a/src/OpenClaw.Core/Skills/SkillLoader.cs
+++ b/src/OpenClaw.Core/Skills/SkillLoader.cs
@@ -3281,7 +3281,7 @@ public static class SkillLoader
         if (root.ValueKind != JsonValueKind.Object)
             return null;
 
-        return new ProjectionContractIndex
+        var index = new ProjectionContractIndex
         {
             ProducerSkill = ReadString(root, "producer_skill"),
             ProducerPriority = ReadInt32(root, "producer_priority", ReadInt32(root, "producer_precedence", 0)),
@@ -3298,6 +3298,22 @@ public static class SkillLoader
                 ? ParseProjectionTopics(topics)
                 : []
         };
+
+        // Reject indexes that have no usable topics or every topic has zero views.
+        if (index.Topics.Count == 0)
+            return null;
+
+        var hasUsableView = false;
+        foreach (var topic in index.Topics)
+        {
+            if (topic.Views.Count > 0)
+            {
+                hasUsableView = true;
+                break;
+            }
+        }
+
+        return hasUsableView ? index : null;
     }
 
     private static ProjectionSelectionPolicy ParseProjectionSelectionPolicy(JsonElement element)

--- a/src/OpenClaw.Core/Skills/SkillLoader.cs
+++ b/src/OpenClaw.Core/Skills/SkillLoader.cs
@@ -3299,22 +3299,37 @@ public static class SkillLoader
                 : []
         };
 
-        // Reject indexes that have no usable topics or every topic has zero views.
-        if (index.Topics.Count == 0)
-            return null;
-
-        var hasUsableView = false;
-        foreach (var topic in index.Topics)
-        {
-            if (topic.Views.Count > 0)
-            {
-                hasUsableView = true;
-                break;
-            }
-        }
-
-        return hasUsableView ? index : null;
+        return IsUsableProjectionContractIndex(index) ? index : null;
     }
+
+    private static bool IsUsableProjectionContractIndex(ProjectionContractIndex index)
+    {
+        var usableTopics = index.Topics
+            .Where(static topic =>
+                !string.IsNullOrWhiteSpace(topic.DomainSlug) &&
+                !string.IsNullOrWhiteSpace(topic.DefaultTargetView) &&
+                topic.Views.Any(static view =>
+                    !string.IsNullOrWhiteSpace(view.TargetView) &&
+                    !string.IsNullOrWhiteSpace(view.Path)))
+            .ToList();
+        if (usableTopics.Count == 0)
+            return false;
+
+        var fallbackViews = index.DefaultSelectionPolicy.FallbackOrderByTargetView
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var hasUsableFallback = fallbackViews.Count > 0 &&
+            usableTopics.Any(topic => topic.Views.Any(view => fallbackViews.Contains(view.TargetView)));
+        var hasUsableTopicSignals = index.TopicScoring?.Topics.Any(HasUsableTopicSignals) == true;
+
+        return hasUsableFallback || hasUsableTopicSignals;
+    }
+
+    private static bool HasUsableTopicSignals(ProjectionTopicSignals signals)
+        => !string.IsNullOrWhiteSpace(signals.DomainSlug) &&
+           (signals.PrimaryIntentSignals.Any(static value => !string.IsNullOrWhiteSpace(value)) ||
+            signals.SupportingSignals.Any(static value => !string.IsNullOrWhiteSpace(value)) ||
+            signals.ExplicitArtifactSignals.Any(static value => !string.IsNullOrWhiteSpace(value)));
 
     private static ProjectionSelectionPolicy ParseProjectionSelectionPolicy(JsonElement element)
         => new()

--- a/src/OpenClaw.Core/Skills/SkillLoader.cs
+++ b/src/OpenClaw.Core/Skills/SkillLoader.cs
@@ -3305,28 +3305,12 @@ public static class SkillLoader
 
     private static bool IsUsableProjectionContractIndex(ProjectionContractIndex index)
     {
-        var usableTopics = index.Topics
-            .Where(static topic =>
-                !string.IsNullOrWhiteSpace(topic.DomainSlug) &&
-                !string.IsNullOrWhiteSpace(topic.DefaultTargetView) &&
-                topic.Views.Any(static view =>
-                    !string.IsNullOrWhiteSpace(view.TargetView) &&
-                    !string.IsNullOrWhiteSpace(view.Path)))
-            .ToList();
-        if (usableTopics.Count == 0)
-            return false;
-
-        var hasUsableView = false;
-        foreach (var topic in index.Topics)
-        {
-            if (topic.Views.Count > 0)
-            {
-                hasUsableView = true;
-                break;
-            }
-        }
-
-        return hasUsableView ? index : null;
+        return index.Topics.Any(topic =>
+            !string.IsNullOrWhiteSpace(topic.DomainSlug) &&
+            !string.IsNullOrWhiteSpace(topic.DefaultTargetView) &&
+            topic.Views.Any(view =>
+                !string.IsNullOrWhiteSpace(view.TargetView) &&
+                !string.IsNullOrWhiteSpace(view.Path)));
     }
 
     private static ProjectionSelectionPolicy ParseProjectionSelectionPolicy(JsonElement element)

--- a/src/OpenClaw.Core/Skills/SkillLoader.cs
+++ b/src/OpenClaw.Core/Skills/SkillLoader.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using OpenClaw.Core.Models;
 using Microsoft.Extensions.Logging;
 
 namespace OpenClaw.Core.Skills;
@@ -399,6 +400,9 @@ public static class SkillLoader
         // *not* loaded here — only the listing — so the model can fetch on demand.
         var resources = ScanSkillResources(skillDir);
 
+        var artifactContract = TryLoadArtifactContract(skillDir, null);
+        var projectionContractDiscovery = TryLoadProjectionContracts(skillDir, null);
+
         return new SkillDefinition
         {
             Name = name,
@@ -417,7 +421,10 @@ public static class SkillLoader
             CommandDispatch = commandDispatch,
             CommandTool = commandTool,
             CommandArgMode = commandArgMode,
-            Resources = resources
+            Resources = resources,
+            ArtifactContract = artifactContract,
+            ProjectionContracts = projectionContractDiscovery.Contracts,
+            ProjectionDiscovery = projectionContractDiscovery.Discovery
         };
     }
 
@@ -3122,4 +3129,395 @@ public static class SkillLoader
         }
         return result;
     }
+
+    private static string[] ReadStringArray(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property))
+            return [];
+
+        return ReadStringArray(property);
+    }
+
+    private static SkillArtifactContract? TryLoadArtifactContract(string skillDir, ILogger? logger)
+    {
+        var contractPath = Path.Combine(skillDir, "contracts", "artifacts.json");
+        if (!File.Exists(contractPath))
+            return null;
+
+        try
+        {
+            using var stream = File.OpenRead(contractPath);
+            var contract = JsonSerializer.Deserialize(stream, CoreJsonContext.Default.SkillArtifactContract);
+            if (contract is null)
+            {
+                logger?.LogWarning("Artifact contract at {Path} is empty or invalid.", contractPath);
+                return null;
+            }
+
+            return contract;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Failed to load artifact contract from {Path}.", contractPath);
+            return null;
+        }
+    }
+
+    private sealed record ProjectionContractDiscoveryResult(
+        IReadOnlyList<SkillProjectionContractSet> Contracts,
+        SkillProjectionDiscovery Discovery);
+
+    private static ProjectionContractDiscoveryResult TryLoadProjectionContracts(string skillDir, ILogger? logger)
+    {
+        var projectionsRoot = Path.Combine(skillDir, "contracts", "projections");
+        if (!Directory.Exists(projectionsRoot))
+        {
+            return new ProjectionContractDiscoveryResult(
+                [],
+                new SkillProjectionDiscovery
+                {
+                    Status = "none",
+                    IndexCount = 0,
+                    BoundCount = 0
+                });
+        }
+
+        string[] indexFiles;
+        try
+        {
+            indexFiles = Directory.GetFiles(projectionsRoot, "contract-index.json", SearchOption.AllDirectories)
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Failed to enumerate projection contract indexes under {Path}", projectionsRoot);
+            return new ProjectionContractDiscoveryResult(
+                [],
+                new SkillProjectionDiscovery
+                {
+                    Status = "enumeration-failed",
+                    IndexCount = 0,
+                    BoundCount = 0,
+                    Message = ex.Message
+                });
+        }
+
+        if (indexFiles.Length == 0)
+        {
+            return new ProjectionContractDiscoveryResult(
+                [],
+                new SkillProjectionDiscovery
+                {
+                    Status = "none",
+                    IndexCount = 0,
+                    BoundCount = 0
+                });
+        }
+
+        var contracts = new List<SkillProjectionContractSet>(indexFiles.Length);
+        var failedIndexes = new List<string>();
+
+        foreach (var indexPath in indexFiles)
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(File.ReadAllText(indexPath));
+                var index = ParseProjectionContractIndex(document.RootElement);
+                if (index is null)
+                {
+                    logger?.LogWarning("Failed to parse projection contract index at {Path}: missing required fields.", indexPath);
+                    failedIndexes.Add(indexPath);
+                    continue;
+                }
+
+                contracts.Add(new SkillProjectionContractSet
+                {
+                    ProducerName = index.ProducerSkill ?? Path.GetFileName(Path.GetDirectoryName(indexPath)),
+                    ProducerPriority = index.ProducerPriority,
+                    RootPath = Path.GetDirectoryName(indexPath) ?? projectionsRoot,
+                    Index = index
+                });
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Failed to parse projection contract index at {Path}", indexPath);
+                failedIndexes.Add(indexPath);
+            }
+        }
+
+        if (contracts.Count == 0)
+        {
+            return new ProjectionContractDiscoveryResult(
+                [],
+                new SkillProjectionDiscovery
+                {
+                    Status = "parse-failed",
+                    IndexCount = indexFiles.Length,
+                    BoundCount = 0,
+                    IndexPaths = [.. indexFiles],
+                    Message = failedIndexes.Count > 0
+                        ? $"Failed to parse {failedIndexes.Count} projection contract index file(s)."
+                        : "Projection contract index is missing required fields."
+                });
+        }
+
+        return new ProjectionContractDiscoveryResult(
+            contracts,
+            new SkillProjectionDiscovery
+            {
+                Status = failedIndexes.Count == 0 ? "bound" : "partial",
+                IndexCount = indexFiles.Length,
+                BoundCount = contracts.Count,
+                IndexPaths = [.. indexFiles],
+                Message = failedIndexes.Count == 0
+                    ? null
+                    : $"Bound {contracts.Count} of {indexFiles.Length} projection contract index file(s)."
+            });
+    }
+
+    private static ProjectionContractIndex? ParseProjectionContractIndex(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+            return null;
+
+        return new ProjectionContractIndex
+        {
+            ProducerSkill = ReadString(root, "producer_skill"),
+            ProducerPriority = ReadInt32(root, "producer_priority", ReadInt32(root, "producer_precedence", 0)),
+            DefaultSelectionPolicy = root.TryGetProperty("default_selection_policy", out var selectionPolicy)
+                ? ParseProjectionSelectionPolicy(selectionPolicy)
+                : new ProjectionSelectionPolicy(),
+            TopicScoring = root.TryGetProperty("topic_scoring", out var topicScoring)
+                ? ParseProjectionTopicScoring(topicScoring)
+                : null,
+            TargetViewScoring = root.TryGetProperty("target_view_scoring", out var targetViewScoring)
+                ? ParseProjectionTargetViewScoring(targetViewScoring)
+                : null,
+            Topics = root.TryGetProperty("topics", out var topics)
+                ? ParseProjectionTopics(topics)
+                : []
+        };
+    }
+
+    private static ProjectionSelectionPolicy ParseProjectionSelectionPolicy(JsonElement element)
+        => new()
+        {
+            PreferReadyOnly = ReadBoolean(element, "prefer_ready_only"),
+            BlockOnOpenQuestions = ReadBoolean(element, "block_on_open_questions"),
+            FallbackOrderByTargetView = ReadStringArray(element, "fallback_order_by_target_view")
+        };
+
+    private static ProjectionTopicScoring ParseProjectionTopicScoring(JsonElement element)
+        => new()
+        {
+            ClarifyWhenScoreGapBelow = ReadInt32(element, "clarify_when_score_gap_below", 2),
+            ScoreDimensions = element.TryGetProperty("score_dimensions", out var scoreDimensions)
+                ? ParseProjectionScoreDimensions(scoreDimensions)
+                : [],
+            Topics = element.TryGetProperty("topics", out var topics)
+                ? ParseProjectionTopicSignals(topics)
+                : []
+        };
+
+    private static ProjectionTargetViewScoring ParseProjectionTargetViewScoring(JsonElement element)
+        => new()
+        {
+            ClarifyWhenScoreGapBelow = ReadInt32(element, "clarify_when_score_gap_below", 2),
+            PreferExplicitUserArtifactRequests = ReadBoolean(element, "prefer_explicit_user_artifact_requests"),
+            ScoreDimensions = element.TryGetProperty("score_dimensions", out var scoreDimensions)
+                ? ParseProjectionScoreDimensions(scoreDimensions)
+                : [],
+            Views = element.TryGetProperty("views", out var views)
+                ? ParseProjectionViewSignals(views)
+                : [],
+            WithinTopicOverrides = element.TryGetProperty("within_topic_overrides", out var overrides)
+                ? ParseProjectionTopicViewOverrides(overrides)
+                : []
+        };
+
+    private static IReadOnlyList<ProjectionScoreDimension> ParseProjectionScoreDimensions(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var values = new List<ProjectionScoreDimension>();
+        foreach (var item in element.EnumerateArray())
+        {
+            var dimension = ReadString(item, "dimension");
+            if (string.IsNullOrWhiteSpace(dimension))
+                continue;
+
+            values.Add(new ProjectionScoreDimension
+            {
+                Dimension = dimension,
+                Score = ReadInt32(item, "score", 0)
+            });
+        }
+
+        return values;
+    }
+
+    private static IReadOnlyList<ProjectionTopicSignals> ParseProjectionTopicSignals(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var values = new List<ProjectionTopicSignals>();
+        foreach (var item in element.EnumerateArray())
+        {
+            var domainSlug = ReadString(item, "domain_slug");
+            if (string.IsNullOrWhiteSpace(domainSlug))
+                continue;
+
+            values.Add(new ProjectionTopicSignals
+            {
+                DomainSlug = domainSlug,
+                PrimaryIntentSignals = ReadStringArray(item, "primary_intent_signals"),
+                SupportingSignals = ReadStringArray(item, "supporting_signals"),
+                ExplicitArtifactSignals = ReadStringArray(item, "explicit_artifact_signals"),
+                DemoteWhenCompetingTopicSignals = ReadStringArray(item, "demote_when_competing_topic_signals")
+            });
+        }
+
+        return values;
+    }
+
+    private static IReadOnlyList<ProjectionViewSignals> ParseProjectionViewSignals(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var values = new List<ProjectionViewSignals>();
+        foreach (var item in element.EnumerateArray())
+        {
+            var targetView = ReadString(item, "target_view");
+            if (string.IsNullOrWhiteSpace(targetView))
+                continue;
+
+            values.Add(new ProjectionViewSignals
+            {
+                TargetView = targetView,
+                ExplicitOutputSignals = ReadStringArray(item, "explicit_output_signals"),
+                StrongSignals = ReadStringArray(item, "strong_signals"),
+                SupportingSignals = ReadStringArray(item, "supporting_signals"),
+                DemoteWhenCompetingViewSignals = ReadStringArray(item, "demote_when_competing_view_signals")
+            });
+        }
+
+        return values;
+    }
+
+    private static IReadOnlyList<ProjectionTopicViewOverride> ParseProjectionTopicViewOverrides(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var values = new List<ProjectionTopicViewOverride>();
+        foreach (var item in element.EnumerateArray())
+        {
+            var domainSlug = ReadString(item, "domain_slug");
+            if (string.IsNullOrWhiteSpace(domainSlug))
+                continue;
+
+            values.Add(new ProjectionTopicViewOverride
+            {
+                DomainSlug = domainSlug,
+                Bonuses = item.TryGetProperty("bonuses", out var bonuses)
+                    ? ParseProjectionTopicViewBonuses(bonuses)
+                    : []
+            });
+        }
+
+        return values;
+    }
+
+    private static IReadOnlyList<ProjectionTopicViewBonus> ParseProjectionTopicViewBonuses(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var values = new List<ProjectionTopicViewBonus>();
+        foreach (var item in element.EnumerateArray())
+        {
+            var targetView = ReadString(item, "target_view");
+            if (string.IsNullOrWhiteSpace(targetView))
+                continue;
+
+            values.Add(new ProjectionTopicViewBonus
+            {
+                TargetView = targetView,
+                WhenRequestSignals = ReadStringArray(item, "when_request_signals"),
+                Score = ReadInt32(item, "score", 0)
+            });
+        }
+
+        return values;
+    }
+
+    private static IReadOnlyList<ProjectionTopicRecord> ParseProjectionTopics(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var values = new List<ProjectionTopicRecord>();
+        foreach (var item in element.EnumerateArray())
+        {
+            var domainSlug = ReadString(item, "domain_slug");
+            var defaultTargetView = ReadString(item, "default_target_view");
+            if (string.IsNullOrWhiteSpace(domainSlug) || string.IsNullOrWhiteSpace(defaultTargetView))
+                continue;
+
+            values.Add(new ProjectionTopicRecord
+            {
+                DomainSlug = domainSlug,
+                DefaultTargetView = defaultTargetView,
+                Views = item.TryGetProperty("views", out var views)
+                    ? ParseProjectionViews(views)
+                    : []
+            });
+        }
+
+        return values;
+    }
+
+    private static IReadOnlyList<ProjectionViewRecord> ParseProjectionViews(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var values = new List<ProjectionViewRecord>();
+        foreach (var item in element.EnumerateArray())
+        {
+            var targetView = ReadString(item, "target_view");
+            var status = ReadString(item, "status");
+            var path = ReadString(item, "path");
+            if (string.IsNullOrWhiteSpace(targetView) || string.IsNullOrWhiteSpace(status) || string.IsNullOrWhiteSpace(path))
+                continue;
+
+            values.Add(new ProjectionViewRecord
+            {
+                TargetView = targetView,
+                Status = status,
+                Path = path
+            });
+        }
+
+        return values;
+    }
+
+    private static string ReadString(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString() ?? string.Empty
+            : string.Empty;
+
+    private static bool ReadBoolean(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var property) &&
+           (property.ValueKind == JsonValueKind.True || property.ValueKind == JsonValueKind.False) &&
+           property.GetBoolean();
+
+    private static int ReadInt32(JsonElement element, string propertyName, int fallback)
+        => element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.Number && property.TryGetInt32(out var value)
+            ? value
+            : fallback;
 }

--- a/src/OpenClaw.Core/Skills/SkillModels.cs
+++ b/src/OpenClaw.Core/Skills/SkillModels.cs
@@ -163,6 +163,15 @@ public sealed class SkillDefinition
     /// (Anthropic-style progressive disclosure, level 3).
     /// </summary>
     public IReadOnlyList<SkillResource> Resources { get; init; } = [];
+
+    /// <summary>Bound projection contracts that can refine this skill per request.</summary>
+    public IReadOnlyList<SkillProjectionContractSet> ProjectionContracts { get; init; } = [];
+
+    /// <summary>Optional machine-readable artifact/stage contract loaded from contracts/artifacts.json.</summary>
+    public SkillArtifactContract? ArtifactContract { get; init; }
+
+    /// <summary>Optional projection contract discovery diagnostics for loader summaries.</summary>
+    public SkillProjectionDiscovery? ProjectionDiscovery { get; init; }
 }
 
 /// <summary>

--- a/src/OpenClaw.Core/Skills/SkillProjectionArtifactTerms.cs
+++ b/src/OpenClaw.Core/Skills/SkillProjectionArtifactTerms.cs
@@ -1,0 +1,22 @@
+namespace OpenClaw.Core.Skills;
+
+public static class SkillProjectionViewKeys
+{
+    public const string JsonSchema = "json-schema";
+    public const string WorkflowContract = "workflow-contract";
+    public const string DomainModel = "domain-model";
+    public const string PromptConstraint = "prompt-constraint";
+}
+
+internal static class SkillProjectionArtifactTerms
+{
+    public static IReadOnlyList<string> GetExplicitArtifactTerms(string targetView)
+        => targetView.Trim().ToLowerInvariant() switch
+        {
+            SkillProjectionViewKeys.JsonSchema => ["json schema", "schema file", "schema definition", "json schema 文件", "schema 文件", "schema 定义"],
+            SkillProjectionViewKeys.WorkflowContract => ["workflow contract", "工作流契约"],
+            SkillProjectionViewKeys.DomainModel => ["domain model", "领域模型"],
+            SkillProjectionViewKeys.PromptConstraint => ["prompt policy", "prompt constraint", "提示词策略", "提示词约束"],
+            _ => []
+        };
+}

--- a/src/OpenClaw.Core/Skills/SkillProjectionResolver.cs
+++ b/src/OpenClaw.Core/Skills/SkillProjectionResolver.cs
@@ -159,7 +159,20 @@ public static class SkillProjectionResolver
                 totalScore);
         }
 
-        var projectionPath = Path.Combine(contract.RootPath, resolvedView.Item.Path.Replace('/', Path.DirectorySeparatorChar));
+        var resolvedViewPath = resolvedView.Item.Path.Replace('/', Path.DirectorySeparatorChar);
+        if (Path.IsPathRooted(resolvedViewPath) || resolvedViewPath.Contains(".."))
+            return ProjectionRouteAttempt.Blocked(
+                Block(skillName, $"Projection view path '{resolvedView.Item.Path}' is not a safe relative path."),
+                totalScore);
+
+        var projectionPath = Path.GetFullPath(Path.Combine(contract.RootPath, resolvedViewPath));
+        var canonicalRoot = Path.GetFullPath(contract.RootPath);
+        if (!projectionPath.StartsWith(canonicalRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) &&
+            projectionPath != canonicalRoot)
+            return ProjectionRouteAttempt.Blocked(
+                Block(skillName, $"Projection view path '{resolvedView.Item.Path}' escapes the contract root."),
+                totalScore);
+
         if (!File.Exists(projectionPath))
         {
             logger.LogWarning("Projection file not found for skill '{SkillName}' at {ProjectionPath}", skillName, projectionPath);
@@ -230,7 +243,9 @@ public static class SkillProjectionResolver
         var crossTopicPenalty = GetDimensionScore(dimensionScores, "cross_topic_conflict_penalty", -2);
         var threshold = index.TopicScoring?.ClarifyWhenScoreGapBelow ?? 2;
 
-        var topicSignals = index.TopicScoring?.Topics.ToDictionary(topic => topic.DomainSlug, StringComparer.OrdinalIgnoreCase)
+        var topicSignals = index.TopicScoring?.Topics
+            .GroupBy(topic => topic.DomainSlug, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase)
             ?? new Dictionary<string, ProjectionTopicSignals>(StringComparer.OrdinalIgnoreCase);
 
         var scored = index.Topics
@@ -286,7 +301,9 @@ public static class SkillProjectionResolver
         var explicitArtifactRequestBonus = GetDimensionScore(dimensionScores, "explicit_user_artifact_request_bonus", 4);
         var threshold = index.TargetViewScoring?.ClarifyWhenScoreGapBelow ?? 2;
 
-        var viewSignals = index.TargetViewScoring?.Views.ToDictionary(view => view.TargetView, StringComparer.OrdinalIgnoreCase)
+        var viewSignals = index.TargetViewScoring?.Views
+            .GroupBy(view => view.TargetView, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase)
             ?? new Dictionary<string, ProjectionViewSignals>(StringComparer.OrdinalIgnoreCase);
         var topicOverride = index.TargetViewScoring?.WithinTopicOverrides
             .FirstOrDefault(overrideRecord => overrideRecord.DomainSlug.Equals(topic.DomainSlug, StringComparison.OrdinalIgnoreCase));
@@ -481,7 +498,9 @@ public static class SkillProjectionResolver
         };
 
     private static Dictionary<string, int> ToScoreMap(IReadOnlyList<ProjectionScoreDimension>? dimensions)
-        => dimensions?.ToDictionary(item => item.Dimension, item => item.Score, StringComparer.OrdinalIgnoreCase)
+        => dimensions?
+            .GroupBy(item => item.Dimension, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First().Score, StringComparer.OrdinalIgnoreCase)
             ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
     private static int GetDimensionScore(Dictionary<string, int> scores, string name, int fallback)

--- a/src/OpenClaw.Core/Skills/SkillProjectionResolver.cs
+++ b/src/OpenClaw.Core/Skills/SkillProjectionResolver.cs
@@ -1,0 +1,612 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace OpenClaw.Core.Skills;
+
+/// <summary>
+/// Resolves a bound projection contract for a skill against the current request text.
+/// </summary>
+public static class SkillProjectionResolver
+{
+    public static SkillProjectionResolution ResolveForRequest(
+        SkillDefinition skill,
+        string requestText,
+        ILogger logger)
+    {
+        if (skill.ProjectionContracts.Count == 0)
+        {
+            return new SkillProjectionResolution
+            {
+                SkillName = skill.Name,
+                HasContracts = false
+            };
+        }
+
+        var normalizedRequest = requestText?.Trim().ToLowerInvariant() ?? string.Empty;
+        var matchedAttempts = new List<ProjectionRouteAttempt>(skill.ProjectionContracts.Count);
+        var ambiguousAttempts = new List<string>();
+
+        foreach (var contract in skill.ProjectionContracts)
+        {
+            var attempt = TryResolveContract(skill.Name, contract, normalizedRequest, logger);
+            if (attempt is null)
+                continue;
+
+            if (attempt.IsAmbiguous)
+            {
+                if (!string.IsNullOrWhiteSpace(attempt.AmbiguousReason))
+                    ambiguousAttempts.Add(attempt.AmbiguousReason);
+                continue;
+            }
+
+            matchedAttempts.Add(attempt);
+        }
+
+        if (matchedAttempts.Count == 0)
+        {
+            if (ambiguousAttempts.Count > 0)
+                return Block(skill.Name, ambiguousAttempts[0]);
+
+            return Block(skill.Name, "Projection topic selection did not produce a usable route for this request.");
+        }
+
+        var rankedAttempts = matchedAttempts
+            .OrderByDescending(attempt => attempt.Score)
+            .ThenByDescending(attempt => attempt.ProducerPriority)
+            .ToList();
+
+        if (rankedAttempts.Count > 1 &&
+            rankedAttempts[0].Score == rankedAttempts[1].Score &&
+            rankedAttempts[0].ProducerPriority == rankedAttempts[1].ProducerPriority)
+        {
+            return Block(skill.Name, "Projection route selection is ambiguous across multiple producers for this request.");
+        }
+
+        return rankedAttempts[0].Resolution;
+    }
+
+    public static string BuildPromptPatch(SkillProjectionResolution resolution)
+    {
+        if (resolution.Projection is null ||
+            string.IsNullOrWhiteSpace(resolution.SelectedTopic) ||
+            string.IsNullOrWhiteSpace(resolution.SelectedTargetView) ||
+            string.IsNullOrWhiteSpace(resolution.ProjectionFilePath))
+            return string.Empty;
+
+        var sb = new StringBuilder();
+        sb.AppendLine();
+        sb.AppendLine("[Projection Route]");
+        sb.AppendLine($"Selected topic: {resolution.SelectedTopic}");
+        sb.AppendLine($"Selected target view: {resolution.SelectedTargetView}");
+        sb.AppendLine($"Projection source: {resolution.ProjectionFilePath}");
+
+        var promptConstraint = BuildPromptAssumptionConstraint(resolution.Projection.MappingPolicy.PromptAssumptionPolicy);
+        if (!string.IsNullOrWhiteSpace(promptConstraint))
+            sb.AppendLine($"Prompt constraint: {promptConstraint}");
+
+        AppendList(sb, "Allowed terms", resolution.Projection.PromptProjection.AllowedTerms);
+        AppendList(sb, "Forbidden assumptions", resolution.Projection.PromptProjection.ForbiddenAssumptions);
+        AppendList(sb, "Required clarifications", resolution.Projection.PromptProjection.RequiredClarifications);
+        AppendList(sb, "Reasoning paths", resolution.Projection.PromptProjection.ReasoningPaths);
+        AppendList(sb, "Source digest", resolution.Projection.PromptProjection.SourceDigest);
+        AppendList(sb, "Delivery artifacts", resolution.Projection.DeliveryArtifacts.Select(FormatDeliveryArtifact).ToArray());
+
+        if (resolution.Projection.DroppedItems.Count > 0)
+            AppendList(sb, "Dropped items", resolution.Projection.DroppedItems);
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static SkillProjectionResolution Block(string skillName, string reason)
+        => new()
+        {
+            SkillName = skillName,
+            HasContracts = true,
+            IsBlocked = true,
+            BlockReason = reason
+        };
+
+    private static ProjectionRouteAttempt? TryResolveContract(
+        string skillName,
+        SkillProjectionContractSet contract,
+        string requestText,
+        ILogger logger)
+    {
+        var index = contract.Index;
+
+        var selectedTopic = SelectTopic(index, requestText);
+        if (selectedTopic is null)
+        {
+            if (!TryResolveNoSignalFallback(index, out selectedTopic))
+            {
+                return ProjectionRouteAttempt.Ambiguous(
+                    "Projection topic selection is ambiguous for this request.");
+            }
+
+            logger.LogDebug(
+                "Projection routing for skill '{SkillName}' used fallback topic '{Topic}' because request text matched no projection signals.",
+                skillName,
+                selectedTopic!.Item.DomainSlug);
+        }
+
+        var resolvedTopic = selectedTopic!;
+
+        var selectedView = SelectView(index, resolvedTopic.Item, requestText);
+        if (selectedView is null)
+        {
+            if (!(resolvedTopic.Score == 0 && TryResolveFallbackView(index, resolvedTopic.Item, out selectedView)))
+            {
+                return ProjectionRouteAttempt.Ambiguous(
+                    $"Projection target view selection is ambiguous for topic '{resolvedTopic.Item.DomainSlug}'.");
+            }
+
+            logger.LogDebug(
+                "Projection routing for skill '{SkillName}' used fallback target view '{TargetView}' for topic '{Topic}'.",
+                skillName,
+                selectedView!.Item.TargetView,
+                resolvedTopic.Item.DomainSlug);
+        }
+
+        var resolvedView = selectedView!;
+
+        var totalScore = resolvedTopic.Score + resolvedView.Score;
+        if (index.DefaultSelectionPolicy.PreferReadyOnly &&
+            !resolvedView.Item.Status.Equals("READY", StringComparison.OrdinalIgnoreCase))
+        {
+            return ProjectionRouteAttempt.Blocked(
+                Block(skillName, $"Projection '{resolvedTopic.Item.DomainSlug}/{resolvedView.Item.TargetView}' is not READY."),
+                totalScore);
+        }
+
+        var projectionPath = Path.Combine(contract.RootPath, resolvedView.Item.Path.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(projectionPath))
+        {
+            logger.LogWarning("Projection file not found for skill '{SkillName}' at {ProjectionPath}", skillName, projectionPath);
+            return ProjectionRouteAttempt.Blocked(
+                Block(skillName, $"Projection file '{resolvedView.Item.Path}' was not found."),
+                totalScore);
+        }
+
+        ProjectionDocument? projection;
+        try
+        {
+            projection = LoadProjection(projectionPath);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to parse projection file for skill '{SkillName}' at {ProjectionPath}", skillName, projectionPath);
+            return ProjectionRouteAttempt.Blocked(
+                Block(skillName, $"Projection file '{resolvedView.Item.Path}' could not be parsed."),
+                totalScore);
+        }
+
+        if (projection is null)
+        {
+            return ProjectionRouteAttempt.Blocked(
+                Block(skillName, $"Projection file '{resolvedView.Item.Path}' is missing required route fields."),
+                totalScore);
+        }
+
+        if (index.DefaultSelectionPolicy.BlockOnOpenQuestions && projection.OpenQuestions.Count > 0)
+        {
+            return ProjectionRouteAttempt.Blocked(
+                Block(skillName, $"Projection '{resolvedTopic.Item.DomainSlug}/{resolvedView.Item.TargetView}' has blocking open questions."),
+                totalScore);
+        }
+
+        if (string.Equals(projection.MappingPolicy.UnresolvedItemPolicy, "block_or_escalate", StringComparison.OrdinalIgnoreCase) &&
+            projection.OpenQuestions.Count > 0)
+        {
+            return ProjectionRouteAttempt.Blocked(
+                Block(skillName, $"Projection '{resolvedTopic.Item.DomainSlug}/{resolvedView.Item.TargetView}' requires escalation before use."),
+                totalScore);
+        }
+
+        return ProjectionRouteAttempt.Success(
+            new SkillProjectionResolution
+            {
+                SkillName = skillName,
+                HasContracts = true,
+                SelectedTopic = resolvedTopic.Item.DomainSlug,
+                SelectedTargetView = resolvedView.Item.TargetView,
+                ProjectionFilePath = projectionPath,
+                Projection = projection
+            },
+            totalScore,
+            contract.ProducerPriority);
+    }
+
+    private static ProjectionScore<ProjectionTopicRecord>? SelectTopic(ProjectionContractIndex index, string requestText)
+    {
+        if (index.Topics.Count == 0)
+            return null;
+
+        var dimensionScores = ToScoreMap(index.TopicScoring?.ScoreDimensions);
+        var explicitArtifactBonus = GetDimensionScore(dimensionScores, "explicit_artifact_bonus", 4);
+        var primaryIntentMatch = GetDimensionScore(dimensionScores, "primary_intent_match", 5);
+        var strongKeywordMatch = GetDimensionScore(dimensionScores, "strong_keyword_match", 3);
+        var supportingKeywordMatch = GetDimensionScore(dimensionScores, "supporting_keyword_match", 1);
+        var crossTopicPenalty = GetDimensionScore(dimensionScores, "cross_topic_conflict_penalty", -2);
+        var threshold = index.TopicScoring?.ClarifyWhenScoreGapBelow ?? 2;
+
+        var topicSignals = index.TopicScoring?.Topics.ToDictionary(topic => topic.DomainSlug, StringComparer.OrdinalIgnoreCase)
+            ?? new Dictionary<string, ProjectionTopicSignals>(StringComparer.OrdinalIgnoreCase);
+
+        var scored = index.Topics
+            .Select(topic =>
+            {
+                topicSignals.TryGetValue(topic.DomainSlug, out var signals);
+                var score = 0;
+
+                if (signals is not null)
+                {
+                    score += CountMatches(requestText, signals.PrimaryIntentSignals) * strongKeywordMatch;
+                    score += CountMatches(requestText, signals.SupportingSignals) * supportingKeywordMatch;
+                    if (HasAnyMatch(requestText, signals.ExplicitArtifactSignals))
+                        score += explicitArtifactBonus;
+                    if (HasAnyMatch(requestText, signals.PrimaryIntentSignals))
+                        score += primaryIntentMatch;
+                    if (HasAnyMatch(requestText, signals.DemoteWhenCompetingTopicSignals))
+                        score += crossTopicPenalty;
+                }
+
+                return new ProjectionScore<ProjectionTopicRecord>(topic, score);
+            })
+            .OrderByDescending(item => item.Score)
+            .ToList();
+
+        if (scored.Count == 0)
+            return null;
+
+        if (scored[0].Score <= 0)
+            return null;
+
+        if (scored.Count > 1 && (scored[0].Score - scored[1].Score) < threshold)
+            return null;
+
+        return scored[0];
+    }
+
+    private static ProjectionScore<ProjectionViewRecord>? SelectView(ProjectionContractIndex index, ProjectionTopicRecord topic, string requestText)
+    {
+        var candidates = index.DefaultSelectionPolicy.PreferReadyOnly
+            ? topic.Views.Where(view => view.Status.Equals("READY", StringComparison.OrdinalIgnoreCase)).ToList()
+            : topic.Views.ToList();
+
+        if (candidates.Count == 0)
+            return null;
+
+        var dimensionScores = ToScoreMap(index.TargetViewScoring?.ScoreDimensions);
+        var explicitOutputMatch = GetDimensionScore(dimensionScores, "explicit_output_match", 5);
+        var strongSignalMatch = GetDimensionScore(dimensionScores, "strong_signal_match", 3);
+        var supportingSignalMatch = GetDimensionScore(dimensionScores, "supporting_signal_match", 1);
+        var crossViewPenalty = GetDimensionScore(dimensionScores, "cross_view_conflict_penalty", -2);
+        var defaultViewBonus = GetDimensionScore(dimensionScores, "topic_default_view_bonus", 1);
+        var explicitArtifactRequestBonus = GetDimensionScore(dimensionScores, "explicit_user_artifact_request_bonus", 4);
+        var threshold = index.TargetViewScoring?.ClarifyWhenScoreGapBelow ?? 2;
+
+        var viewSignals = index.TargetViewScoring?.Views.ToDictionary(view => view.TargetView, StringComparer.OrdinalIgnoreCase)
+            ?? new Dictionary<string, ProjectionViewSignals>(StringComparer.OrdinalIgnoreCase);
+        var topicOverride = index.TargetViewScoring?.WithinTopicOverrides
+            .FirstOrDefault(overrideRecord => overrideRecord.DomainSlug.Equals(topic.DomainSlug, StringComparison.OrdinalIgnoreCase));
+
+        var scored = candidates
+            .Select(view =>
+            {
+                viewSignals.TryGetValue(view.TargetView, out var signals);
+                var score = 0;
+
+                if (signals is not null)
+                {
+                    if (HasAnyMatch(requestText, signals.ExplicitOutputSignals))
+                        score += explicitOutputMatch;
+                    score += CountMatches(requestText, signals.StrongSignals) * strongSignalMatch;
+                    score += CountMatches(requestText, signals.SupportingSignals) * supportingSignalMatch;
+                    if (HasAnyMatch(requestText, signals.DemoteWhenCompetingViewSignals))
+                        score += crossViewPenalty;
+                }
+
+                if (index.TargetViewScoring?.PreferExplicitUserArtifactRequests == true &&
+                    HasExplicitArtifactRequestForView(requestText, view.TargetView))
+                {
+                    score += explicitArtifactRequestBonus;
+                }
+
+                if (view.TargetView.Equals(topic.DefaultTargetView, StringComparison.OrdinalIgnoreCase))
+                    score += defaultViewBonus;
+
+                if (topicOverride is not null)
+                {
+                    foreach (var bonus in topicOverride.Bonuses)
+                    {
+                        if (!bonus.TargetView.Equals(view.TargetView, StringComparison.OrdinalIgnoreCase))
+                            continue;
+
+                        if (HasAnyMatch(requestText, bonus.WhenRequestSignals))
+                            score += bonus.Score;
+                    }
+                }
+
+                return new ProjectionScore<ProjectionViewRecord>(view, score);
+            })
+            .OrderByDescending(item => item.Score)
+            .ToList();
+
+        if (scored.Count == 0)
+            return null;
+
+        if (scored[0].Score <= 0)
+            return null;
+
+        if (scored.Count > 1 && (scored[0].Score - scored[1].Score) < threshold)
+            return null;
+
+        return scored[0];
+    }
+
+    private static bool TryResolveNoSignalFallback(
+        ProjectionContractIndex index,
+        out ProjectionScore<ProjectionTopicRecord>? selectedTopic)
+    {
+        selectedTopic = null;
+
+        foreach (var targetView in index.DefaultSelectionPolicy.FallbackOrderByTargetView)
+        {
+            if (string.IsNullOrWhiteSpace(targetView))
+                continue;
+
+            foreach (var topic in index.Topics)
+            {
+                if (!topic.Views.Any(view => view.TargetView.Equals(targetView, StringComparison.OrdinalIgnoreCase)))
+                    continue;
+
+                selectedTopic = new ProjectionScore<ProjectionTopicRecord>(topic, 0);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveFallbackView(
+        ProjectionContractIndex index,
+        ProjectionTopicRecord topic,
+        out ProjectionScore<ProjectionViewRecord>? selectedView)
+    {
+        selectedView = null;
+
+        var candidates = index.DefaultSelectionPolicy.PreferReadyOnly
+            ? topic.Views.Where(view => view.Status.Equals("READY", StringComparison.OrdinalIgnoreCase)).ToList()
+            : topic.Views.ToList();
+
+        foreach (var targetView in index.DefaultSelectionPolicy.FallbackOrderByTargetView)
+        {
+            if (string.IsNullOrWhiteSpace(targetView))
+                continue;
+
+            var view = candidates.FirstOrDefault(candidate => candidate.TargetView.Equals(targetView, StringComparison.OrdinalIgnoreCase));
+            if (view is null)
+                continue;
+
+            selectedView = new ProjectionScore<ProjectionViewRecord>(view, 0);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static ProjectionDocument? LoadProjection(string projectionPath)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(projectionPath));
+        var root = document.RootElement;
+
+        var mappingPolicy = root.TryGetProperty("mapping_policy", out var mappingPolicyElement)
+            ? new ProjectionMappingPolicy
+            {
+                UnresolvedItemPolicy = GetOptionalString(mappingPolicyElement, "unresolved_item_policy"),
+                PromptAssumptionPolicy = GetOptionalString(mappingPolicyElement, "prompt_assumption_policy")
+            }
+            : new ProjectionMappingPolicy();
+
+        var promptProjection = root.TryGetProperty("prompt_projection", out var promptProjectionElement)
+            ? new ProjectionPromptPayload
+            {
+                AllowedTerms = ReadStringArray(promptProjectionElement, "allowed_terms"),
+                ForbiddenAssumptions = ReadStringArray(promptProjectionElement, "forbidden_assumptions"),
+                RequiredClarifications = ReadStringArray(promptProjectionElement, "required_clarifications"),
+                ReasoningPaths = ReadStringArray(promptProjectionElement, "reasoning_paths"),
+                SourceDigest = ReadStringArray(promptProjectionElement, "source_digest")
+            }
+            : new ProjectionPromptPayload();
+
+        var deliveryArtifacts = new List<ProjectionDeliveryArtifact>();
+        if (root.TryGetProperty("delivery_artifacts", out var artifactsElement) && artifactsElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var artifact in artifactsElement.EnumerateArray())
+            {
+                var artifactName = GetOptionalString(artifact, "artifact_name");
+                var artifactType = GetOptionalString(artifact, "artifact_type");
+                var path = GetOptionalString(artifact, "path");
+                if (string.IsNullOrWhiteSpace(artifactName) || string.IsNullOrWhiteSpace(artifactType) || string.IsNullOrWhiteSpace(path))
+                    continue;
+
+                deliveryArtifacts.Add(new ProjectionDeliveryArtifact
+                {
+                    ArtifactName = artifactName,
+                    ArtifactType = artifactType,
+                    Path = path,
+                    Status = GetOptionalString(artifact, "status")
+                });
+            }
+        }
+
+        return new ProjectionDocument
+        {
+            MappingPolicy = mappingPolicy,
+            PromptProjection = promptProjection,
+            DeliveryArtifacts = deliveryArtifacts,
+            DroppedItems = ReadDisplayArray(root, "dropped_items"),
+            OpenQuestions = ReadDisplayArray(root, "open_questions")
+        };
+    }
+
+    private static void AppendList(StringBuilder sb, string label, IReadOnlyList<string> items)
+    {
+        if (items.Count == 0)
+            return;
+
+        sb.AppendLine();
+        sb.AppendLine(label + ":");
+        foreach (var item in items)
+            sb.AppendLine($"- {item}");
+    }
+
+    private static string FormatDeliveryArtifact(ProjectionDeliveryArtifact artifact)
+    {
+        var statusSuffix = string.IsNullOrWhiteSpace(artifact.Status)
+            ? string.Empty
+            : $" [{artifact.Status}]";
+        return $"{artifact.ArtifactName} ({artifact.ArtifactType}) -> {artifact.Path}{statusSuffix}";
+    }
+
+    private static string? BuildPromptAssumptionConstraint(string? policy)
+        => policy?.Trim().ToLowerInvariant() switch
+        {
+            "disallow_unmapped_terms" => "Do not use unmapped terms or invent terminology beyond this projection.",
+            "warn_on_unmapped_terms" => "If you use terms not mapped by this projection, explicitly warn that they are unmapped assumptions.",
+            "allow_unmapped_terms" => "Unmapped terms are allowed, but prefer mapped terminology when available.",
+            null or "" => null,
+            _ => $"Follow prompt assumption policy '{policy}' when introducing terms not mapped by this projection."
+        };
+
+    private static Dictionary<string, int> ToScoreMap(IReadOnlyList<ProjectionScoreDimension>? dimensions)
+        => dimensions?.ToDictionary(item => item.Dimension, item => item.Score, StringComparer.OrdinalIgnoreCase)
+            ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+    private static int GetDimensionScore(Dictionary<string, int> scores, string name, int fallback)
+        => scores.TryGetValue(name, out var value) ? value : fallback;
+
+    private static int CountMatches(string requestText, IReadOnlyList<string> signals)
+        => signals.Count(signal => ContainsPhrase(requestText, signal));
+
+    private static bool HasAnyMatch(string requestText, IReadOnlyList<string> signals)
+        => signals.Any(signal => ContainsPhrase(requestText, signal));
+
+    private static bool HasExplicitArtifactRequestForView(string requestText, string targetView)
+        => SkillProjectionArtifactTerms.GetExplicitArtifactTerms(targetView)
+            .Any(signal => ContainsPhrase(requestText, signal));
+
+    private static bool ContainsPhrase(string requestText, string signal)
+        => !string.IsNullOrWhiteSpace(signal) && requestText.Contains(signal.Trim().ToLowerInvariant(), StringComparison.Ordinal);
+
+    private static string? GetOptionalString(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static IReadOnlyList<string> ReadStringArray(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property) || property.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var values = new List<string>();
+        foreach (var item in property.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String && !string.IsNullOrWhiteSpace(item.GetString()))
+                values.Add(item.GetString()!);
+        }
+
+        return values;
+    }
+
+    private static IReadOnlyList<string> ReadDisplayArray(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property) || property.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var values = new List<string>();
+        foreach (var item in property.EnumerateArray())
+        {
+            var displayText = ToDisplayText(item);
+            if (!string.IsNullOrWhiteSpace(displayText))
+                values.Add(displayText);
+        }
+
+        return values;
+    }
+
+    private static string? ToDisplayText(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.String)
+            return string.IsNullOrWhiteSpace(element.GetString()) ? null : element.GetString();
+
+        if (element.ValueKind != JsonValueKind.Object)
+            return null;
+
+        if (TryBuildOpenQuestionText(element, out var openQuestionText))
+            return openQuestionText;
+
+        if (TryBuildDroppedItemText(element, out var droppedItemText))
+            return droppedItemText;
+
+        return element.GetRawText();
+    }
+
+    private static bool TryBuildOpenQuestionText(JsonElement element, out string? text)
+    {
+        text = GetOptionalString(element, "question");
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        var details = new List<string>();
+        var impact = GetOptionalString(element, "impact");
+        var requiredInput = GetOptionalString(element, "required_input");
+
+        if (!string.IsNullOrWhiteSpace(impact))
+            details.Add($"Impact: {impact}");
+
+        if (!string.IsNullOrWhiteSpace(requiredInput))
+            details.Add($"Required input: {requiredInput}");
+
+        if (details.Count > 0)
+            text = $"{text} ({string.Join("; ", details)})";
+
+        return true;
+    }
+
+    private static bool TryBuildDroppedItemText(JsonElement element, out string? text)
+    {
+        text = GetOptionalString(element, "reason");
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        var itemType = GetOptionalString(element, "item_type");
+        var itemId = GetOptionalString(element, "item_id");
+        var prefix = string.Join(" ", new[] { itemType, itemId }.Where(static value => !string.IsNullOrWhiteSpace(value)));
+
+        if (!string.IsNullOrWhiteSpace(prefix))
+            text = $"{prefix}: {text}";
+
+        return true;
+    }
+
+    private sealed record ProjectionScore<T>(T Item, int Score);
+
+    private sealed record ProjectionRouteAttempt(
+        SkillProjectionResolution Resolution,
+        int Score,
+        int ProducerPriority,
+        bool IsAmbiguous,
+        string? AmbiguousReason)
+    {
+        public static ProjectionRouteAttempt Success(SkillProjectionResolution resolution, int score, int producerPriority)
+            => new(resolution, score, producerPriority, false, null);
+
+        public static ProjectionRouteAttempt Blocked(SkillProjectionResolution resolution, int score)
+            => new(resolution, score, 0, false, null);
+
+        public static ProjectionRouteAttempt Ambiguous(string reason)
+            => new(Block(string.Empty, reason), int.MinValue, int.MinValue, true, reason);
+    }
+}

--- a/src/OpenClaw.Core/Skills/SkillProjectionResolver.cs
+++ b/src/OpenClaw.Core/Skills/SkillProjectionResolver.cs
@@ -159,19 +159,13 @@ public static class SkillProjectionResolver
                 totalScore);
         }
 
-        var resolvedViewPath = resolvedView.Item.Path.Replace('/', Path.DirectorySeparatorChar);
-        if (Path.IsPathRooted(resolvedViewPath) || resolvedViewPath.Contains(".."))
+        if (!TryResolveProjectionPath(contract.RootPath, resolvedView.Item.Path, out var projectionPath))
+        {
+            logger.LogWarning("Projection path escaped contract root for skill '{SkillName}': {ProjectionPath}", skillName, resolvedView.Item.Path);
             return ProjectionRouteAttempt.Blocked(
-                Block(skillName, $"Projection view path '{resolvedView.Item.Path}' is not a safe relative path."),
+                Block(skillName, $"Projection file '{resolvedView.Item.Path}' is outside the projection contract root."),
                 totalScore);
-
-        var projectionPath = Path.GetFullPath(Path.Combine(contract.RootPath, resolvedViewPath));
-        var canonicalRoot = Path.GetFullPath(contract.RootPath);
-        if (!projectionPath.StartsWith(canonicalRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) &&
-            projectionPath != canonicalRoot)
-            return ProjectionRouteAttempt.Blocked(
-                Block(skillName, $"Projection view path '{resolvedView.Item.Path}' escapes the contract root."),
-                totalScore);
+        }
 
         if (!File.Exists(projectionPath))
         {
@@ -243,10 +237,7 @@ public static class SkillProjectionResolver
         var crossTopicPenalty = GetDimensionScore(dimensionScores, "cross_topic_conflict_penalty", -2);
         var threshold = index.TopicScoring?.ClarifyWhenScoreGapBelow ?? 2;
 
-        var topicSignals = index.TopicScoring?.Topics
-            .GroupBy(topic => topic.DomainSlug, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase)
-            ?? new Dictionary<string, ProjectionTopicSignals>(StringComparer.OrdinalIgnoreCase);
+        var topicSignals = ToFirstByKey(index.TopicScoring?.Topics, static topic => topic.DomainSlug);
 
         var scored = index.Topics
             .Select(topic =>
@@ -301,10 +292,7 @@ public static class SkillProjectionResolver
         var explicitArtifactRequestBonus = GetDimensionScore(dimensionScores, "explicit_user_artifact_request_bonus", 4);
         var threshold = index.TargetViewScoring?.ClarifyWhenScoreGapBelow ?? 2;
 
-        var viewSignals = index.TargetViewScoring?.Views
-            .GroupBy(view => view.TargetView, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase)
-            ?? new Dictionary<string, ProjectionViewSignals>(StringComparer.OrdinalIgnoreCase);
+        var viewSignals = ToFirstByKey(index.TargetViewScoring?.Views, static view => view.TargetView);
         var topicOverride = index.TargetViewScoring?.WithinTopicOverrides
             .FirstOrDefault(overrideRecord => overrideRecord.DomainSlug.Equals(topic.DomainSlug, StringComparison.OrdinalIgnoreCase));
 
@@ -335,11 +323,9 @@ public static class SkillProjectionResolver
 
                 if (topicOverride is not null)
                 {
-                    foreach (var bonus in topicOverride.Bonuses)
+                    foreach (var bonus in topicOverride.Bonuses.Where(bonus =>
+                        bonus.TargetView.Equals(view.TargetView, StringComparison.OrdinalIgnoreCase)))
                     {
-                        if (!bonus.TargetView.Equals(view.TargetView, StringComparison.OrdinalIgnoreCase))
-                            continue;
-
                         if (HasAnyMatch(requestText, bonus.WhenRequestSignals))
                             score += bonus.Score;
                     }
@@ -373,11 +359,9 @@ public static class SkillProjectionResolver
             if (string.IsNullOrWhiteSpace(targetView))
                 continue;
 
-            foreach (var topic in index.Topics)
+            foreach (var topic in index.Topics.Where(topic =>
+                topic.Views.Any(view => view.TargetView.Equals(targetView, StringComparison.OrdinalIgnoreCase))))
             {
-                if (!topic.Views.Any(view => view.TargetView.Equals(targetView, StringComparison.OrdinalIgnoreCase)))
-                    continue;
-
                 selectedTopic = new ProjectionScore<ProjectionTopicRecord>(topic, 0);
                 return true;
             }
@@ -498,10 +482,64 @@ public static class SkillProjectionResolver
         };
 
     private static Dictionary<string, int> ToScoreMap(IReadOnlyList<ProjectionScoreDimension>? dimensions)
-        => dimensions?
-            .GroupBy(item => item.Dimension, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.First().Score, StringComparer.OrdinalIgnoreCase)
-            ?? new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        => ToFirstByKey(dimensions, static item => item.Dimension)
+            .ToDictionary(item => item.Key, item => item.Value.Score, StringComparer.OrdinalIgnoreCase);
+
+    private static Dictionary<string, T> ToFirstByKey<T>(IEnumerable<T>? items, Func<T, string?> keySelector)
+    {
+        var values = new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
+        if (items is null)
+            return values;
+
+        foreach (var item in items)
+        {
+            var key = keySelector(item);
+            if (string.IsNullOrWhiteSpace(key) || values.ContainsKey(key))
+                continue;
+
+            values[key] = item;
+        }
+
+        return values;
+    }
+
+    private static bool TryResolveProjectionPath(string rootPath, string relativePath, out string projectionPath)
+    {
+        projectionPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(rootPath) || string.IsNullOrWhiteSpace(relativePath))
+            return false;
+
+        var normalizedRelativePath = relativePath
+            .Replace('/', Path.DirectorySeparatorChar)
+            .Replace('\\', Path.DirectorySeparatorChar);
+        if (Path.IsPathRooted(normalizedRelativePath))
+            return false;
+
+        try
+        {
+            var rootFullPath = Path.GetFullPath(rootPath);
+            var candidateFullPath = Path.GetFullPath(Path.Combine(rootFullPath, normalizedRelativePath));
+            var rootWithSeparator = rootFullPath.EndsWith(Path.DirectorySeparatorChar)
+                ? rootFullPath
+                : rootFullPath + Path.DirectorySeparatorChar;
+            var comparison = OperatingSystem.IsWindows()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            if (!candidateFullPath.StartsWith(rootWithSeparator, comparison) &&
+                !string.Equals(candidateFullPath, rootFullPath, comparison))
+            {
+                return false;
+            }
+
+            projectionPath = candidateFullPath;
+            return true;
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or PathTooLongException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
 
     private static int GetDimensionScore(Dictionary<string, int> scores, string name, int fallback)
         => scores.TryGetValue(name, out var value) ? value : fallback;

--- a/src/OpenClaw.Core/Skills/SkillPromptBuilder.cs
+++ b/src/OpenClaw.Core/Skills/SkillPromptBuilder.cs
@@ -165,6 +165,35 @@ public static class SkillPromptBuilder
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Build the skill body with optional projection resolution.
+    /// When <paramref name="userRequestText"/> is non-null and the skill has projection contracts,
+    /// the best-matching projection patch is appended to the instructions body.
+    /// </summary>
+    public static string BuildSkillBody(SkillDefinition skill, string? userRequestText,
+        Microsoft.Extensions.Logging.ILogger? logger = null)
+    {
+        var body = BuildSkillBody(skill);
+        if (body.Length == 0)
+            return body;
+
+        if (string.IsNullOrWhiteSpace(userRequestText) || skill.ProjectionContracts.Count == 0)
+            return body;
+
+        var resolution = SkillProjectionResolver.ResolveForRequest(
+            skill, userRequestText,
+            logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+        if (resolution.IsBlocked)
+            return body;
+
+        var patch = SkillProjectionResolver.BuildPromptPatch(resolution);
+        if (string.IsNullOrWhiteSpace(patch))
+            return body;
+
+        return body.TrimEnd() + "\n\n" + patch + "\n";
+    }
+
     private static void AppendSkillEntry(StringBuilder sb, SkillDefinition skill)
     {
         sb.AppendLine("<skill>");

--- a/src/OpenClaw.Gateway/Composition/GatewayAppRuntime.cs
+++ b/src/OpenClaw.Gateway/Composition/GatewayAppRuntime.cs
@@ -14,6 +14,7 @@ using OpenClaw.Core.Sessions;
 using OpenClaw.Core.Skills;
 using OpenClaw.Gateway;
 using OpenClaw.Gateway.Extensions;
+using OpenClaw.Gateway.Tools;
 using OpenClaw.Payments.Core;
 
 namespace OpenClaw.Gateway.Composition;
@@ -57,6 +58,9 @@ internal sealed class GatewayAppRuntime
     public NativeDynamicPluginHost? NativeDynamicPluginHost { get; init; }
     public FirstPartyWhatsAppWorkerHost? WhatsAppWorkerHost { get; init; }
     public required ChannelAuthEventStore ChannelAuthEvents { get; init; }
+
+    /// <summary>Runtime that validates emit_artifact calls against skill artifact contracts.</summary>
+    public required SkillArtifactRuntime ArtifactRuntime { get; init; }
 
     /// <summary>Names of all registered tools (built-in + native plugins + bridge plugins).</summary>
     public required FrozenSet<string> RegisteredToolNames { get; init; }

--- a/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.CompositionStages.cs
+++ b/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.CompositionStages.cs
@@ -65,6 +65,7 @@ internal static partial class RuntimeInitializationExtensions
             ToolSandbox = app.Services.GetService<IToolSandbox>(),
             Pipeline = app.Services.GetRequiredService<MessagePipeline>(),
             WebSocketChannel = app.Services.GetRequiredService<WebSocketChannel>(),
+            MediaCache = app.Services.GetRequiredService<MediaCacheStore>(),
             CanvasBroker = app.Services.GetRequiredService<CanvasCommandBroker>(),
             NativeRegistry = app.Services.GetRequiredService<NativePluginRegistry>(),
             McpRegistry = app.Services.GetRequiredService<McpServerToolRegistry>(),
@@ -584,6 +585,7 @@ internal static partial class RuntimeInitializationExtensions
         public IToolSandbox? ToolSandbox { get; init; }
         public required MessagePipeline Pipeline { get; init; }
         public required WebSocketChannel WebSocketChannel { get; init; }
+        public required MediaCacheStore MediaCache { get; init; }
         public required CanvasCommandBroker CanvasBroker { get; init; }
         public required NativePluginRegistry NativeRegistry { get; init; }
         public required McpServerToolRegistry McpRegistry { get; init; }

--- a/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.RuntimeFactories.cs
+++ b/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.RuntimeFactories.cs
@@ -37,7 +37,8 @@ internal static partial class RuntimeInitializationExtensions
         string orchestratorId,
         IReadOnlyList<ITool> tools,
         IReadOnlyList<SkillDefinition> skills,
-        CronScheduler? cronScheduler)
+        CronScheduler? cronScheduler,
+        SkillArtifactRuntime artifactRuntime)
     {
         var operations = new RuntimeOperationsState
         {
@@ -98,6 +99,7 @@ internal static partial class RuntimeInitializationExtensions
             NativeDynamicPluginHost = pluginComposition.NativeDynamicPluginHost,
             WhatsAppWorkerHost = channelComposition.WhatsAppWorkerHost,
             RegisteredToolNames = tools.Select(t => t.Name).ToFrozenSet(StringComparer.Ordinal),
+            ArtifactRuntime = artifactRuntime,
             ChannelAuthEvents = WireChannelAuthEvents(channelComposition.ChannelAdapters)
         };
     }
@@ -106,7 +108,8 @@ internal static partial class RuntimeInitializationExtensions
         GatewayConfig config,
         RuntimeServices services,
         string? workspacePath,
-        GatewayRuntimeState runtimeState)
+        GatewayRuntimeState runtimeState,
+        SkillArtifactRuntime artifactRuntime)
     {
         var projectId = config.Memory.ProjectId
             ?? Environment.GetEnvironmentVariable("OPENCLAW_PROJECT")
@@ -205,6 +208,9 @@ internal static partial class RuntimeInitializationExtensions
 
         if (string.Equals(Environment.GetEnvironmentVariable("OPENCLAW_ENABLE_STREAMING_SMOKE_TOOL"), "1", StringComparison.Ordinal))
             tools.Add(new StreamingSmokeEchoTool());
+
+        if (config.Tooling.EnableEmitArtifact)
+            tools.Add(new EmitArtifactTool(services.MediaCache, services.WebSocketChannel, config, artifactRuntime));
 
         return tools;
     }

--- a/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs
+++ b/src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs
@@ -70,11 +70,14 @@ internal static partial class RuntimeInitializationExtensions
         var blockedPluginIds = services.PluginHealth.GetBlockedPluginIds();
         var channelComposition = await BuildChannelCompositionAsync(app, startup, services, loggerFactory);
 
+        var artifactRuntime = new SkillArtifactRuntime();
+
         var builtInTools = CreateBuiltInTools(
             config,
             services,
             startup.WorkspacePath,
-            startup.RuntimeState);
+            startup.RuntimeState,
+            artifactRuntime);
         if (config.Plugins.Mcp.Enabled)
             await services.McpRegistry.RegisterToolsAsync(services.NativeRegistry, app.Lifetime.ApplicationStopping);
         await using var mcpAppStartupCleanup = new AsyncStartupCleanupGuard();
@@ -135,6 +138,7 @@ internal static partial class RuntimeInitializationExtensions
         var skills = SkillLoader.LoadAll(config.Skills, startup.WorkspacePath, skillLogger, combinedPluginSkillRoots);
         if (skills.Count > 0)
             skillLogger.LogInformation("{Summary}", SkillPromptBuilder.BuildSummary(skills));
+        artifactRuntime.ReplaceSkills(skills);
         IAgentRuntime? runtimeForLoadSkill = null;
         Func<IReadOnlyList<SkillDefinition>> skillsProvider = () => runtimeForLoadSkill?.LoadedSkills ?? skills;
         tools =
@@ -200,7 +204,8 @@ internal static partial class RuntimeInitializationExtensions
             startup.WorkspacePath,
             combinedPluginSkillRoots,
             agentRuntime,
-            app.Services.GetRequiredService<ILogger<SkillWatcherService>>());
+            app.Services.GetRequiredService<ILogger<SkillWatcherService>>(),
+            skills => artifactRuntime.ReplaceSkills(skills));
         skillWatcher.Start(app.Lifetime.ApplicationStopping);
 
         await services.AutomationService.RefreshCacheAsync(app.Lifetime.ApplicationStopping);
@@ -225,7 +230,8 @@ internal static partial class RuntimeInitializationExtensions
             orchestratorId,
             tools,
             skills,
-            cronScheduler);
+            cronScheduler,
+            artifactRuntime);
         shutdownCoordinator.AttachRuntime(startup, runtime);
 
         services.PluginHealth.SetRuntimeReports(

--- a/src/OpenClaw.Gateway/SkillWatcherService.cs
+++ b/src/OpenClaw.Gateway/SkillWatcherService.cs
@@ -75,6 +75,23 @@ internal sealed class SkillWatcherService : IAsyncDisposable, IDisposable
                 watcher.Deleted += OnWatcherChanged;
                 watcher.Renamed += OnWatcherRenamed;
                 _watchers.Add(watcher);
+
+                // Also watch contract files (artifacts.json, projection indexes, etc.)
+                var jsonWatcher = new FileSystemWatcher(root, "*.json")
+                {
+                    IncludeSubdirectories = true,
+                    NotifyFilter = NotifyFilters.CreationTime |
+                                   NotifyFilters.FileName |
+                                   NotifyFilters.LastWrite |
+                                   NotifyFilters.Size,
+                    EnableRaisingEvents = true
+                };
+
+                jsonWatcher.Changed += OnWatcherChanged;
+                jsonWatcher.Created += OnWatcherChanged;
+                jsonWatcher.Deleted += OnWatcherChanged;
+                jsonWatcher.Renamed += OnWatcherRenamed;
+                _watchers.Add(jsonWatcher);
             }
             catch (Exception ex)
             {
@@ -88,7 +105,7 @@ internal sealed class SkillWatcherService : IAsyncDisposable, IDisposable
             return;
         }
 
-        _logger.LogInformation("Watching {Count} skill directories for SKILL.md changes.", _watchers.Count);
+        _logger.LogInformation("Watching {Count} skill watchers for SKILL.md and contract JSON changes.", _watchers.Count);
     }
 
     public void Dispose()

--- a/src/OpenClaw.Gateway/SkillWatcherService.cs
+++ b/src/OpenClaw.Gateway/SkillWatcherService.cs
@@ -8,6 +8,7 @@ internal sealed class SkillWatcherService : IAsyncDisposable, IDisposable
 {
     private readonly IAgentRuntime _agentRuntime;
     private readonly ILogger<SkillWatcherService> _logger;
+    private readonly Action<IReadOnlyList<SkillDefinition>>? _onSkillsReloaded;
     private readonly Channel<byte> _reloadRequests = Channel.CreateUnbounded<byte>(new UnboundedChannelOptions
     {
         SingleReader = true,
@@ -27,10 +28,12 @@ internal sealed class SkillWatcherService : IAsyncDisposable, IDisposable
         string? workspacePath,
         IReadOnlyList<string>? pluginSkillDirs,
         IAgentRuntime agentRuntime,
-        ILogger<SkillWatcherService> logger)
+        ILogger<SkillWatcherService> logger,
+        Action<IReadOnlyList<SkillDefinition>>? onSkillsReloaded = null)
     {
         _agentRuntime = agentRuntime;
         _logger = logger;
+        _onSkillsReloaded = onSkillsReloaded;
         _watchRoots = GetWatchRoots(config, workspacePath, pluginSkillDirs)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
@@ -243,6 +246,11 @@ internal sealed class SkillWatcherService : IAsyncDisposable, IDisposable
         {
             var loadedSkillNames = await _agentRuntime.ReloadSkillsAsync(_stoppingToken);
             _logger.LogInformation("Reloaded {Count} skills after file change.", loadedSkillNames.Count);
+            if (_onSkillsReloaded is not null)
+            {
+                var skills = _agentRuntime.LoadedSkills;
+                _onSkillsReloaded(skills);
+            }
         }
         catch (OperationCanceledException) when (_stoppingToken.IsCancellationRequested)
         {

--- a/src/OpenClaw.Gateway/SkillWatcherService.cs
+++ b/src/OpenClaw.Gateway/SkillWatcherService.cs
@@ -193,11 +193,32 @@ internal sealed class SkillWatcherService : IAsyncDisposable, IDisposable
             yield return Path.Combine(workspacePath, "skills");
     }
 
-    private void OnWatcherChanged(object sender, FileSystemEventArgs e) => ScheduleReload();
+    private void OnWatcherChanged(object sender, FileSystemEventArgs e)
+    {
+        if (ShouldReloadForPath(e.FullPath))
+            ScheduleReload();
+    }
 
-    private void OnWatcherRenamed(object sender, RenamedEventArgs e) => ScheduleReload();
+    private void OnWatcherRenamed(object sender, RenamedEventArgs e)
+    {
+        if (ShouldReloadForPath(e.FullPath) || ShouldReloadForPath(e.OldFullPath))
+            ScheduleReload();
+    }
 
     internal void NotifySkillChanged() => ScheduleReload();
+
+    private static bool ShouldReloadForPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        if (string.Equals(Path.GetFileName(path), "SKILL.md", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        var normalizedPath = path.Replace('\\', '/');
+        return normalizedPath.Contains("/contracts/", StringComparison.OrdinalIgnoreCase) &&
+               normalizedPath.EndsWith(".json", StringComparison.OrdinalIgnoreCase);
+    }
 
     private void ScheduleReload()
     {

--- a/src/OpenClaw.Gateway/Tools/EmitArtifactTool.cs
+++ b/src/OpenClaw.Gateway/Tools/EmitArtifactTool.cs
@@ -1,0 +1,329 @@
+using System.Text.Json;
+using OpenClaw.Channels;
+using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Models;
+using OpenClaw.Agent.Tools;
+using OpenClaw.Core.Security;
+
+namespace OpenClaw.Gateway.Tools;
+
+/// <summary>
+/// Unified artifact emitter. Handles two cases selected by the <c>kind</c> parameter:
+///
+/// <list type="bullet">
+///   <item><term>kind = "file"</term>
+///     <description>Read a file from the filesystem, store it in the media cache, and push
+///     a WebSocket <c>artifact</c> envelope so the client receives it immediately (mid-turn)
+///     as a named downloadable attachment.</description></item>
+///   <item><term>kind = "data"</term>
+///     <description>Emit a structured JSON payload (stage checkpoint, analysis result, progress
+///     update, etc.) as a WebSocket <c>artifact</c> envelope with a display hint so the frontend
+///     can render it using the appropriate generic component (table, tree, code, badge, …).</description></item>
+/// </list>
+///
+/// Both kinds carry the same <see cref="SkillArtifact"/> structure so the client can handle
+/// all artifacts through a single unified path.
+/// </summary>
+internal sealed class EmitArtifactTool : IToolWithContext
+{
+    private readonly MediaCacheStore _mediaCache;
+    private readonly WebSocketChannel _wsChannel;
+    private readonly GatewayConfig _config;
+    private readonly SkillArtifactRuntime _artifactRuntime;
+
+    public EmitArtifactTool(MediaCacheStore mediaCache, WebSocketChannel wsChannel, GatewayConfig config, SkillArtifactRuntime artifactRuntime)
+    {
+        _mediaCache = mediaCache;
+        _wsChannel = wsChannel;
+        _config = config;
+        _artifactRuntime = artifactRuntime;
+    }
+
+    public string Name => "emit_artifact";
+
+    public string Description =>
+        "Emit a typed artifact to the user immediately (mid-turn). " +
+        "Use kind=\"file\" to publish a file (template package, skill bundle, export) as a downloadable attachment. " +
+        "Use kind=\"data\" to push a structured JSON payload (analysis result, plan, progress, stage checkpoint) " +
+        "that the frontend renders using a generic display component (table, tree, code block, badge, etc.). " +
+        "Both kinds are delivered instantly via WebSocket without waiting for the turn to complete.";
+
+    public string ParameterSchema => """
+    {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["file", "data"],
+          "default": "file",
+          "description": "Artifact kind. 'file': publish a filesystem file as a downloadable attachment. 'data': push a structured JSON payload as a stage checkpoint or inline display."
+        },
+        "artifact_type": {
+          "type": "string",
+          "description": "Semantic type. Well-known: template_package | skill_package | ontology | analysis | plan | progress | generic. Defaults to 'template_package' for file, 'generic' for data."
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable title shown in the UI"
+        },
+        "skill_name": {
+          "type": "string",
+          "description": "Name of the skill emitting this artifact (optional)"
+        },
+        "stage": {
+          "type": "string",
+          "description": "Stage identifier in a multi-stage workflow (optional)"
+        },
+        "terminal": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, marks the current stage as complete"
+        },
+        "path": {
+          "type": "string",
+          "description": "(kind=file) Absolute path of the file to publish — must already exist on the filesystem"
+        },
+        "display_name": {
+          "type": "string",
+          "description": "(kind=file) Override the filename shown to the user (defaults to the file's basename)"
+        },
+        "data": {
+          "description": "(kind=data) Structured JSON payload — any object or array"
+        },
+        "display_hint": {
+          "type": "string",
+          "enum": ["tree", "table", "code", "badge", "progress", "text"],
+          "description": "(kind=data) Rendering hint for the frontend component"
+        }
+      }
+    }
+    """;
+
+    public ValueTask<string> ExecuteAsync(string argumentsJson, CancellationToken ct)
+        => ValueTask.FromResult("Error: emit_artifact requires an execution context (session info).");
+
+    public async ValueTask<string> ExecuteAsync(string argumentsJson, ToolExecutionContext context, CancellationToken ct)
+    {
+        using var doc = JsonDocument.Parse(string.IsNullOrWhiteSpace(argumentsJson) ? "{}" : argumentsJson);
+        var root = doc.RootElement;
+
+        var kind = root.TryGetProperty("kind", out var kindEl) ? (kindEl.GetString() ?? "file") : "file";
+        var label = root.TryGetProperty("label", out var labelEl) ? labelEl.GetString() : null;
+        var skillName = root.TryGetProperty("skill_name", out var snEl) ? snEl.GetString() : null;
+        var stage = root.TryGetProperty("stage", out var stageEl) ? stageEl.GetString() : null;
+        var isTerminal = root.TryGetProperty("terminal", out var termEl) && termEl.ValueKind == JsonValueKind.True;
+
+        return kind == "data"
+            ? await ExecuteDataAsync(root, label, skillName, stage, isTerminal, context, ct)
+            : await ExecuteFileAsync(root, label, skillName, stage, isTerminal, context, ct);
+    }
+
+    // ── kind = "file" ────────────────────────────────────────────────────────
+
+    private async ValueTask<string> ExecuteFileAsync(
+        JsonElement root, string? label, string? skillName, string? stage, bool isTerminal,
+        ToolExecutionContext context, CancellationToken ct)
+    {
+        var path = root.TryGetProperty("path", out var pathEl) ? pathEl.GetString() : null;
+        if (string.IsNullOrWhiteSpace(path))
+            return "Error: 'path' is required for kind=\"file\".";
+
+        var artifactType = root.TryGetProperty("artifact_type", out var typeEl)
+            ? (typeEl.GetString() ?? "template_package")
+            : "template_package";
+
+        var displayName = root.TryGetProperty("display_name", out var nameEl)
+            ? nameEl.GetString()
+            : null;
+
+        var resolvedPath = ToolPathPolicy.ResolveRealPath(path);
+        if (!ToolPathPolicy.IsReadAllowed(_config.Tooling, resolvedPath))
+            return $"Error: Read access denied for path: {path}";
+        if (!File.Exists(resolvedPath))
+            return $"Error: File not found: {path}";
+
+        var publishPath = ToolPathPolicy.IsWriteAllowed(_config.Tooling, resolvedPath)
+            ? resolvedPath
+            : await CopyToDownloadsFolderAsync(resolvedPath, ct);
+        if (publishPath is null)
+            return "Error: Could not copy artifact to a publishable location. Ensure WorkspaceRoot or an AllowedWriteRoot is configured.";
+
+        byte[] bytes;
+        try { bytes = await File.ReadAllBytesAsync(publishPath, ct); }
+        catch (Exception ex) { return $"Error: Could not read file: {ex.Message}"; }
+
+        var fileName = !string.IsNullOrWhiteSpace(displayName) ? displayName : Path.GetFileName(publishPath);
+        var mimeType = GuessMimeType(Path.GetExtension(publishPath));
+
+        StoredMediaAsset asset;
+        try { asset = await _mediaCache.SaveAsync(bytes.AsMemory(), mimeType, fileName, ct); }
+        catch (Exception ex) { return $"Error: Could not save artifact to media store: {ex.Message}"; }
+
+        var fileUrl = $"/media/{asset.Id}";
+        var effectiveLabel = !string.IsNullOrWhiteSpace(label) ? label : fileName;
+
+        if (string.Equals(context.Session.ChannelId, "websocket", StringComparison.Ordinal) &&
+            _wsChannel.IsClientUsingEnvelopes(context.Session.SenderId))
+        {
+            var result = _artifactRuntime.NormalizeAndRecord(context.Session.Id, new SkillArtifact
+            {
+                Kind = "file",
+                ArtifactType = artifactType,
+                Label = effectiveLabel,
+                SkillName = skillName,
+                Stage = stage,
+                IsTerminal = isTerminal,
+                FileUrl = fileUrl,
+                FileName = fileName,
+                MimeType = mimeType,
+                FileSizeBytes = asset.SizeBytes,
+            });
+            if (!result.Succeeded || result.Artifact is null)
+                return $"Error: {result.Error}";
+
+            await _wsChannel.SendEnvelopeAsync(context.Session.SenderId, new WsServerEnvelope
+            {
+                Type = "artifact",
+                Text = effectiveLabel,
+                Artifact = result.Artifact,
+            }, ct);
+
+            if (result.StageGate is not null)
+            {
+                await _wsChannel.SendEnvelopeAsync(context.Session.SenderId, new WsServerEnvelope
+                {
+                    Type = "skill_stage_gate",
+                    Text = result.StageGate.CanProceed ? result.StageGate.NextStage : result.StageGate.BlockedReason,
+                    StageGate = result.StageGate,
+                }, ct);
+            }
+        }
+
+        var sizeLabel = FormatSize(asset.SizeBytes);
+        return $"Artifact published: {fileName} ({sizeLabel}) [kind=file type={artifactType}]\n[FILE_URL:{fileUrl}]";
+    }
+
+    // ── kind = "data" ────────────────────────────────────────────────────────
+
+    private async ValueTask<string> ExecuteDataAsync(
+        JsonElement root, string? label, string? skillName, string? stage, bool isTerminal,
+        ToolExecutionContext context, CancellationToken ct)
+    {
+        if (!root.TryGetProperty("data", out var dataEl))
+            return "Error: 'data' is required for kind=\"data\".";
+
+        var artifactType = root.TryGetProperty("artifact_type", out var typeEl)
+            ? (typeEl.GetString() ?? "generic")
+            : "generic";
+
+        var displayHint = root.TryGetProperty("display_hint", out var hintEl)
+            ? hintEl.GetString()
+            : null;
+
+        if (string.Equals(context.Session.ChannelId, "websocket", StringComparison.Ordinal) &&
+            _wsChannel.IsClientUsingEnvelopes(context.Session.SenderId))
+        {
+            var result = _artifactRuntime.NormalizeAndRecord(context.Session.Id, new SkillArtifact
+            {
+                Kind = "data",
+                ArtifactType = artifactType,
+                Label = label,
+                SkillName = skillName,
+                Stage = stage,
+                IsTerminal = isTerminal,
+                Data = dataEl.Clone(),
+                DisplayHint = displayHint,
+            });
+            if (!result.Succeeded || result.Artifact is null)
+                return $"Error: {result.Error}";
+
+            await _wsChannel.SendEnvelopeAsync(context.Session.SenderId, new WsServerEnvelope
+            {
+                Type = "artifact",
+                Text = result.Artifact.Label ?? result.Artifact.ArtifactType,
+                Artifact = result.Artifact,
+            }, ct);
+
+            if (result.StageGate is not null)
+            {
+                await _wsChannel.SendEnvelopeAsync(context.Session.SenderId, new WsServerEnvelope
+                {
+                    Type = "skill_stage_gate",
+                    Text = result.StageGate.CanProceed ? result.StageGate.NextStage : result.StageGate.BlockedReason,
+                    StageGate = result.StageGate,
+                }, ct);
+            }
+        }
+
+        return $"Data artifact emitted: [kind=data type={artifactType} stage={stage ?? "-"} terminal={isTerminal}]";
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<string?> CopyToDownloadsFolderAsync(string sourcePath, CancellationToken ct)
+    {
+        var downloadsDir = ResolveDownloadsDirectory();
+        if (downloadsDir is null)
+            return null;
+
+        try
+        {
+            Directory.CreateDirectory(downloadsDir);
+
+            var fileName = Path.GetFileName(sourcePath);
+            var destPath = Path.Combine(downloadsDir, fileName);
+
+            if (File.Exists(destPath) &&
+                !string.Equals(Path.GetFullPath(sourcePath), Path.GetFullPath(destPath), StringComparison.OrdinalIgnoreCase))
+            {
+                var stem = Path.GetFileNameWithoutExtension(fileName);
+                var ext = Path.GetExtension(fileName);
+                destPath = Path.Combine(downloadsDir, $"{stem}_{Guid.NewGuid().ToString("N")[..8]}{ext}");
+            }
+
+            await using var src = File.OpenRead(sourcePath);
+            await using var dest = File.Create(destPath);
+            await src.CopyToAsync(dest, ct);
+
+            return destPath;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private string? ResolveDownloadsDirectory()
+    {
+        var workspaceRaw = SecretResolver.Resolve(_config.Tooling.WorkspaceRoot);
+        var workspaceBase = !string.IsNullOrWhiteSpace(workspaceRaw)
+            ? workspaceRaw
+            : Directory.GetCurrentDirectory();
+
+        var downloadsDir = Path.Combine(Path.GetFullPath(workspaceBase), ".downloads");
+        return ToolPathPolicy.IsWriteAllowed(_config.Tooling, downloadsDir) ? downloadsDir : null;
+    }
+
+    private static string FormatSize(long bytes) => bytes switch
+    {
+        < 1024 => $"{bytes} B",
+        < 1_048_576 => $"{bytes / 1024.0:F1} KB",
+        _ => $"{bytes / 1_048_576.0:F1} MB"
+    };
+
+    private static string GuessMimeType(string extension) =>
+        extension.ToLowerInvariant() switch
+        {
+            ".zip" => "application/zip",
+            ".tar" => "application/x-tar",
+            ".gz" or ".tgz" => "application/gzip",
+            ".json" => "application/json",
+            ".md" => "text/markdown",
+            ".pdf" => "application/pdf",
+            ".png" => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".svg" => "image/svg+xml",
+            ".txt" => "text/plain",
+            _ => "application/octet-stream"
+        };
+}

--- a/src/OpenClaw.Gateway/Tools/EmitArtifactTool.cs
+++ b/src/OpenClaw.Gateway/Tools/EmitArtifactTool.cs
@@ -148,6 +148,11 @@ internal sealed class EmitArtifactTool : IToolWithContext
         if (publishPath is null)
             return "Error: Could not copy artifact to a publishable location. Ensure WorkspaceRoot or an AllowedWriteRoot is configured.";
 
+        var fileInfo = new FileInfo(publishPath);
+        const long maxArtifactBytes = 100 * 1024 * 1024; // 100 MB
+        if (fileInfo.Length > maxArtifactBytes)
+            return $"Error: File exceeds maximum artifact size of {maxArtifactBytes / (1024 * 1024)} MB ({fileInfo.Length} bytes).";
+
         byte[] bytes;
         try { bytes = await File.ReadAllBytesAsync(publishPath, ct); }
         catch (Exception ex) { return $"Error: Could not read file: {ex.Message}"; }
@@ -162,39 +167,40 @@ internal sealed class EmitArtifactTool : IToolWithContext
         var fileUrl = $"/media/{asset.Id}";
         var effectiveLabel = !string.IsNullOrWhiteSpace(label) ? label : fileName;
 
+        // Always validate against the artifact contract, regardless of client type.
+        var fileResult = _artifactRuntime.NormalizeAndRecord(context.Session.Id, new SkillArtifact
+        {
+            Kind = "file",
+            ArtifactType = artifactType,
+            Label = effectiveLabel,
+            SkillName = skillName,
+            Stage = stage,
+            IsTerminal = isTerminal,
+            FileUrl = fileUrl,
+            FileName = fileName,
+            MimeType = mimeType,
+            FileSizeBytes = asset.SizeBytes,
+        });
+        if (!fileResult.Succeeded || fileResult.Artifact is null)
+            return $"Error: {fileResult.Error}";
+
         if (string.Equals(context.Session.ChannelId, "websocket", StringComparison.Ordinal) &&
             _wsChannel.IsClientUsingEnvelopes(context.Session.SenderId))
         {
-            var result = _artifactRuntime.NormalizeAndRecord(context.Session.Id, new SkillArtifact
-            {
-                Kind = "file",
-                ArtifactType = artifactType,
-                Label = effectiveLabel,
-                SkillName = skillName,
-                Stage = stage,
-                IsTerminal = isTerminal,
-                FileUrl = fileUrl,
-                FileName = fileName,
-                MimeType = mimeType,
-                FileSizeBytes = asset.SizeBytes,
-            });
-            if (!result.Succeeded || result.Artifact is null)
-                return $"Error: {result.Error}";
-
             await _wsChannel.SendEnvelopeAsync(context.Session.SenderId, new WsServerEnvelope
             {
                 Type = "artifact",
-                Text = effectiveLabel,
-                Artifact = result.Artifact,
+                Text = fileResult.Artifact.Label ?? fileResult.Artifact.ArtifactType,
+                Artifact = fileResult.Artifact,
             }, ct);
 
-            if (result.StageGate is not null)
+            if (fileResult.StageGate is not null)
             {
                 await _wsChannel.SendEnvelopeAsync(context.Session.SenderId, new WsServerEnvelope
                 {
                     Type = "skill_stage_gate",
-                    Text = result.StageGate.CanProceed ? result.StageGate.NextStage : result.StageGate.BlockedReason,
-                    StageGate = result.StageGate,
+                    Text = fileResult.StageGate.CanProceed ? fileResult.StageGate.NextStage : fileResult.StageGate.BlockedReason,
+                    StageGate = fileResult.StageGate,
                 }, ct);
             }
         }
@@ -220,37 +226,38 @@ internal sealed class EmitArtifactTool : IToolWithContext
             ? hintEl.GetString()
             : null;
 
+        // Always validate against the artifact contract, regardless of client type.
+        var dataResult = _artifactRuntime.NormalizeAndRecord(context.Session.Id, new SkillArtifact
+        {
+            Kind = "data",
+            ArtifactType = artifactType,
+            Label = label,
+            SkillName = skillName,
+            Stage = stage,
+            IsTerminal = isTerminal,
+            Data = dataEl.Clone(),
+            DisplayHint = displayHint,
+        });
+        if (!dataResult.Succeeded || dataResult.Artifact is null)
+            return $"Error: {dataResult.Error}";
+
         if (string.Equals(context.Session.ChannelId, "websocket", StringComparison.Ordinal) &&
             _wsChannel.IsClientUsingEnvelopes(context.Session.SenderId))
         {
-            var result = _artifactRuntime.NormalizeAndRecord(context.Session.Id, new SkillArtifact
-            {
-                Kind = "data",
-                ArtifactType = artifactType,
-                Label = label,
-                SkillName = skillName,
-                Stage = stage,
-                IsTerminal = isTerminal,
-                Data = dataEl.Clone(),
-                DisplayHint = displayHint,
-            });
-            if (!result.Succeeded || result.Artifact is null)
-                return $"Error: {result.Error}";
-
             await _wsChannel.SendEnvelopeAsync(context.Session.SenderId, new WsServerEnvelope
             {
                 Type = "artifact",
-                Text = result.Artifact.Label ?? result.Artifact.ArtifactType,
-                Artifact = result.Artifact,
+                Text = dataResult.Artifact.Label ?? dataResult.Artifact.ArtifactType,
+                Artifact = dataResult.Artifact,
             }, ct);
 
-            if (result.StageGate is not null)
+            if (dataResult.StageGate is not null)
             {
                 await _wsChannel.SendEnvelopeAsync(context.Session.SenderId, new WsServerEnvelope
                 {
                     Type = "skill_stage_gate",
-                    Text = result.StageGate.CanProceed ? result.StageGate.NextStage : result.StageGate.BlockedReason,
-                    StageGate = result.StageGate,
+                    Text = dataResult.StageGate.CanProceed ? dataResult.StageGate.NextStage : dataResult.StageGate.BlockedReason,
+                    StageGate = dataResult.StageGate,
                 }, ct);
             }
         }

--- a/src/OpenClaw.Gateway/Tools/EmitArtifactTool.cs
+++ b/src/OpenClaw.Gateway/Tools/EmitArtifactTool.cs
@@ -26,6 +26,8 @@ namespace OpenClaw.Gateway.Tools;
 /// </summary>
 internal sealed class EmitArtifactTool : IToolWithContext
 {
+    private const long MaxArtifactFileBytes = 64L * 1024 * 1024;
+
     private readonly MediaCacheStore _mediaCache;
     private readonly WebSocketChannel _wsChannel;
     private readonly GatewayConfig _config;
@@ -149,9 +151,8 @@ internal sealed class EmitArtifactTool : IToolWithContext
             return "Error: Could not copy artifact to a publishable location. Ensure WorkspaceRoot or an AllowedWriteRoot is configured.";
 
         var fileInfo = new FileInfo(publishPath);
-        const long maxArtifactBytes = 100 * 1024 * 1024; // 100 MB
-        if (fileInfo.Length > maxArtifactBytes)
-            return $"Error: File exceeds maximum artifact size of {maxArtifactBytes / (1024 * 1024)} MB ({fileInfo.Length} bytes).";
+        if (fileInfo.Length > MaxArtifactFileBytes)
+            return $"Error: Artifact file is too large ({FormatSize(fileInfo.Length)}). Maximum allowed size is {FormatSize(MaxArtifactFileBytes)}.";
 
         byte[] bytes;
         try { bytes = await File.ReadAllBytesAsync(publishPath, ct); }
@@ -167,7 +168,6 @@ internal sealed class EmitArtifactTool : IToolWithContext
         var fileUrl = $"/media/{asset.Id}";
         var effectiveLabel = !string.IsNullOrWhiteSpace(label) ? label : fileName;
 
-        // Always validate against the artifact contract, regardless of client type.
         var fileResult = _artifactRuntime.NormalizeAndRecord(context.Session.Id, new SkillArtifact
         {
             Kind = "file",
@@ -206,7 +206,7 @@ internal sealed class EmitArtifactTool : IToolWithContext
         }
 
         var sizeLabel = FormatSize(asset.SizeBytes);
-        return $"Artifact published: {fileName} ({sizeLabel}) [kind=file type={artifactType}]\n[FILE_URL:{fileUrl}]";
+        return $"Artifact published: {fileName} ({sizeLabel}) [kind=file type={fileResult.Artifact.ArtifactType}]\n[FILE_URL:{fileUrl}]";
     }
 
     // ── kind = "data" ────────────────────────────────────────────────────────
@@ -226,7 +226,6 @@ internal sealed class EmitArtifactTool : IToolWithContext
             ? hintEl.GetString()
             : null;
 
-        // Always validate against the artifact contract, regardless of client type.
         var dataResult = _artifactRuntime.NormalizeAndRecord(context.Session.Id, new SkillArtifact
         {
             Kind = "data",
@@ -262,7 +261,7 @@ internal sealed class EmitArtifactTool : IToolWithContext
             }
         }
 
-        return $"Data artifact emitted: [kind=data type={artifactType} stage={stage ?? "-"} terminal={isTerminal}]";
+        return $"Data artifact emitted: [kind=data type={dataResult.Artifact.ArtifactType} stage={dataResult.Artifact.Stage ?? "-"} terminal={dataResult.Artifact.IsTerminal}]";
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/src/OpenClaw.Gateway/Tools/SkillArtifactRuntime.cs
+++ b/src/OpenClaw.Gateway/Tools/SkillArtifactRuntime.cs
@@ -1,0 +1,166 @@
+using System.Collections.Concurrent;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Skills;
+
+namespace OpenClaw.Gateway.Tools;
+
+internal sealed class SkillArtifactRuntime
+{
+    private readonly ConcurrentDictionary<string, SkillDefinition> _skills = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, StageState> _stageStates = new(StringComparer.OrdinalIgnoreCase);
+
+    public void ReplaceSkills(IEnumerable<SkillDefinition> skills)
+    {
+        _skills.Clear();
+        foreach (var skill in skills)
+            _skills[skill.Name] = skill;
+    }
+
+    public SkillArtifactResult NormalizeAndRecord(string sessionId, SkillArtifact artifact)
+    {
+        if (string.IsNullOrWhiteSpace(artifact.SkillName))
+            return SkillArtifactResult.Success(artifact, null);
+
+        if (!_skills.TryGetValue(artifact.SkillName, out var skill))
+            return SkillArtifactResult.Failure($"Unknown skill '{artifact.SkillName}'.");
+
+        var contract = skill.ArtifactContract;
+        if (contract is null || contract.Stages.Count == 0)
+            return SkillArtifactResult.Success(artifact, null);
+
+        if (!TryResolveArtifactContract(contract, artifact, out var stage, out var artifactType, out var error))
+            return SkillArtifactResult.Failure(error ?? "Artifact does not match the skill contract.");
+
+        var normalized = artifact with
+        {
+            SkillName = skill.Name,
+            Stage = stage.Name,
+            ArtifactType = artifactType.Type,
+            Label = artifact.Label ?? artifactType.Label,
+            DisplayHint = artifact.DisplayHint ?? artifactType.Display,
+            IsTerminal = artifactType.Terminal ?? artifact.IsTerminal
+        };
+
+        SkillStageGateEvent? gate = null;
+        if (normalized.IsTerminal)
+        {
+            MarkStageTerminal(sessionId, skill.Name, stage.Name);
+            gate = BuildGateEvent(sessionId, skill.Name, contract, stage.Name);
+        }
+
+        return SkillArtifactResult.Success(normalized, gate);
+    }
+
+    private static bool TryResolveArtifactContract(
+        SkillArtifactContract contract,
+        SkillArtifact artifact,
+        out SkillArtifactStageContract stage,
+        out SkillArtifactTypeContract artifactType,
+        out string? error)
+    {
+        stage = null!;
+        artifactType = null!;
+        error = null;
+
+        if (!string.IsNullOrWhiteSpace(artifact.Stage))
+        {
+            stage = contract.Stages.FirstOrDefault(s => string.Equals(s.Name, artifact.Stage, StringComparison.OrdinalIgnoreCase))!;
+            if (stage is null)
+            {
+                error = $"Stage '{artifact.Stage}' is not declared in contracts/artifacts.json.";
+                return false;
+            }
+
+            artifactType = stage.Artifacts.FirstOrDefault(a => string.Equals(a.Type, artifact.ArtifactType, StringComparison.OrdinalIgnoreCase))!;
+            if (artifactType is null)
+            {
+                error = $"Artifact type '{artifact.ArtifactType}' is not declared for stage '{stage.Name}'.";
+                return false;
+            }
+
+            return true;
+        }
+
+        var matches = contract.Stages
+            .SelectMany(s => s.Artifacts.Select(a => (Stage: s, Artifact: a)))
+            .Where(x => string.Equals(x.Artifact.Type, artifact.ArtifactType, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (matches.Count == 1)
+        {
+            stage = matches[0].Stage;
+            artifactType = matches[0].Artifact;
+            return true;
+        }
+
+        error = matches.Count == 0
+            ? $"Artifact type '{artifact.ArtifactType}' is not declared in contracts/artifacts.json."
+            : $"Artifact type '{artifact.ArtifactType}' appears in multiple stages; pass the stage explicitly.";
+        return false;
+    }
+
+    private void MarkStageTerminal(string sessionId, string skillName, string stageName)
+    {
+        var key = StageKey(sessionId, skillName, stageName);
+        _stageStates.AddOrUpdate(
+            key,
+            static _ => new StageState(true, DateTimeOffset.UtcNow),
+            static (_, existing) => existing with { IsTerminal = true, UpdatedAtUtc = DateTimeOffset.UtcNow });
+    }
+
+    private SkillStageGateEvent? BuildGateEvent(string sessionId, string skillName, SkillArtifactContract contract, string completedStage)
+    {
+        var currentIndex = -1;
+        for (var i = 0; i < contract.Stages.Count; i++)
+        {
+            if (string.Equals(contract.Stages[i].Name, completedStage, StringComparison.OrdinalIgnoreCase))
+            {
+                currentIndex = i;
+                break;
+            }
+        }
+
+        if (currentIndex < 0 || currentIndex >= contract.Stages.Count - 1)
+            return null;
+
+        var nextStage = contract.Stages[currentIndex + 1];
+        if (!string.IsNullOrWhiteSpace(nextStage.Gate?.RequiresStage))
+        {
+            var requiredStage = nextStage.Gate.RequiresStage;
+            var satisfied = _stageStates.TryGetValue(StageKey(sessionId, skillName, requiredStage), out var state)
+                && state.IsTerminal;
+            return new SkillStageGateEvent
+            {
+                SkillName = skillName,
+                CompletedStage = completedStage,
+                NextStage = nextStage.Name,
+                CanProceed = satisfied,
+                BlockedReason = satisfied ? null : $"Stage '{requiredStage}' is not complete."
+            };
+        }
+
+        return new SkillStageGateEvent
+        {
+            SkillName = skillName,
+            CompletedStage = completedStage,
+            NextStage = nextStage.Name,
+            CanProceed = true
+        };
+    }
+
+    private static string StageKey(string sessionId, string skillName, string stageName)
+        => $"{sessionId}:{skillName}:{stageName}";
+
+    private sealed record StageState(bool IsTerminal, DateTimeOffset UpdatedAtUtc);
+}
+
+internal sealed record SkillArtifactResult(SkillArtifact? Artifact, SkillStageGateEvent? StageGate, string? Error)
+{
+    public bool Succeeded => Error is null;
+
+    public static SkillArtifactResult Success(SkillArtifact artifact, SkillStageGateEvent? stageGate)
+        => new(artifact, stageGate, null);
+
+    public static SkillArtifactResult Failure(string error)
+        => new(null, null, error);
+}

--- a/src/OpenClaw.Gateway/Tools/SkillArtifactRuntime.cs
+++ b/src/OpenClaw.Gateway/Tools/SkillArtifactRuntime.cs
@@ -7,23 +7,33 @@ namespace OpenClaw.Gateway.Tools;
 
 internal sealed class SkillArtifactRuntime
 {
-    private ConcurrentDictionary<string, SkillDefinition> _skills = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly TimeSpan StageStateTtl = TimeSpan.FromHours(12);
+
+    private IReadOnlyDictionary<string, SkillDefinition> _skills = new Dictionary<string, SkillDefinition>(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, StageState> _stageStates = new(StringComparer.OrdinalIgnoreCase);
 
     public void ReplaceSkills(IEnumerable<SkillDefinition> skills)
     {
-        var next = new ConcurrentDictionary<string, SkillDefinition>(StringComparer.OrdinalIgnoreCase);
+        var nextSkills = new Dictionary<string, SkillDefinition>(StringComparer.OrdinalIgnoreCase);
         foreach (var skill in skills)
-            next[skill.Name] = skill;
-        Interlocked.Exchange(ref _skills, next);
+        {
+            if (!string.IsNullOrWhiteSpace(skill.Name))
+                nextSkills[skill.Name] = skill;
+        }
+
+        Volatile.Write(ref _skills, nextSkills);
+        PruneStageStates();
     }
 
     public SkillArtifactResult NormalizeAndRecord(string sessionId, SkillArtifact artifact)
     {
+        PruneStageStates();
+
         if (string.IsNullOrWhiteSpace(artifact.SkillName))
             return SkillArtifactResult.Success(artifact, null);
 
-        if (!_skills.TryGetValue(artifact.SkillName, out var skill))
+        var skills = Volatile.Read(ref _skills);
+        if (!skills.TryGetValue(artifact.SkillName, out var skill))
             return SkillArtifactResult.Failure($"Unknown skill '{artifact.SkillName}'.");
 
         var contract = skill.ArtifactContract;
@@ -32,6 +42,9 @@ internal sealed class SkillArtifactRuntime
 
         if (!TryResolveArtifactContract(contract, artifact, out var stage, out var artifactType, out var error))
             return SkillArtifactResult.Failure(error ?? "Artifact does not match the skill contract.");
+
+        if (!IsStageGateSatisfied(sessionId, skill.Name, stage, out var gateError))
+            return SkillArtifactResult.Failure(gateError ?? $"Stage '{stage.Name}' is not available.");
 
         var normalized = artifact with
         {
@@ -101,6 +114,20 @@ internal sealed class SkillArtifactRuntime
         return false;
     }
 
+    private bool IsStageGateSatisfied(string sessionId, string skillName, SkillArtifactStageContract stage, out string? blockedReason)
+    {
+        blockedReason = null;
+        var requiredStage = stage.Gate?.RequiresStage;
+        if (string.IsNullOrWhiteSpace(requiredStage))
+            return true;
+
+        if (IsStageTerminal(sessionId, skillName, requiredStage))
+            return true;
+
+        blockedReason = $"Stage '{requiredStage}' is not complete.";
+        return false;
+    }
+
     private void MarkStageTerminal(string sessionId, string skillName, string stageName)
     {
         var key = StageKey(sessionId, skillName, stageName);
@@ -129,8 +156,7 @@ internal sealed class SkillArtifactRuntime
         if (!string.IsNullOrWhiteSpace(nextStage.Gate?.RequiresStage))
         {
             var requiredStage = nextStage.Gate.RequiresStage;
-            var satisfied = _stageStates.TryGetValue(StageKey(sessionId, skillName, requiredStage), out var state)
-                && state.IsTerminal;
+            var satisfied = IsStageTerminal(sessionId, skillName, requiredStage);
             return new SkillStageGateEvent
             {
                 SkillName = skillName,
@@ -150,17 +176,30 @@ internal sealed class SkillArtifactRuntime
         };
     }
 
-    /// <summary>
-    /// Remove all stage state entries for a given session.
-    /// Call when a session ends to prevent unbounded growth of _stageStates.
-    /// </summary>
     public void RemoveSession(string sessionId)
     {
+        if (string.IsNullOrWhiteSpace(sessionId))
+            return;
+
         var prefix = sessionId + ":";
         foreach (var key in _stageStates.Keys)
         {
             if (key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                 _stageStates.TryRemove(key, out _);
+        }
+    }
+
+    private bool IsStageTerminal(string sessionId, string skillName, string stageName)
+        => _stageStates.TryGetValue(StageKey(sessionId, skillName, stageName), out var state)
+           && state.IsTerminal;
+
+    private void PruneStageStates()
+    {
+        var cutoff = DateTimeOffset.UtcNow - StageStateTtl;
+        foreach (var state in _stageStates)
+        {
+            if (state.Value.UpdatedAtUtc < cutoff)
+                _stageStates.TryRemove(state.Key, out _);
         }
     }
 

--- a/src/OpenClaw.Gateway/Tools/SkillArtifactRuntime.cs
+++ b/src/OpenClaw.Gateway/Tools/SkillArtifactRuntime.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Threading;
 using OpenClaw.Core.Models;
 using OpenClaw.Core.Skills;
 
@@ -6,14 +7,15 @@ namespace OpenClaw.Gateway.Tools;
 
 internal sealed class SkillArtifactRuntime
 {
-    private readonly ConcurrentDictionary<string, SkillDefinition> _skills = new(StringComparer.OrdinalIgnoreCase);
+    private ConcurrentDictionary<string, SkillDefinition> _skills = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, StageState> _stageStates = new(StringComparer.OrdinalIgnoreCase);
 
     public void ReplaceSkills(IEnumerable<SkillDefinition> skills)
     {
-        _skills.Clear();
+        var next = new ConcurrentDictionary<string, SkillDefinition>(StringComparer.OrdinalIgnoreCase);
         foreach (var skill in skills)
-            _skills[skill.Name] = skill;
+            next[skill.Name] = skill;
+        Interlocked.Exchange(ref _skills, next);
     }
 
     public SkillArtifactResult NormalizeAndRecord(string sessionId, SkillArtifact artifact)
@@ -146,6 +148,20 @@ internal sealed class SkillArtifactRuntime
             NextStage = nextStage.Name,
             CanProceed = true
         };
+    }
+
+    /// <summary>
+    /// Remove all stage state entries for a given session.
+    /// Call when a session ends to prevent unbounded growth of _stageStates.
+    /// </summary>
+    public void RemoveSession(string sessionId)
+    {
+        var prefix = sessionId + ":";
+        foreach (var key in _stageStates.Keys)
+        {
+            if (key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                _stageStates.TryRemove(key, out _);
+        }
     }
 
     private static string StageKey(string sessionId, string skillName, string stageName)

--- a/src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs
+++ b/src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs
@@ -735,10 +735,13 @@ public sealed class MafAgentRuntime : IAgentRuntime
 
                 if (hasProjectionSkills)
                 {
-                    var effectiveSkills = ResolveSkillsForTurn(_loadedSkills, userMessage, out blockedRoutes);
+                    var effectiveSkills = ResolveSkillsForTurn(_loadedSkills, userMessage, out blockedRoutes, out var projectionPatches);
                     var skillSection = SkillPromptBuilder.BuildIndex(effectiveSkills, _skillsConfig?.InstructionPrompt);
                     var basePrompt = AgentSystemPromptBuilder.BuildBaseSystemPrompt(_requireToolApproval);
                     systemPrompt = string.IsNullOrEmpty(skillSection) ? basePrompt : basePrompt + "\n" + skillSection;
+
+                    if (!string.IsNullOrWhiteSpace(projectionPatches))
+                        systemPrompt += "\n\n[Skill Projection Patches]\n" + projectionPatches.Trim();
                 }
             }
         }
@@ -758,9 +761,17 @@ public sealed class MafAgentRuntime : IAgentRuntime
         IReadOnlyList<SkillDefinition> skills,
         string userMessage,
         out string blockedRoutes)
+        => ResolveSkillsForTurn(skills, userMessage, out blockedRoutes, out _);
+
+    internal static SkillDefinition[] ResolveSkillsForTurn(
+        IReadOnlyList<SkillDefinition> skills,
+        string userMessage,
+        out string blockedRoutes,
+        out string projectionPatches)
     {
         var resolvedSkills = new List<SkillDefinition>(skills.Count);
         var blocked = new StringBuilder();
+        var patches = new StringBuilder();
 
         foreach (var skill in skills)
         {
@@ -793,9 +804,14 @@ public sealed class MafAgentRuntime : IAgentRuntime
 
             var patchedInstructions = string.Concat(skill.Instructions.TrimEnd(), "\n\n", patch);
             resolvedSkills.Add(CloneSkill(skill, patchedInstructions, skill.DisableModelInvocation));
+
+            patches.AppendLine($"## {skill.Name}");
+            patches.AppendLine(patch);
+            patches.AppendLine();
         }
 
         blockedRoutes = blocked.ToString();
+        projectionPatches = patches.ToString();
         return [.. resolvedSkills];
     }
 

--- a/src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs
+++ b/src/OpenClaw.MicrosoftAgentFrameworkAdapter/MafAgentRuntime.cs
@@ -238,7 +238,7 @@ public sealed class MafAgentRuntime : IAgentRuntime
 
         try
         {
-            ChatClientAgent agent = CreateAgent(session);
+            ChatClientAgent agent = CreateAgent(session, userMessage);
             AgentSession mafSession = await _sessionStateStore.LoadAsync(agent, session, sidecarHistoryHash, ct);
             var toolInvocations = new List<ToolInvocation>();
 
@@ -441,7 +441,7 @@ public sealed class MafAgentRuntime : IAgentRuntime
 
         try
         {
-            ChatClientAgent agent = CreateAgent(session);
+            ChatClientAgent agent = CreateAgent(session, userMessage);
             AgentSession mafSession = await _sessionStateStore.LoadAsync(agent, session, sidecarHistoryHash, ct);
 
             session.History.Add(new ChatTurn { Role = "user", Content = userMessage });
@@ -561,12 +561,12 @@ public sealed class MafAgentRuntime : IAgentRuntime
         }
     }
 
-    private ChatClientAgent CreateAgent(Session session)
+    private ChatClientAgent CreateAgent(Session session, string? userMessage = null)
     {
         var tools = _toolExecutor.GetToolDeclarations(session)
             .Select(tool => _mafToolsByName[tool.Name])
             .ToArray();
-        return _agentFactory.Create(_chatClient, GetSystemPrompt(session), tools);
+        return _agentFactory.Create(_chatClient, GetSystemPrompt(session, userMessage), tools);
     }
 
     private async Task<StreamingIterationResult> ProduceStreamingRunAsync(
@@ -710,21 +710,122 @@ public sealed class MafAgentRuntime : IAgentRuntime
         return options;
     }
 
-    private string GetSystemPrompt(Session session)
+    private string GetSystemPrompt(Session session, string? userMessage = null)
     {
         string systemPrompt;
+        string? blockedRoutes = null;
         lock (_skillGate)
         {
             systemPrompt = _systemPrompt;
+
+            // Per-turn projection resolution: when a user message is available and any
+            // loaded skill has projection contracts, resolve them to patch skill instructions
+            // and build a per-turn skill index. Matches kingcrab MafAgentRuntime behavior.
+            if (!string.IsNullOrWhiteSpace(userMessage))
+            {
+                var hasProjectionSkills = false;
+                foreach (var s in _loadedSkills)
+                {
+                    if (s.ProjectionContracts.Count > 0)
+                    {
+                        hasProjectionSkills = true;
+                        break;
+                    }
+                }
+
+                if (hasProjectionSkills)
+                {
+                    var effectiveSkills = ResolveSkillsForTurn(_loadedSkills, userMessage, out blockedRoutes);
+                    var skillSection = SkillPromptBuilder.BuildIndex(effectiveSkills, _skillsConfig?.InstructionPrompt);
+                    var basePrompt = AgentSystemPromptBuilder.BuildBaseSystemPrompt(_requireToolApproval);
+                    systemPrompt = string.IsNullOrEmpty(skillSection) ? basePrompt : basePrompt + "\n" + skillSection;
+                }
+            }
         }
 
         systemPrompt = AgentSystemPromptBuilder.ApplyResponseMode(systemPrompt, session.ResponseMode);
+
+        if (!string.IsNullOrWhiteSpace(blockedRoutes))
+            systemPrompt += "\n\n[Blocked Skill Routes]\n" + blockedRoutes.Trim();
 
         if (string.IsNullOrWhiteSpace(session.SystemPromptOverride))
             return systemPrompt;
 
         return systemPrompt + "\n\n[Route Instructions]\n" + session.SystemPromptOverride.Trim();
     }
+
+    internal static SkillDefinition[] ResolveSkillsForTurn(
+        IReadOnlyList<SkillDefinition> skills,
+        string userMessage,
+        out string blockedRoutes)
+    {
+        var resolvedSkills = new List<SkillDefinition>(skills.Count);
+        var blocked = new StringBuilder();
+
+        foreach (var skill in skills)
+        {
+            if (skill.ProjectionContracts.Count == 0)
+            {
+                resolvedSkills.Add(skill);
+                continue;
+            }
+
+            var resolution = OpenClaw.Core.Skills.SkillProjectionResolver.ResolveForRequest(
+                skill, userMessage,
+                NullLogger.Instance);
+
+            if (resolution.IsBlocked)
+            {
+                blocked.Append("- ");
+                blocked.Append(skill.Name);
+                blocked.Append(": ");
+                blocked.AppendLine(resolution.BlockReason ?? "Projection contract resolution blocked this skill for the current request.");
+                resolvedSkills.Add(CloneSkill(skill, skill.Instructions, disableModelInvocation: true));
+                continue;
+            }
+
+            var patch = OpenClaw.Core.Skills.SkillProjectionResolver.BuildPromptPatch(resolution);
+            if (string.IsNullOrWhiteSpace(patch))
+            {
+                resolvedSkills.Add(skill);
+                continue;
+            }
+
+            var patchedInstructions = string.Concat(skill.Instructions.TrimEnd(), "\n\n", patch);
+            resolvedSkills.Add(CloneSkill(skill, patchedInstructions, skill.DisableModelInvocation));
+        }
+
+        blockedRoutes = blocked.ToString();
+        return [.. resolvedSkills];
+    }
+
+    internal static SkillDefinition CloneSkill(SkillDefinition source, string instructions, bool disableModelInvocation)
+        => new()
+        {
+            Name = source.Name,
+            Description = source.Description,
+            Instructions = instructions,
+            Location = source.Location,
+            Source = source.Source,
+            Metadata = source.Metadata,
+            Kind = source.Kind,
+            Triggers = source.Triggers,
+            MetaPriority = source.MetaPriority,
+            FinalTextMode = source.FinalTextMode,
+            Composition = source.Composition,
+            UserInvocable = source.UserInvocable,
+            DisableModelInvocation = disableModelInvocation,
+            CommandDispatch = source.CommandDispatch,
+            CommandTool = source.CommandTool,
+            CommandArgMode = source.CommandArgMode,
+            Resources = source.Resources,
+            ProjectionContracts = source.ProjectionContracts,
+            ProjectionDiscovery = source.ProjectionDiscovery,
+            ArtifactContract = source.ArtifactContract
+        };
+
+    private int GetSystemPromptLength(Session session)
+        => GetSystemPrompt(session).Length;
 
     private async ValueTask<IDisposable> ApplyTurnRoutingAsync(
         Session session,
@@ -3136,9 +3237,6 @@ public sealed class MafAgentRuntime : IAgentRuntime
             return first;
         return first.Trim() + "\n" + second.Trim();
     }
-
-    private int GetSystemPromptLength(Session session)
-        => GetSystemPrompt(session).Length;
 
     private readonly record struct TurnRoutingSnapshot(
         string? ModelProfileId,

--- a/src/OpenClaw.Tests/AgentRuntimeProjectionTests.cs
+++ b/src/OpenClaw.Tests/AgentRuntimeProjectionTests.cs
@@ -183,6 +183,7 @@ public sealed class AgentRuntimeProjectionTests
         Assert.Equal(source.Metadata.Emoji, nativeClone.Metadata.Emoji);
         Assert.Equal(source.Metadata.Emoji, mafClone.Metadata.Emoji);
         Assert.Equal(source.Metadata.Always, nativeClone.Metadata.Always);
+        Assert.Equal(source.Metadata.Always, mafClone.Metadata.Always);
         Assert.Equal(source.Kind, nativeClone.Kind);
         Assert.Equal(source.Kind, mafClone.Kind);
         Assert.Equal(source.Triggers, nativeClone.Triggers);
@@ -192,6 +193,7 @@ public sealed class AgentRuntimeProjectionTests
         Assert.Equal(source.FinalTextMode, nativeClone.FinalTextMode);
         Assert.Equal(source.FinalTextMode, mafClone.FinalTextMode);
         Assert.Equal(source.UserInvocable, nativeClone.UserInvocable);
+        Assert.Equal(source.UserInvocable, mafClone.UserInvocable);
         Assert.Equal(source.CommandDispatch, nativeClone.CommandDispatch);
         Assert.Equal(source.CommandDispatch, mafClone.CommandDispatch);
         Assert.Equal(source.CommandTool, nativeClone.CommandTool);
@@ -207,6 +209,7 @@ public sealed class AgentRuntimeProjectionTests
         Assert.NotNull(nativeClone.ArtifactContract);
         Assert.NotNull(mafClone.ArtifactContract);
         Assert.Equal(source.ArtifactContract!.SchemaVersion, nativeClone.ArtifactContract!.SchemaVersion);
+        Assert.Equal(source.ArtifactContract!.SchemaVersion, mafClone.ArtifactContract!.SchemaVersion);
     }
 
     [Fact]

--- a/src/OpenClaw.Tests/AgentRuntimeProjectionTests.cs
+++ b/src/OpenClaw.Tests/AgentRuntimeProjectionTests.cs
@@ -280,8 +280,8 @@ public sealed class AgentRuntimeProjectionTests
                 CreateSkill("developer", projectionContracts: [contract])
             };
 
-            var nativeResult = AgentRuntime.ResolveSkillsForTurn(skills, "task execution", out var nativeBlocked);
-            var mafResult = MafAgentRuntime.ResolveSkillsForTurn(skills, "task execution", out var mafBlocked);
+            var nativeResult = AgentRuntime.ResolveSkillsForTurn(skills, "task execution", out var nativeBlocked, out var nativePatches);
+            var mafResult = MafAgentRuntime.ResolveSkillsForTurn(skills, "task execution", out var mafBlocked, out var mafPatches);
 
             Assert.Single(nativeResult);
             Assert.Single(mafResult);
@@ -295,6 +295,10 @@ public sealed class AgentRuntimeProjectionTests
             Assert.Contains("Base instructions.", mafResult[0].Instructions);
             Assert.Contains("approved term", nativeResult[0].Instructions);
             Assert.Contains("approved term", mafResult[0].Instructions);
+            Assert.Contains("## developer", nativePatches);
+            Assert.Contains("[Projection Route]", nativePatches);
+            Assert.Contains("approved term", nativePatches);
+            Assert.Equal(nativePatches, mafPatches);
 
             // Patch output should be identical
             Assert.Equal(nativeResult[0].Instructions, mafResult[0].Instructions);

--- a/src/OpenClaw.Tests/AgentRuntimeProjectionTests.cs
+++ b/src/OpenClaw.Tests/AgentRuntimeProjectionTests.cs
@@ -1,0 +1,509 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenClaw.Agent;
+using OpenClaw.Core.Skills;
+using OpenClaw.MicrosoftAgentFrameworkAdapter;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+/// <summary>
+/// Verifies that both AgentRuntime (native) and MafAgentRuntime (MAF adapter)
+/// produce identical behavior for ArtifactContract + Projection resolution.
+/// </summary>
+public sealed class AgentRuntimeProjectionTests
+{
+    // ────────────────────────────────────────────────────────
+    // Test helpers
+    // ────────────────────────────────────────────────────────
+
+    private static SkillDefinition CreateSkill(
+        string name,
+        string instructions = "Base instructions.",
+        IReadOnlyList<SkillProjectionContractSet>? projectionContracts = null,
+        SkillArtifactContract? artifactContract = null,
+        bool disableModelInvocation = false)
+        => new()
+        {
+            Name = name,
+            Description = $"Description of {name}",
+            Instructions = instructions,
+            Location = $"/skills/{name}",
+            DisableModelInvocation = disableModelInvocation,
+            ProjectionContracts = projectionContracts ?? [],
+            ArtifactContract = artifactContract,
+            Resources = []
+        };
+
+    private static SkillProjectionContractSet CreateProjectionContract(
+        string tempDir,
+        string topicSlug = "task-execution",
+        string defaultTargetView = "prompt-constraint",
+        IReadOnlyList<string>? primaryIntentSignals = null,
+        IReadOnlyList<string>? explicitArtifactSignals = null,
+        IReadOnlyList<string>? allowedTerms = null,
+        int producerPriority = 0)
+    {
+        var relativePath = $"{topicSlug}/{topicSlug}.{defaultTargetView}.projection.json";
+        var projectionDir = Path.Combine(tempDir, topicSlug);
+        Directory.CreateDirectory(projectionDir);
+
+        File.WriteAllText(
+            Path.Combine(tempDir, relativePath),
+            $$"""
+            {
+              "mapping_policy": {
+                "unresolved_item_policy": "allow_unmapped_terms"
+              },
+              "prompt_projection": {
+                "allowed_terms": {{(allowedTerms is not null ? System.Text.Json.JsonSerializer.Serialize(allowedTerms) : "[]")}}
+              },
+              "delivery_artifacts": [],
+              "dropped_items": [],
+              "open_questions": []
+            }
+            """);
+
+        return new SkillProjectionContractSet
+        {
+            ProducerName = "test-producer",
+            ProducerPriority = producerPriority,
+            RootPath = tempDir,
+            Index = new ProjectionContractIndex
+            {
+                ProducerSkill = "test-producer",
+                ProducerPriority = producerPriority,
+                DefaultSelectionPolicy = new ProjectionSelectionPolicy
+                {
+                    FallbackOrderByTargetView = [defaultTargetView]
+                },
+                Topics =
+                [
+                    new ProjectionTopicRecord
+                    {
+                        DomainSlug = topicSlug,
+                        DefaultTargetView = defaultTargetView,
+                        Views =
+                        [
+                            new ProjectionViewRecord
+                            {
+                                TargetView = defaultTargetView,
+                                Status = "READY",
+                                Path = relativePath.Replace('\\', '/')
+                            }
+                        ]
+                    }
+                ],
+                TopicScoring = new ProjectionTopicScoring
+                {
+                    Topics =
+                    [
+                        new ProjectionTopicSignals
+                        {
+                            DomainSlug = topicSlug,
+                            PrimaryIntentSignals = primaryIntentSignals ?? ["task execution"],
+                            SupportingSignals = [],
+                            ExplicitArtifactSignals = explicitArtifactSignals ?? [],
+                            DemoteWhenCompetingTopicSignals = []
+                        }
+                    ]
+                },
+                TargetViewScoring = new ProjectionTargetViewScoring
+                {
+                    Views =
+                    [
+                        new ProjectionViewSignals
+                        {
+                            TargetView = defaultTargetView,
+                            ExplicitOutputSignals = explicitArtifactSignals ?? [],
+                            StrongSignals = [],
+                            SupportingSignals = [],
+                            DemoteWhenCompetingViewSignals = []
+                        }
+                    ]
+                }
+            }
+        };
+    }
+
+    // ────────────────────────────────────────────────────────
+    // CloneSkill tests — verify both runtimes produce identical clones
+    // ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CloneSkill_BothRuntimes_PreserveAll20Fields()
+    {
+        var source = new SkillDefinition
+        {
+            Name = "source-skill",
+            Description = "A test skill",
+            Instructions = "Original instructions.",
+            Location = "/skills/source-skill",
+            Source = SkillSource.Workspace,
+            Metadata = new SkillMetadata { Emoji = "🧪", Always = true },
+            Kind = SkillKind.Standard,
+            Triggers = ["test", "sample"],
+            MetaPriority = 5,
+            FinalTextMode = "raw",
+            Composition = null,
+            UserInvocable = true,
+            DisableModelInvocation = false,
+            CommandDispatch = "tool",
+            CommandTool = "emit_artifact",
+            CommandArgMode = "json",
+            Resources = [new SkillResource { Name = "ref.md", RelativePath = "references/ref.md", AbsolutePath = "/abs/ref.md", Kind = SkillResourceKind.Reference }],
+            ProjectionContracts = [],
+            ProjectionDiscovery = null,
+            ArtifactContract = new SkillArtifactContract { SchemaVersion = 1, Stages = [] }
+        };
+
+        var nativeClone = AgentRuntime.CloneSkill(source, "patched instructions.", disableModelInvocation: true);
+        var mafClone = OpenClaw.MicrosoftAgentFrameworkAdapter.MafAgentRuntime.CloneSkill(source, "patched instructions.", disableModelInvocation: true);
+
+        // Verify both clones are independent of source
+        Assert.NotSame(source, nativeClone);
+        Assert.NotSame(source, mafClone);
+
+        // Verify instructions are patched
+        Assert.Equal("patched instructions.", nativeClone.Instructions);
+        Assert.Equal("patched instructions.", mafClone.Instructions);
+
+        // Verify disableModelInvocation is applied
+        Assert.True(nativeClone.DisableModelInvocation);
+        Assert.True(mafClone.DisableModelInvocation);
+
+        // Verify all 20 fields match between the two runtimes
+        Assert.Equal(source.Name, nativeClone.Name);
+        Assert.Equal(source.Name, mafClone.Name);
+        Assert.Equal(source.Description, nativeClone.Description);
+        Assert.Equal(source.Description, mafClone.Description);
+        Assert.Equal(source.Location, nativeClone.Location);
+        Assert.Equal(source.Location, mafClone.Location);
+        Assert.Equal(source.Source, nativeClone.Source);
+        Assert.Equal(source.Source, mafClone.Source);
+        Assert.Equal(source.Metadata.Emoji, nativeClone.Metadata.Emoji);
+        Assert.Equal(source.Metadata.Emoji, mafClone.Metadata.Emoji);
+        Assert.Equal(source.Metadata.Always, nativeClone.Metadata.Always);
+        Assert.Equal(source.Kind, nativeClone.Kind);
+        Assert.Equal(source.Kind, mafClone.Kind);
+        Assert.Equal(source.Triggers, nativeClone.Triggers);
+        Assert.Equal(source.Triggers, mafClone.Triggers);
+        Assert.Equal(source.MetaPriority, nativeClone.MetaPriority);
+        Assert.Equal(source.MetaPriority, mafClone.MetaPriority);
+        Assert.Equal(source.FinalTextMode, nativeClone.FinalTextMode);
+        Assert.Equal(source.FinalTextMode, mafClone.FinalTextMode);
+        Assert.Equal(source.UserInvocable, nativeClone.UserInvocable);
+        Assert.Equal(source.CommandDispatch, nativeClone.CommandDispatch);
+        Assert.Equal(source.CommandDispatch, mafClone.CommandDispatch);
+        Assert.Equal(source.CommandTool, nativeClone.CommandTool);
+        Assert.Equal(source.CommandTool, mafClone.CommandTool);
+        Assert.Equal(source.CommandArgMode, nativeClone.CommandArgMode);
+        Assert.Equal(source.CommandArgMode, mafClone.CommandArgMode);
+        Assert.Equal(source.Resources, nativeClone.Resources);
+        Assert.Equal(source.Resources, mafClone.Resources);
+        Assert.Equal(source.ProjectionContracts, nativeClone.ProjectionContracts);
+        Assert.Equal(source.ProjectionContracts, mafClone.ProjectionContracts);
+        Assert.Null(nativeClone.ProjectionDiscovery);
+        Assert.Null(mafClone.ProjectionDiscovery);
+        Assert.NotNull(nativeClone.ArtifactContract);
+        Assert.NotNull(mafClone.ArtifactContract);
+        Assert.Equal(source.ArtifactContract!.SchemaVersion, nativeClone.ArtifactContract!.SchemaVersion);
+    }
+
+    [Fact]
+    public void CloneSkill_BothRuntimes_PatchedInstructionsMatch()
+    {
+        var source = CreateSkill("test", instructions: "Original.");
+
+        var nativeClone = AgentRuntime.CloneSkill(source, "Patched.", disableModelInvocation: false);
+        var mafClone = MafAgentRuntime.CloneSkill(source, "Patched.", disableModelInvocation: false);
+
+        Assert.Equal("Patched.", nativeClone.Instructions);
+        Assert.Equal("Patched.", mafClone.Instructions);
+    }
+
+    [Fact]
+    public void CloneSkill_BothRuntimes_DisableModelInvocationMatch()
+    {
+        var source = CreateSkill("test");
+
+        var nativeEnabled = AgentRuntime.CloneSkill(source, "Body.", disableModelInvocation: false);
+        var mafEnabled = MafAgentRuntime.CloneSkill(source, "Body.", disableModelInvocation: false);
+        var nativeDisabled = AgentRuntime.CloneSkill(source, "Body.", disableModelInvocation: true);
+        var mafDisabled = MafAgentRuntime.CloneSkill(source, "Body.", disableModelInvocation: true);
+
+        Assert.False(nativeEnabled.DisableModelInvocation);
+        Assert.False(mafEnabled.DisableModelInvocation);
+        Assert.True(nativeDisabled.DisableModelInvocation);
+        Assert.True(mafDisabled.DisableModelInvocation);
+    }
+
+    // ────────────────────────────────────────────────────────
+    // ResolveSkillsForTurn tests — verify both runtimes produce identical results
+    // ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveSkillsForTurn_NoProjectionSkills_BothRuntimes_ReturnOriginalSkills()
+    {
+        var skills = new List<SkillDefinition>
+        {
+            CreateSkill("skill-a"),
+            CreateSkill("skill-b")
+        };
+
+        var nativeResult = AgentRuntime.ResolveSkillsForTurn(skills, "anything", out var nativeBlocked);
+        var mafResult = MafAgentRuntime.ResolveSkillsForTurn(skills, "anything", out var mafBlocked);
+
+        Assert.Equal(2, nativeResult.Length);
+        Assert.Equal(2, mafResult.Length);
+        Assert.Equal("", nativeBlocked);
+        Assert.Equal("", mafBlocked);
+        Assert.Equal("Base instructions.", nativeResult[0].Instructions);
+        Assert.Equal("Base instructions.", mafResult[0].Instructions);
+    }
+
+    [Fact]
+    public void ResolveSkillsForTurn_WithProjectionMatch_BothRuntimes_PatchIdentically()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-agent-proj-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var contract = CreateProjectionContract(tempDir,
+                primaryIntentSignals: ["task execution"],
+                allowedTerms: ["approved term"]);
+
+            var skills = new List<SkillDefinition>
+            {
+                CreateSkill("developer", projectionContracts: [contract])
+            };
+
+            var nativeResult = AgentRuntime.ResolveSkillsForTurn(skills, "task execution", out var nativeBlocked);
+            var mafResult = MafAgentRuntime.ResolveSkillsForTurn(skills, "task execution", out var mafBlocked);
+
+            Assert.Single(nativeResult);
+            Assert.Single(mafResult);
+            Assert.Equal("", nativeBlocked);
+            Assert.Equal("", mafBlocked);
+
+            // Both should have patched instructions
+            Assert.Contains("[Projection Route]", nativeResult[0].Instructions);
+            Assert.Contains("[Projection Route]", mafResult[0].Instructions);
+            Assert.Contains("Base instructions.", nativeResult[0].Instructions);
+            Assert.Contains("Base instructions.", mafResult[0].Instructions);
+            Assert.Contains("approved term", nativeResult[0].Instructions);
+            Assert.Contains("approved term", mafResult[0].Instructions);
+
+            // Patch output should be identical
+            Assert.Equal(nativeResult[0].Instructions, mafResult[0].Instructions);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ResolveSkillsForTurn_ProjectionBlocked_BothRuntimes_BlockIdentically()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-agent-proj-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var contract = CreateProjectionContract(tempDir,
+                primaryIntentSignals: ["task execution"],
+                explicitArtifactSignals: ["prompt policy"]);
+
+            var skills = new List<SkillDefinition>
+            {
+                CreateSkill("developer", projectionContracts: [contract])
+            };
+
+            // Request matches no signals — falls back to default view (not blocked).
+            // To test blocking, we need a scenario that actually blocks.
+            // Use a contract with BlockOnOpenQuestions + open_questions in the projection file.
+            var relativePathDir = Path.Combine(tempDir, "task-execution");
+            var projectionPath = Path.Combine(relativePathDir,
+                $"task-execution.{SkillProjectionViewKeys.PromptConstraint}.projection.json");
+            File.WriteAllText(projectionPath, """
+            {
+              "mapping_policy": { "unresolved_item_policy": "block_or_escalate" },
+              "prompt_projection": { "allowed_terms": [] },
+              "delivery_artifacts": [],
+              "dropped_items": [],
+              "open_questions": ["Needs clarification."]
+            }
+            """);
+
+            var nativeResult = AgentRuntime.ResolveSkillsForTurn(skills, "task execution", out var nativeBlocked);
+            var mafResult = MafAgentRuntime.ResolveSkillsForTurn(skills, "task execution", out var mafBlocked);
+
+            Assert.Single(nativeResult);
+            Assert.Single(mafResult);
+
+            // BlockOnOpenQuestions not set by default, but block_or_escalate + open_questions triggers block
+            Assert.True(nativeResult[0].DisableModelInvocation);
+            Assert.True(mafResult[0].DisableModelInvocation);
+
+            Assert.Contains("developer", nativeBlocked);
+            Assert.Contains("developer", mafBlocked);
+            Assert.Equal(nativeBlocked, mafBlocked);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ResolveSkillsForTurn_MixedSkills_BothRuntimes_IdenticalOutput()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-agent-proj-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var patchedContract = CreateProjectionContract(tempDir,
+                primaryIntentSignals: ["task execution"],
+                allowedTerms: ["approved term"]);
+
+            var skills = new List<SkillDefinition>
+            {
+                CreateSkill("no-projection"),  // No projection → pass through
+                CreateSkill("patched", projectionContracts: [patchedContract]),  // Has projection → patched
+                CreateSkill("also-no-projection")  // No projection → pass through
+            };
+
+            var nativeResult = AgentRuntime.ResolveSkillsForTurn(skills, "task execution", out var nativeBlocked);
+            var mafResult = MafAgentRuntime.ResolveSkillsForTurn(skills, "task execution", out var mafBlocked);
+
+            Assert.Equal(3, nativeResult.Length);
+            Assert.Equal(3, mafResult.Length);
+            Assert.Equal("", nativeBlocked);
+            Assert.Equal("", mafBlocked);
+
+            // Skill 0: no projection, unchanged
+            Assert.Equal("Base instructions.", nativeResult[0].Instructions);
+            Assert.Equal("Base instructions.", mafResult[0].Instructions);
+
+            // Skill 1: patched
+            Assert.Contains("[Projection Route]", nativeResult[1].Instructions);
+            Assert.Contains("[Projection Route]", mafResult[1].Instructions);
+            Assert.Equal(nativeResult[1].Instructions, mafResult[1].Instructions);
+
+            // Skill 2: no projection, unchanged
+            Assert.Equal("Base instructions.", nativeResult[2].Instructions);
+            Assert.Equal("Base instructions.", mafResult[2].Instructions);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    // ────────────────────────────────────────────────────────
+    // End-to-end consistency: ResolveSkillsForTurn + BuildPromptPatch integration
+    // ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveSkillsForTurn_BothRuntimes_SameSkillsProduceIdenticalBlockedRoutes()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-agent-block-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var relativePathDir = Path.Combine(tempDir, "task-execution");
+            Directory.CreateDirectory(relativePathDir);
+            var projectionPath = Path.Combine(relativePathDir,
+                $"task-execution.{SkillProjectionViewKeys.PromptConstraint}.projection.json");
+
+            File.WriteAllText(projectionPath, """
+            {
+              "mapping_policy": { "unresolved_item_policy": "block_or_escalate" },
+              "prompt_projection": { "allowed_terms": [] },
+              "delivery_artifacts": [],
+              "dropped_items": [],
+              "open_questions": ["Requires clarification."]
+            }
+            """);
+
+            var blockedContract = new SkillProjectionContractSet
+            {
+                ProducerName = "blocker",
+                ProducerPriority = 0,
+                RootPath = tempDir,
+                Index = new ProjectionContractIndex
+                {
+                    DefaultSelectionPolicy = new ProjectionSelectionPolicy
+                    {
+                        FallbackOrderByTargetView = [SkillProjectionViewKeys.PromptConstraint]
+                    },
+                    Topics =
+                    [
+                        new ProjectionTopicRecord
+                        {
+                            DomainSlug = "task-execution",
+                            DefaultTargetView = SkillProjectionViewKeys.PromptConstraint,
+                            Views =
+                            [
+                                new ProjectionViewRecord
+                                {
+                                    TargetView = SkillProjectionViewKeys.PromptConstraint,
+                                    Status = "READY",
+                                    Path = $"task-execution/task-execution.{SkillProjectionViewKeys.PromptConstraint}.projection.json"
+                                }
+                            ]
+                        }
+                    ],
+                    TopicScoring = new ProjectionTopicScoring
+                    {
+                        Topics =
+                        [
+                            new ProjectionTopicSignals
+                            {
+                                DomainSlug = "task-execution",
+                                PrimaryIntentSignals = ["task execution"],
+                                SupportingSignals = [],
+                                ExplicitArtifactSignals = [],
+                                DemoteWhenCompetingTopicSignals = []
+                            }
+                        ]
+                    },
+                    TargetViewScoring = new ProjectionTargetViewScoring
+                    {
+                        Views =
+                        [
+                            new ProjectionViewSignals
+                            {
+                                TargetView = SkillProjectionViewKeys.PromptConstraint,
+                                ExplicitOutputSignals = [],
+                                StrongSignals = [],
+                                SupportingSignals = [],
+                                DemoteWhenCompetingViewSignals = []
+                            }
+                        ]
+                    }
+                }
+            };
+
+            var skills = new List<SkillDefinition>
+            {
+                CreateSkill("blocked-skill", projectionContracts: [blockedContract])
+            };
+
+            var nativeResult = AgentRuntime.ResolveSkillsForTurn(skills, "task execution", out var nativeBlocked);
+            var mafResult = MafAgentRuntime.ResolveSkillsForTurn(skills, "task execution", out var mafBlocked);
+
+            // Both should block the skill
+            Assert.True(nativeResult[0].DisableModelInvocation);
+            Assert.True(mafResult[0].DisableModelInvocation);
+
+            // Blocked routes text should be identical
+            Assert.Equal(nativeBlocked, mafBlocked);
+            Assert.Contains("requires escalation", nativeBlocked);
+            Assert.Contains("requires escalation", mafBlocked);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
+++ b/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
@@ -38,6 +38,7 @@ using ModelContextProtocol.AspNetCore;
 using OpenClaw.Gateway.Composition;
 using OpenClaw.Gateway.Endpoints;
 using OpenClaw.Gateway.Extensions;
+using OpenClaw.Gateway.Tools;
 using OpenClaw.Gateway.Mcp;
 using OpenClaw.Gateway.Models;
 using OpenClaw.Payments.Core;
@@ -7625,6 +7626,7 @@ public sealed class GatewayAdminEndpointTests
             TwilioSmsWebhookHandler = null,
             PluginHost = null,
             NativeDynamicPluginHost = null,
+            ArtifactRuntime = new SkillArtifactRuntime(),
             RegisteredToolNames = System.Collections.Frozen.FrozenSet<string>.Empty,
             ChannelAuthEvents = new ChannelAuthEventStore()
         };

--- a/src/OpenClaw.Tests/GatewayRuntimeLifecycleTests.cs
+++ b/src/OpenClaw.Tests/GatewayRuntimeLifecycleTests.cs
@@ -189,6 +189,56 @@ public sealed class GatewayRuntimeLifecycleTests
     }
 
     [Fact]
+    public async Task SkillWatcherService_OnSkillsReloaded_Callback_ReceivesReloadedSkills()
+    {
+        var root = CreateTempRoot();
+        Directory.CreateDirectory(root);
+        try
+        {
+            var skillsRoot = Path.Combine(root, "skills");
+            Directory.CreateDirectory(skillsRoot);
+
+            var config = new SkillsConfig();
+            config.Load.ExtraDirs = [skillsRoot];
+
+            var reloadedSkills = new List<SkillDefinition>
+            {
+                new()
+                {
+                    Name = "reloaded-skill",
+                    Description = "A reloaded skill",
+                    Instructions = "Reloaded body.",
+                    Location = Path.Combine(skillsRoot, "reloaded-skill")
+                }
+            };
+
+            var agentRuntime = Substitute.For<IAgentRuntime>();
+            agentRuntime.CircuitBreakerState.Returns(CircuitState.Closed);
+            agentRuntime.LoadedSkillNames.Returns(["reloaded-skill"]);
+            agentRuntime.LoadedSkills.Returns(reloadedSkills);
+            agentRuntime.ReloadSkillsAsync(Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<IReadOnlyList<string>>(["reloaded-skill"]));
+
+            var callbackFired = new TaskCompletionSource<IReadOnlyList<SkillDefinition>>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var service = new SkillWatcherService(config, null, [], agentRuntime,
+                NullLogger<SkillWatcherService>.Instance,
+                onSkillsReloaded: skills => callbackFired.TrySetResult(skills));
+            service.Start(TestContext.Current.CancellationToken);
+            service.NotifySkillChanged();
+
+            var received = await callbackFired.Task.WaitAsync(TimeSpan.FromSeconds(3));
+            Assert.Single(received);
+            Assert.Equal("reloaded-skill", received[0].Name);
+            Assert.Equal("Reloaded body.", received[0].Instructions);
+        }
+        finally
+        {
+            DeleteDirectoryIfPresent(root);
+        }
+    }
+
+    [Fact]
     public async Task MdnsDiscoveryService_Start_IsIdempotent_AndDisposeStopsInjectedListeners()
     {
         var listenerFactoryCalls = 0;

--- a/src/OpenClaw.Tests/GatewayRuntimeLifecycleTests.cs
+++ b/src/OpenClaw.Tests/GatewayRuntimeLifecycleTests.cs
@@ -21,6 +21,7 @@ using OpenClaw.Gateway.Composition;
 using OpenClaw.Gateway.Extensions;
 using OpenClaw.Gateway.Integrations;
 using OpenClaw.Gateway.Pipeline;
+using OpenClaw.Gateway.Tools;
 using OpenClaw.Payments.Core;
 using Xunit;
 
@@ -394,6 +395,7 @@ public sealed class GatewayRuntimeLifecycleTests
             PluginHost = null,
             NativeDynamicPluginHost = null,
             WhatsAppWorkerHost = null,
+            ArtifactRuntime = new SkillArtifactRuntime(),
             RegisteredToolNames = FrozenSet<string>.Empty,
             ChannelAuthEvents = new ChannelAuthEventStore()
         };

--- a/src/OpenClaw.Tests/GatewayStructureTests.cs
+++ b/src/OpenClaw.Tests/GatewayStructureTests.cs
@@ -11,7 +11,7 @@ public sealed class GatewayStructureTests
 
         AssertFileLineBudget(root, "src/OpenClaw.Gateway/Extensions/GatewayWorkers.cs", 200);
         AssertFileLineBudget(root, "src/OpenClaw.Gateway/Endpoints/OpenAiEndpoints.cs", 250);
-        AssertFileLineBudget(root, "src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs", 260);
+        AssertFileLineBudget(root, "src/OpenClaw.Gateway/Composition/RuntimeInitializationExtensions.cs", 270);
         AssertFileLineBudget(root, "src/OpenClaw.Gateway/Endpoints/AdminEndpoints.cs", 300);
     }
 

--- a/src/OpenClaw.Tests/SkillArtifactRuntimeTests.cs
+++ b/src/OpenClaw.Tests/SkillArtifactRuntimeTests.cs
@@ -1,0 +1,93 @@
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Skills;
+using OpenClaw.Gateway.Tools;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class SkillArtifactRuntimeTests
+{
+    [Fact]
+    public void NormalizeAndRecord_BlocksGatedStageUntilRequiredStageIsTerminal()
+    {
+        var runtime = new SkillArtifactRuntime();
+        runtime.ReplaceSkills(
+        [
+            new SkillDefinition
+            {
+                Name = "artifact-skill",
+                Description = "Emits staged artifacts.",
+                Instructions = "Emit artifacts.",
+                Location = "/skills/artifact-skill",
+                ArtifactContract = new SkillArtifactContract
+                {
+                    SchemaVersion = 1,
+                    Stages =
+                    [
+                        new SkillArtifactStageContract
+                        {
+                            Name = "draft",
+                            Artifacts =
+                            [
+                                new SkillArtifactTypeContract
+                                {
+                                    Type = "draft_package",
+                                    Terminal = true
+                                }
+                            ]
+                        },
+                        new SkillArtifactStageContract
+                        {
+                            Name = "final",
+                            Gate = new SkillArtifactStageGateContract
+                            {
+                                RequiresStage = "draft"
+                            },
+                            Artifacts =
+                            [
+                                new SkillArtifactTypeContract
+                                {
+                                    Type = "final_package"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]);
+
+        var blocked = runtime.NormalizeAndRecord("session-1", new SkillArtifact
+        {
+            Kind = "data",
+            SkillName = "artifact-skill",
+            Stage = "final",
+            ArtifactType = "final_package"
+        });
+
+        Assert.False(blocked.Succeeded);
+        Assert.Contains("draft", blocked.Error);
+
+        var completedDraft = runtime.NormalizeAndRecord("session-1", new SkillArtifact
+        {
+            Kind = "data",
+            SkillName = "artifact-skill",
+            Stage = "draft",
+            ArtifactType = "draft_package",
+            IsTerminal = true
+        });
+
+        Assert.True(completedDraft.Succeeded);
+
+        var allowed = runtime.NormalizeAndRecord("session-1", new SkillArtifact
+        {
+            Kind = "data",
+            SkillName = "artifact-skill",
+            Stage = "final",
+            ArtifactType = "final_package"
+        });
+
+        Assert.True(allowed.Succeeded);
+        Assert.Equal("final", allowed.Artifact!.Stage);
+        Assert.Equal("final_package", allowed.Artifact.ArtifactType);
+    }
+}

--- a/src/OpenClaw.Tests/SkillTests.cs
+++ b/src/OpenClaw.Tests/SkillTests.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
 using OpenClaw.Core.Skills;
 using Xunit;
 
@@ -1928,6 +1929,152 @@ public class SkillLoaderTests
             Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void ParseSkillFile_WithArtifactContractAndProjections_LoadsBoth()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-skill-contracts-{Guid.NewGuid():N}");
+        var contractsDir = Path.Combine(tempDir, "contracts");
+        var projectionsDir = Path.Combine(contractsDir, "projections", "producer-one");
+        Directory.CreateDirectory(projectionsDir);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "SKILL.md"), """
+                ---
+                name: pipeline-skill
+                description: A skill with contracts
+                ---
+                Body.
+                """);
+
+            // Add a references/ dir so ScanSkillResources returns at least 1 resource.
+            var referencesDir = Path.Combine(tempDir, "references");
+            Directory.CreateDirectory(referencesDir);
+            File.WriteAllText(Path.Combine(referencesDir, "note.md"), "ref content");
+
+            File.WriteAllText(Path.Combine(contractsDir, "artifacts.json"), """
+                {
+                  "schemaVersion": 2,
+                  "stages": [
+                    {
+                      "name": "design",
+                      "label": "Design Phase",
+                      "artifacts": [
+                        {
+                          "type": "requirements",
+                          "label": "Requirements Doc",
+                          "display": "badge",
+                          "terminal": true
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+            File.WriteAllText(Path.Combine(projectionsDir, "contract-index.json"), """
+                {
+                  "producer_skill": "producer-one",
+                  "producer_priority": 42,
+                  "default_selection_policy": {
+                    "prefer_ready_only": true,
+                    "block_on_open_questions": true,
+                    "fallback_order_by_target_view": ["prompt-constraint"]
+                  },
+                  "topic_scoring": {
+                    "score_dimensions": [
+                      { "dimension": "primary_intent_match", "score": 5 }
+                    ],
+                    "topics": [
+                      {
+                        "domain_slug": "skill-loading",
+                        "primary_intent_signals": ["load skill"],
+                        "supporting_signals": ["skill"],
+                        "explicit_artifact_signals": [],
+                        "demote_when_competing_topic_signals": []
+                      }
+                    ]
+                  },
+                  "target_view_scoring": {
+                    "score_dimensions": [
+                      { "dimension": "explicit_output_match", "score": 5 }
+                    ],
+                    "views": [
+                      {
+                        "target_view": "prompt-constraint",
+                        "explicit_output_signals": ["prompt policy"],
+                        "strong_signals": [],
+                        "supporting_signals": [],
+                        "demote_when_competing_view_signals": []
+                      }
+                    ],
+                    "within_topic_overrides": [
+                      {
+                        "domain_slug": "skill-loading",
+                        "bonuses": [
+                          {
+                            "target_view": "prompt-constraint",
+                            "when_request_signals": ["policy"],
+                            "score": 3
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "topics": [
+                    {
+                      "domain_slug": "skill-loading",
+                      "default_target_view": "prompt-constraint",
+                      "views": [
+                        {
+                          "target_view": "prompt-constraint",
+                          "status": "READY",
+                          "path": "producer-one/skill-loading.prompt-constraint.projection.json"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+            var skill = SkillLoader.ParseSkillFile(
+                Path.Combine(tempDir, "SKILL.md"),
+                tempDir,
+                SkillSource.Workspace);
+
+            Assert.NotNull(skill);
+            Assert.Single(skill!.Resources);
+            Assert.NotNull(skill.ArtifactContract);
+            Assert.Equal(2, skill.ArtifactContract!.SchemaVersion);
+            var stage = Assert.Single(skill.ArtifactContract.Stages);
+            Assert.Equal("design", stage.Name);
+            Assert.Equal("requirements", Assert.Single(stage.Artifacts).Type);
+
+            var contract = Assert.Single(skill.ProjectionContracts);
+            Assert.Equal("producer-one", contract.ProducerName);
+            Assert.Equal(42, contract.ProducerPriority);
+            Assert.Equal(Path.GetFullPath(projectionsDir), Path.GetFullPath(contract.RootPath));
+            Assert.True(contract.Index.DefaultSelectionPolicy.PreferReadyOnly);
+            Assert.True(contract.Index.DefaultSelectionPolicy.BlockOnOpenQuestions);
+            Assert.Equal(["prompt-constraint"], contract.Index.DefaultSelectionPolicy.FallbackOrderByTargetView);
+            Assert.Equal("skill-loading", Assert.Single(contract.Index.Topics).DomainSlug);
+            Assert.Equal("prompt-constraint", Assert.Single(Assert.Single(contract.Index.Topics).Views).TargetView);
+            Assert.Equal("skill-loading", Assert.Single(contract.Index.TopicScoring!.Topics).DomainSlug);
+            Assert.Equal("prompt-constraint", Assert.Single(contract.Index.TargetViewScoring!.Views).TargetView);
+            Assert.Equal("prompt-constraint", Assert.Single(Assert.Single(contract.Index.TargetViewScoring.WithinTopicOverrides).Bonuses).TargetView);
+
+            Assert.NotNull(skill.ProjectionDiscovery);
+            Assert.Equal("bound", skill.ProjectionDiscovery!.Status);
+            Assert.Equal(1, skill.ProjectionDiscovery.IndexCount);
+            Assert.Equal(1, skill.ProjectionDiscovery.BoundCount);
+            Assert.Equal([Path.Combine(projectionsDir, "contract-index.json")], skill.ProjectionDiscovery.IndexPaths);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
 }
 
 public class SkillPromptBuilderTests
@@ -2418,7 +2565,8 @@ public class SkillPromptBuilderTests
 public class LoadSkillToolTests
 {
     private static SkillDefinition Skill(string name, string body = "Body.", bool disableModel = false,
-        IReadOnlyList<SkillResource>? resources = null) =>
+        IReadOnlyList<SkillResource>? resources = null,
+        SkillArtifactContract? artifactContract = null) =>
         new()
         {
             Name = name,
@@ -2426,7 +2574,8 @@ public class LoadSkillToolTests
             Instructions = body,
             Location = $"/skills/{name}",
             DisableModelInvocation = disableModel,
-            Resources = resources ?? []
+            Resources = resources ?? [],
+            ArtifactContract = artifactContract
         };
 
     [Fact]
@@ -2536,6 +2685,113 @@ public class LoadSkillToolTests
 
         Assert.Contains("path=\"references/bad&quot;&lt;&gt;&amp;&apos;.md\"", result);
         Assert.DoesNotContain("bad\"<>&'.md", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AppendsArtifactContract_WhenPresent()
+    {
+        var contract = new SkillArtifactContract
+        {
+            SchemaVersion = 2,
+            Stages =
+            [
+                new SkillArtifactStageContract
+                {
+                    Name = "design",
+                    Label = "Design Phase",
+                    Artifacts =
+                    [
+                        new SkillArtifactTypeContract
+                        {
+                            Type = "requirements",
+                            Label = "Requirements Doc",
+                            Display = "badge",
+                            Terminal = true
+                        }
+                    ]
+                },
+                new SkillArtifactStageContract
+                {
+                    Name = "review",
+                    Label = "Review Phase",
+                    Gate = new SkillArtifactStageGateContract { RequiresStage = "design" },
+                    Artifacts =
+                    [
+                        new SkillArtifactTypeContract
+                        {
+                            Type = "review_checklist",
+                            Label = "Review Checklist",
+                            Display = "tree"
+                            // Terminal omitted (defaults to null) — not written in JSON.
+                        }
+                    ]
+                }
+            ]
+        };
+        var tool = new LoadSkillTool([Skill("pipeline", artifactContract: contract)]);
+
+        var result = await tool.ExecuteAsync("""{"skill":"pipeline"}""", default);
+
+        Assert.Contains("<skill-instructions>", result);
+        Assert.Contains("<skill-artifact-contract>", result);
+        Assert.Contains("\"schema_version\": 2", result);
+        Assert.Contains("\"name\": \"design\"", result);
+        Assert.Contains("\"label\": \"Design Phase\"", result);
+        Assert.Contains("\"type\": \"requirements\"", result);
+        Assert.Contains("\"display\": \"badge\"", result);
+        Assert.Contains("\"terminal\": true", result);
+        Assert.Contains("\"name\": \"review\"", result);
+        Assert.Contains("\"requires_stage\": \"design\"", result);
+        Assert.Contains("\"type\": \"review_checklist\"", result);
+        Assert.Contains("\"display\": \"tree\"", result);
+        Assert.DoesNotContain("\"terminal\": false", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AppendsArtifactContract_BeforeResourceManifest()
+    {
+        var resources = new List<SkillResource>
+        {
+            new()
+            {
+                Name = "spec.md",
+                RelativePath = "references/spec.md",
+                AbsolutePath = "/skills/dsgn/references/spec.md",
+                Kind = SkillResourceKind.Reference
+            }
+        };
+        var contract = new SkillArtifactContract
+        {
+            Stages =
+            [
+                new SkillArtifactStageContract
+                {
+                    Name = "plan",
+                    Artifacts = [new SkillArtifactTypeContract { Type = "requirements" }]
+                }
+            ]
+        };
+        var tool = new LoadSkillTool([Skill("dsgn", resources: resources, artifactContract: contract)]);
+
+        var result = await tool.ExecuteAsync("""{"skill":"dsgn"}""", default);
+
+        var contractIndex = result.IndexOf("<skill-artifact-contract>", StringComparison.Ordinal);
+        var resourcesIndex = result.IndexOf("<skill-resources>", StringComparison.Ordinal);
+        Assert.True(contractIndex >= 0);
+        Assert.True(resourcesIndex >= 0);
+        Assert.True(contractIndex < resourcesIndex, "Artifact contract must appear before resource manifest");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoArtifactContract_DoesNotInjectBlock()
+    {
+        var tool = new LoadSkillTool([Skill("lean")]);
+
+        var result = await tool.ExecuteAsync("""{"skill":"lean"}""", default);
+
+        Assert.Contains("<skill-instructions>", result);
+        Assert.DoesNotContain("<skill-artifact-contract>", result);
+        Assert.DoesNotContain("schema_version", result);
     }
 
     [Fact]
@@ -3019,6 +3275,318 @@ public class ReadSkillResourceToolTests : IDisposable
     {
         // Lock the public default so SkillsConfig.MaxResourceReadBytes can rely on it.
         Assert.Equal(256 * 1024, ReadSkillResourceTool.DefaultMaxResourceBytes);
+    }
+}
+
+public class SkillProjectionResolverTests
+{
+    private static SkillDefinition SkillWithProjections(
+        string name,
+        string tempDir,
+        string relativePath,
+        IReadOnlyList<string>? explicitArtifactSignals = null,
+        IReadOnlyList<string>? allowedTermsSignals = null,
+        int producerPriority = 0,
+        string? unresolvedItemPolicy = null)
+    {
+        var projectionDir = Path.Combine(tempDir, Path.GetDirectoryName(relativePath)!);
+        Directory.CreateDirectory(projectionDir);
+
+        File.WriteAllText(
+            Path.Combine(tempDir, relativePath),
+            $$"""
+            {
+              "mapping_policy": {
+                "unresolved_item_policy": "{{unresolvedItemPolicy ?? "allow_unmapped_terms"}}"
+              },
+              "prompt_projection": {
+                "allowed_terms": {{(allowedTermsSignals is not null ? JsonSerializer.Serialize(allowedTermsSignals) : "[]")}}
+              },
+              "delivery_artifacts": [],
+              "dropped_items": [],
+              "open_questions": []
+            }
+            """);
+
+        return new SkillDefinition
+        {
+            Name = name,
+            Description = $"Description of {name}",
+            Instructions = "Base skill instructions.",
+            Location = $"/skills/{name}",
+            ProjectionContracts =
+            [
+                new SkillProjectionContractSet
+                {
+                    ProducerName = "test-producer",
+                    ProducerPriority = producerPriority,
+                    RootPath = tempDir,
+                    Index = new ProjectionContractIndex
+                    {
+                        ProducerSkill = "test-producer",
+                        ProducerPriority = producerPriority,
+                        DefaultSelectionPolicy = new ProjectionSelectionPolicy
+                        {
+                            FallbackOrderByTargetView = [SkillProjectionViewKeys.PromptConstraint]
+                        },
+                        Topics =
+                        [
+                            new ProjectionTopicRecord
+                            {
+                                DomainSlug = "task-execution",
+                                DefaultTargetView = SkillProjectionViewKeys.PromptConstraint,
+                                Views =
+                                [
+                                    new ProjectionViewRecord
+                                    {
+                                        TargetView = SkillProjectionViewKeys.PromptConstraint,
+                                        Status = "READY",
+                                        Path = relativePath.Replace('\\', '/')
+                                    }
+                                ]
+                            }
+                        ],
+                        TopicScoring = new ProjectionTopicScoring
+                        {
+                            Topics =
+                            [
+                                new ProjectionTopicSignals
+                                {
+                                    DomainSlug = "task-execution",
+                                    PrimaryIntentSignals = ["task execution"],
+                                    SupportingSignals = ["run"],
+                                    ExplicitArtifactSignals = explicitArtifactSignals ?? [],
+                                    DemoteWhenCompetingTopicSignals = []
+                                }
+                            ]
+                        },
+                        TargetViewScoring = new ProjectionTargetViewScoring
+                        {
+                            Views =
+                            [
+                                new ProjectionViewSignals
+                                {
+                                    TargetView = SkillProjectionViewKeys.PromptConstraint,
+                                    ExplicitOutputSignals = explicitArtifactSignals ?? [],
+                                    StrongSignals = [],
+                                    SupportingSignals = [],
+                                    DemoteWhenCompetingViewSignals = []
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        };
+    }
+
+    [Fact]
+    public void ResolveForRequest_NoProjectionContracts_ReturnsNoContracts()
+    {
+        var skill = new SkillDefinition
+        {
+            Name = "bare",
+            Description = "No projections",
+            Instructions = "Body.",
+            Location = "/skills/bare"
+        };
+
+        var result = SkillProjectionResolver.ResolveForRequest(skill, "task execution",
+            NullLogger.Instance);
+
+        Assert.Equal("bare", result.SkillName);
+        Assert.False(result.HasContracts);
+        Assert.False(result.IsBlocked);
+    }
+
+    [Fact]
+    public void ResolveForRequest_MatchingRequest_PatchesInstructionsWithProjection()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-proj-resolve-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var relativePath = Path.Combine("task-execution",
+                $"task-execution.{SkillProjectionViewKeys.PromptConstraint}.projection.json").Replace('\\', '/');
+            var skill = SkillWithProjections("software-developer", tempDir, relativePath,
+                explicitArtifactSignals: ["prompt policy"],
+                allowedTermsSignals: ["review guidance", "prompt policy"]);
+
+            var result = SkillProjectionResolver.ResolveForRequest(skill, "task execution with prompt policy",
+                NullLogger.Instance);
+
+            Assert.Equal("software-developer", result.SkillName);
+            Assert.True(result.HasContracts);
+            Assert.False(result.IsBlocked);
+            Assert.Equal("task-execution", result.SelectedTopic);
+            Assert.Equal("prompt-constraint", result.SelectedTargetView);
+            Assert.NotNull(result.Projection);
+            Assert.Contains("review guidance", result.Projection!.PromptProjection.AllowedTerms);
+
+            var patch = SkillProjectionResolver.BuildPromptPatch(result);
+            Assert.Contains("[Projection Route]", patch);
+            Assert.Contains("Selected topic: task-execution", patch);
+            Assert.Contains("Selected target view: prompt-constraint", patch);
+            Assert.Contains("review guidance", patch);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ResolveForRequest_BlockOnOpenQuestions_ReturnsBlocked()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-proj-block-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var relativePath = Path.Combine("task-execution",
+                $"task-execution.{SkillProjectionViewKeys.PromptConstraint}.projection.json").Replace('\\', '/');
+            var skill = SkillWithProjections("software-developer", tempDir, relativePath,
+                explicitArtifactSignals: ["prompt policy"]);
+
+            // Overwrite projection file to include open_questions.
+            File.WriteAllText(Path.Combine(tempDir, relativePath),
+                """
+                {
+                  "mapping_policy": {
+                    "unresolved_item_policy": "block_or_escalate"
+                  },
+                  "prompt_projection": {
+                    "allowed_terms": ["skills_config"]
+                  },
+                  "delivery_artifacts": [],
+                  "dropped_items": [],
+                  "open_questions": ["Needs clarification."]
+                }
+                """);
+
+            // Override the default_selection_policy in the index to block on open questions.
+            skill = new SkillDefinition
+            {
+                Name = skill.Name,
+                Description = skill.Description,
+                Instructions = skill.Instructions,
+                Location = skill.Location,
+                ProjectionContracts = skill.ProjectionContracts.Select(pc => new SkillProjectionContractSet
+                {
+                    ProducerName = pc.ProducerName,
+                    ProducerPriority = pc.ProducerPriority,
+                    RootPath = pc.RootPath,
+                    Index = pc.Index is { } idx ? new ProjectionContractIndex
+                    {
+                        ProducerSkill = idx.ProducerSkill,
+                        ProducerPriority = idx.ProducerPriority,
+                        DefaultSelectionPolicy = new ProjectionSelectionPolicy
+                        {
+                            BlockOnOpenQuestions = true,
+                            FallbackOrderByTargetView = idx.DefaultSelectionPolicy.FallbackOrderByTargetView
+                        },
+                        Topics = idx.Topics,
+                        TopicScoring = idx.TopicScoring,
+                        TargetViewScoring = idx.TargetViewScoring
+                    } : pc.Index
+                }).ToList()
+            };
+
+            var result = SkillProjectionResolver.ResolveForRequest(skill, "task execution with prompt policy",
+                NullLogger.Instance);
+
+            Assert.True(result.IsBlocked);
+            Assert.Contains("open questions", result.BlockReason);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ResolveForRequest_NoMatchingSignals_FallsBackToOrderedTargetView()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-proj-fallback-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var relativePath = Path.Combine("task-execution",
+                $"task-execution.{SkillProjectionViewKeys.PromptConstraint}.projection.json").Replace('\\', '/');
+            var skill = SkillWithProjections("software-developer", tempDir, relativePath,
+                explicitArtifactSignals: ["prompt policy"]);
+
+            // Request text matches no signals; fallback ordering kicks in.
+            var result = SkillProjectionResolver.ResolveForRequest(skill, "completely unrelated topic",
+                NullLogger.Instance);
+
+            // Fallback resolved successfully, not blocked.
+            Assert.False(result.IsBlocked);
+            Assert.Equal("task-execution", result.SelectedTopic);
+            Assert.Equal("prompt-constraint", result.SelectedTargetView);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void BuildPromptPatch_EmptyResolution_ReturnsEmptyString()
+    {
+        var resolution = new SkillProjectionResolution
+        {
+            SkillName = "test",
+            HasContracts = true,
+            IsBlocked = true,
+            BlockReason = "No matching view"
+        };
+
+        var patch = SkillProjectionResolver.BuildPromptPatch(resolution);
+        Assert.Equal("", patch);
+    }
+
+    [Fact]
+    public void BuildPromptPatch_WithPromptAssumptionPolicy_FormatsConstraint()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-proj-patch-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var relativePath = Path.Combine("task-execution",
+                $"task-execution.{SkillProjectionViewKeys.PromptConstraint}.projection.json").Replace('\\', '/');
+            var skill = SkillWithProjections("software-developer", tempDir, relativePath,
+                explicitArtifactSignals: ["prompt policy"],
+                allowedTermsSignals: ["approved term"],
+                unresolvedItemPolicy: null);
+
+            // Overwrite the projection file to include prompt_assumption_policy.
+            File.WriteAllText(Path.Combine(tempDir, relativePath),
+                """
+                {
+                  "mapping_policy": {
+                    "unresolved_item_policy": "allow_unmapped_terms",
+                    "prompt_assumption_policy": "disallow_unmapped_terms"
+                  },
+                  "prompt_projection": {
+                    "allowed_terms": ["approved term"]
+                  },
+                  "delivery_artifacts": [],
+                  "dropped_items": [],
+                  "open_questions": []
+                }
+                """);
+
+            var result = SkillProjectionResolver.ResolveForRequest(skill, "task execution with prompt policy",
+                NullLogger.Instance);
+
+            Assert.False(result.IsBlocked);
+            var patch = SkillProjectionResolver.BuildPromptPatch(result);
+            Assert.Contains("Do not use unmapped terms", patch);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
     }
 }
 

--- a/src/OpenClaw.Tests/SkillTests.cs
+++ b/src/OpenClaw.Tests/SkillTests.cs
@@ -2075,6 +2075,48 @@ public class SkillLoaderTests
             Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void ParseSkillFile_WithEmptyProjectionIndex_DoesNotBindProjectionContract()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-skill-empty-projections-{Guid.NewGuid():N}");
+        var projectionsDir = Path.Combine(tempDir, "contracts", "projections", "producer-one");
+        Directory.CreateDirectory(projectionsDir);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "SKILL.md"), """
+                ---
+                name: empty-projection-skill
+                description: A skill with an empty projection contract
+                ---
+                Body.
+                """);
+
+            File.WriteAllText(Path.Combine(projectionsDir, "contract-index.json"), """
+                {
+                  "producer_skill": "producer-one",
+                  "topics": []
+                }
+                """);
+
+            var skill = SkillLoader.ParseSkillFile(
+                Path.Combine(tempDir, "SKILL.md"),
+                tempDir,
+                SkillSource.Workspace);
+
+            Assert.NotNull(skill);
+            Assert.Empty(skill!.ProjectionContracts);
+            Assert.NotNull(skill.ProjectionDiscovery);
+            Assert.Equal("parse-failed", skill.ProjectionDiscovery!.Status);
+            Assert.Equal(1, skill.ProjectionDiscovery.IndexCount);
+            Assert.Equal(0, skill.ProjectionDiscovery.BoundCount);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
 }
 
 public class SkillPromptBuilderTests
@@ -3432,6 +3474,165 @@ public class SkillProjectionResolverTests
         finally
         {
             Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ResolveForRequest_DuplicateScoringKeys_DoesNotThrow()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-proj-dup-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var relativePath = Path.Combine("task-execution",
+                $"task-execution.{SkillProjectionViewKeys.PromptConstraint}.projection.json").Replace('\\', '/');
+            var skill = SkillWithProjections("software-developer", tempDir, relativePath,
+                allowedTermsSignals: ["review guidance"]);
+            var contract = skill.ProjectionContracts[0];
+            var topicSignal = contract.Index.TopicScoring!.Topics[0];
+            var viewSignal = contract.Index.TargetViewScoring!.Views[0];
+
+            skill = new SkillDefinition
+            {
+                Name = skill.Name,
+                Description = skill.Description,
+                Instructions = skill.Instructions,
+                Location = skill.Location,
+                ProjectionContracts =
+                [
+                    new SkillProjectionContractSet
+                    {
+                        ProducerName = contract.ProducerName,
+                        ProducerPriority = contract.ProducerPriority,
+                        RootPath = contract.RootPath,
+                        Index = new ProjectionContractIndex
+                        {
+                            ProducerSkill = contract.Index.ProducerSkill,
+                            ProducerPriority = contract.Index.ProducerPriority,
+                            DefaultSelectionPolicy = contract.Index.DefaultSelectionPolicy,
+                            Topics = contract.Index.Topics,
+                            TopicScoring = new ProjectionTopicScoring
+                            {
+                                ClarifyWhenScoreGapBelow = contract.Index.TopicScoring.ClarifyWhenScoreGapBelow,
+                                ScoreDimensions = contract.Index.TopicScoring.ScoreDimensions,
+                                Topics = [topicSignal, topicSignal]
+                            },
+                            TargetViewScoring = new ProjectionTargetViewScoring
+                            {
+                                ClarifyWhenScoreGapBelow = contract.Index.TargetViewScoring.ClarifyWhenScoreGapBelow,
+                                PreferExplicitUserArtifactRequests = contract.Index.TargetViewScoring.PreferExplicitUserArtifactRequests,
+                                ScoreDimensions = contract.Index.TargetViewScoring.ScoreDimensions,
+                                Views = [viewSignal, viewSignal],
+                                WithinTopicOverrides = contract.Index.TargetViewScoring.WithinTopicOverrides
+                            }
+                        }
+                    }
+                ]
+            };
+
+            var result = SkillProjectionResolver.ResolveForRequest(skill, "task execution",
+                NullLogger.Instance);
+
+            Assert.False(result.IsBlocked);
+            Assert.Equal("task-execution", result.SelectedTopic);
+            Assert.Contains("review guidance", result.Projection!.PromptProjection.AllowedTerms);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ResolveForRequest_PathEscapingContractRoot_ReturnsBlocked()
+    {
+        var rootDir = Path.Combine(Path.GetTempPath(), $"openclaw-proj-root-{Guid.NewGuid():N}");
+        var outsideDir = Path.Combine(Path.GetTempPath(), $"openclaw-proj-outside-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(rootDir);
+        Directory.CreateDirectory(outsideDir);
+        try
+        {
+            var outsidePath = Path.Combine(outsideDir, "projection.json");
+            File.WriteAllText(outsidePath,
+                """
+                {
+                  "mapping_policy": {
+                    "unresolved_item_policy": "allow_unmapped_terms"
+                  },
+                  "prompt_projection": {
+                    "allowed_terms": ["outside"]
+                  },
+                  "delivery_artifacts": [],
+                  "dropped_items": [],
+                  "open_questions": []
+                }
+                """);
+
+            var escapingRelativePath = Path.GetRelativePath(rootDir, outsidePath).Replace('\\', '/');
+            var skill = new SkillDefinition
+            {
+                Name = "software-developer",
+                Description = "Description",
+                Instructions = "Base skill instructions.",
+                Location = rootDir,
+                ProjectionContracts =
+                [
+                    new SkillProjectionContractSet
+                    {
+                        ProducerName = "test-producer",
+                        RootPath = rootDir,
+                        Index = new ProjectionContractIndex
+                        {
+                            DefaultSelectionPolicy = new ProjectionSelectionPolicy
+                            {
+                                FallbackOrderByTargetView = [SkillProjectionViewKeys.PromptConstraint]
+                            },
+                            Topics =
+                            [
+                                new ProjectionTopicRecord
+                                {
+                                    DomainSlug = "task-execution",
+                                    DefaultTargetView = SkillProjectionViewKeys.PromptConstraint,
+                                    Views =
+                                    [
+                                        new ProjectionViewRecord
+                                        {
+                                            TargetView = SkillProjectionViewKeys.PromptConstraint,
+                                            Status = "READY",
+                                            Path = escapingRelativePath
+                                        }
+                                    ]
+                                }
+                            ],
+                            TopicScoring = new ProjectionTopicScoring
+                            {
+                                Topics =
+                                [
+                                    new ProjectionTopicSignals
+                                    {
+                                        DomainSlug = "task-execution",
+                                        PrimaryIntentSignals = ["task execution"],
+                                        SupportingSignals = [],
+                                        ExplicitArtifactSignals = [],
+                                        DemoteWhenCompetingTopicSignals = []
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ]
+            };
+
+            var result = SkillProjectionResolver.ResolveForRequest(skill, "task execution",
+                NullLogger.Instance);
+
+            Assert.True(result.IsBlocked);
+            Assert.Contains("outside the projection contract root", result.BlockReason);
+        }
+        finally
+        {
+            Directory.Delete(rootDir, true);
+            Directory.Delete(outsideDir, true);
         }
     }
 

--- a/src/OpenClaw.Tests/SkillTests.cs
+++ b/src/OpenClaw.Tests/SkillTests.cs
@@ -2117,6 +2117,63 @@ public class SkillLoaderTests
             Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void ParseSkillFile_WithProjectionIndexMissingRoutingSurface_DoesNotBindProjectionContract()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-skill-useless-projections-{Guid.NewGuid():N}");
+        var projectionsDir = Path.Combine(tempDir, "contracts", "projections", "producer-one");
+        Directory.CreateDirectory(projectionsDir);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "SKILL.md"), """
+                ---
+                name: unroutable-projection-skill
+                description: A skill with an unroutable projection contract
+                ---
+                Body.
+                """);
+
+            File.WriteAllText(Path.Combine(projectionsDir, "contract-index.json"), """
+                {
+                  "producer_skill": "producer-one",
+                  "default_selection_policy": {
+                    "fallback_order_by_target_view": []
+                  },
+                  "topics": [
+                    {
+                      "domain_slug": "skill-loading",
+                      "default_target_view": "prompt-constraint",
+                      "views": [
+                        {
+                          "target_view": "prompt-constraint",
+                          "status": "READY",
+                          "path": "producer-one/skill-loading.prompt-constraint.projection.json"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+            var skill = SkillLoader.ParseSkillFile(
+                Path.Combine(tempDir, "SKILL.md"),
+                tempDir,
+                SkillSource.Workspace);
+
+            Assert.NotNull(skill);
+            Assert.Empty(skill!.ProjectionContracts);
+            Assert.NotNull(skill.ProjectionDiscovery);
+            Assert.Equal("parse-failed", skill.ProjectionDiscovery!.Status);
+            Assert.Equal(1, skill.ProjectionDiscovery.IndexCount);
+            Assert.Equal(0, skill.ProjectionDiscovery.BoundCount);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
 }
 
 public class SkillPromptBuilderTests


### PR DESCRIPTION
## Description
Add two orthogonal Skill extension systems — ArtifactContract (multi-stage artifact whitelist validation) and Projection (per-turn signal-based skill instruction tailoring). Both are null-safe: absent contract files silently degrade with no impact on normal inference.

## ArtifactContract

- Define artifact type whitelists, stage gating, and normalization rules via JSON contracts under skills/<name>/contracts/artifacts.json
- Runtime validation via SkillArtifactRuntime with concurrent two-level matching (explicit stage or auto-inference) and stage-gate state machine
- EmitArtifactTool pushes "artifact" and "skill_stage_gate" WebSocket envelopes to the frontend for deterministic UI rendering
- LoadSkillTool injects <skill-artifact-contract> XML into the LLM prompt
- Gated by GatewayConfig.Tooling.EnableEmitArtifact (default true)

## Projection

- Define topic/view signal scoring indexes under skills/<name>/contracts/projections/<producer>/contract-index.json
- Load projection documents (.json) with mapping policies, prompt constraints (allowed/forbidden terms, reasoning paths), and delivery artifact registrations
- SkillProjectionResolver: SelectTopic → SelectView → LoadProjection → BuildPromptPatch, with multi-producer Score→Priority ranking
- Per-turn resolution integrated into both AgentRuntime and MafAgentRuntime via GetSystemPrompt(session, userMessage) overload
- Blocked projections produce [Blocked Skill Routes] prompt section

## Files Changed

New (8):
  src/OpenClaw.Core/Models/SkillArtifact.cs src/OpenClaw.Core/Models/SkillArtifactContractModels.cs src/OpenClaw.Core/Skills/SkillProjectionResolver.cs src/OpenClaw.Core/Skills/SkillProjectionArtifactTerms.cs src/OpenClaw.Gateway/Tools/EmitArtifactTool.cs src/OpenClaw.Gateway/Tools/SkillArtifactRuntime.cs src/OpenClaw.Tests/AgentRuntimeProjectionTests.cs docs/RUNTIME_ARTIFACT_CONTRACT.md (+ zh-CN)

Modified (20):
  Core: WebSocketEnvelopes.cs (+SkillStageGateEvent, +WsServerEnvelope fields), Session.cs (+JsonSerializable attrs), GatewayConfig.cs (+EnableEmitArtifact), SkillModels.cs (+3 SkillDefinition props), SkillLoader.cs (+TryLoadArtifactContract, +TryLoadProjectionContracts
    + ~20 projection parser helpers), LoadSkillTool.cs (+RenderArtifact- Contract, +LoadSkillToolJsonContext), SkillPromptBuilder.cs (+BuildSkillBody projection overload) Gateway: GatewayAppRuntime.cs (+ArtifactRuntime), RuntimeInitializa- tionExtensions*.cs (+SkillArtifactRuntime lifecycle, +MediaCache in RuntimeServices, +EmitArtifactTool DI, +hot-reload callback), SkillWatcherService.cs (+onSkillsReloaded callback) Agent: AgentRuntime.cs (+per-turn projection resolution, +Resolve- SkillsForTurn, +CloneSkill), OpenClaw.Agent.csproj (+Internals- VisibleTo for Gateway) MAF: MafAgentRuntime.cs (+per-turn projection resolution parity) Tests: SkillTests.cs (+10: loader contracts, LoadSkillTool artifact injection, SkillProjectionResolver routing), GatewayAdminEndpoint- Tests.cs, GatewayRuntimeLifecycleTests.cs, GatewayStructureTests.cs

## Test Results

  2,330 passed, 0 failed (+18 new tests)
  - 10 SkillProjectionResolver + LoadSkillTool + contract loader tests
  - 8 cross-runtime behavioral alignment tests (AgentRuntime vs MafAgentRuntime)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Tests
- [ ] Build/CI
- [ ] Governance/process
- [x] Refactoring (no functional changes)

## Validation

- [x] `dotnet restore OpenClaw.Net.slnx`
- [x] `dotnet build OpenClaw.Net.slnx --configuration Release --no-restore`
- [x] `dotnet test OpenClaw.Net.slnx --configuration Release --no-build`
- [x] `dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build`

## Review Notes

- [x] I considered NativeAOT compatibility
- [x] I considered security posture and unsafe defaults
- [x] I updated docs/tests where needed
- [x] This PR is scoped and does not mix unrelated changes

## Commercial or Customer-Driven Contribution Disclosure

This contribution originates from the  runtime powering our 数字员工 (Digital Employee) commercial product line.
The ArtifactContract system enables deterministic multi-stage workflow  orchestration for enterprise digital employees (e.g. Hirebot's employment coach conversation pipeline with 4 stages and 5 downstream skills).
The Projection system enables dynamic skill capability tailoring based on user intent signals, used in production for ontology extraction, skill generation, and external system configuration workflows.

Both systems have been validated in production and are contributed back toupstream OpenClaw.NET with no vendor-specific dependencies. All contract formats and resolution algorithms are fully reusable for any downstream skill authoring use case.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style implementation of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed locally (`dotnet test`)
- [x] I have updated the documentation (README.md, comments) if required
- [x] I have checked for security implications (input validation, authorization)
- [x] I have checked the relevant [maintainer review checklist](../docs/maintainers/review-checklist.md)
- [x] I have disclosed whether this directly supports a company or customer use case

## Screenshots (if applicable)

[Add screenshots for UI/UX changes]

## Benchmarks (if applicable)

[Did this change affect performance? Provide benchmark results.]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified `emit_artifact` support for file/data artifacts with richer metadata, WebSocket delivery, and stage-gate signaling.
  * Added per-turn skill projection resolution to patch system prompts and block unavailable skill routes.
  * Added loading of artifact contracts and projection contracts, including `<skill-artifact-contract>` injection during skill load.
* **Bug Fixes**
  * Improved parity across runtimes for projection patching and blocked-route behavior.
* **Documentation**
  * Added runtime specifications for artifact contracts and projections (English + Chinese).
* **Tests**
  * Added coverage for artifact stage-gating, projection behavior, and runtime parity.
* **Chores**
  * Added contract JSON watching for hot reload and a configuration toggle for `emit_artifact`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->