### PR TITLE
feat: add DeepSeek provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Start here:
 - **/loop recurring-prompt command** with TickerQ-backed session-scoped timer injection, idempotent override, and dual-path semantic auto-termination for build health checks, log polling, and other periodic tasks
 - **80+ native and optional tool surfaces** covering file ops, sessions, memory, web, messaging, home automation, databases, email, MCP apps, and more
 - **9 channel adapters** (Telegram, SMS, WhatsApp, Teams, Slack, Discord, Signal, email, webhooks) with DM policy, allowlists, and signature validation
-- **Native LLM providers** for OpenAI, Claude, Gemini, Azure OpenAI, Ollama, and OpenAI-compatible endpoints
+- **Native LLM providers** for OpenAI, Claude, Gemini, Azure OpenAI, DeepSeek, Ollama, and OpenAI-compatible endpoints
 - **Optional embedded local models** with Gemma 4 GGUF packages, package install/verify CLI commands, supervised sidecar inference, and frame-based video understanding
 - **Practical reuse** of existing OpenClaw TS/JS plugins and `SKILL.md` packages
 
@@ -82,7 +82,7 @@ Each desktop bundle includes Companion, the NativeAOT gateway, and the NativeAOT
 1. Extract the archive.
 2. Launch Companion from the `companion` folder.
 3. Open the **Setup** tab.
-4. Choose a provider/model and enter the provider key, choose Ollama for a local model server, or choose Embedded for an OpenClaw-managed local model such as Gemma 4.
+4. Choose a provider/model and enter the provider key, choose DeepSeek for the hosted OpenAI-compatible DeepSeek API, choose Ollama for a local model server, or choose Embedded for an OpenClaw-managed local model such as Gemma 4.
 5. Click **Set Up and Start**.
 
 Companion writes a local config, starts the bundled gateway on `127.0.0.1`, and connects to it. The current Windows and macOS release archives are unsigned, so first-run OS warnings are expected. See [docs/RELEASES.md](docs/RELEASES.md) for checksums, standalone CLI/gateway archives, signing status, and maintainer release flow.
@@ -164,6 +164,14 @@ openclaw setup --non-interactive --profile local --workspace ./workspace --provi
 ```
 
 OpenClaw.NET now treats Ollama as a first-class native provider at `http://127.0.0.1:11434`. Older `/v1` endpoints still work for one compatibility cycle, but `openclaw models doctor` will flag them so you can migrate cleanly.
+
+For DeepSeek, use the named provider instead of the generic OpenAI-compatible provider. Setup writes the current DeepSeek API endpoint, defaults to `deepseek-v4-flash`, and uses `DEEPSEEK_API_KEY` in the generated env example:
+
+```bash
+openclaw setup --non-interactive --profile local --workspace ./workspace --provider deepseek --api-key env:DEEPSEEK_API_KEY
+```
+
+Use `--model deepseek-v4-pro` when you want the higher-capability DeepSeek model.
 
 For OpenClaw-managed local inference, use provider `embedded` with an installable package. Gemma 4 is now the main embedded local model path:
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -215,6 +215,13 @@ dotnet build
 dotnet run --project src/OpenClaw.Cli -c Release -- setup
 ```
 
+For DeepSeek, use `DEEPSEEK_API_KEY` and the named provider so setup writes the DeepSeek OpenAI-compatible endpoint automatically:
+
+```bash
+export DEEPSEEK_API_KEY="sk-..."
+dotnet run --project src/OpenClaw.Cli -c Release -- setup --non-interactive --profile local --workspace ./workspace --provider deepseek --api-key env:DEEPSEEK_API_KEY
+```
+
 What `setup` gives you:
 
 - an external config file, usually at `~/.openclaw/config/openclaw.settings.json`

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -41,6 +41,14 @@ export MODEL_PROVIDER_KEY="sk-..."
 dotnet run --project src/OpenClaw.Cli -c Release -- start
 ```
 
+For DeepSeek, use its own provider key variable and named provider:
+
+```bash
+export DEEPSEEK_API_KEY="sk-..."
+dotnet run --project src/OpenClaw.Cli -c Release -- setup --non-interactive --profile local --workspace ./workspace --provider deepseek --api-key env:DEEPSEEK_API_KEY
+dotnet run --project src/OpenClaw.Cli -c Release -- setup launch --config ~/.openclaw/config/openclaw.settings.json
+```
+
 Accept the defaults. If the config does not exist yet, `openclaw start` runs setup first, writes `~/.openclaw/config/openclaw.settings.json`, and then launches.
 
 **3. Open the browser UI.**
@@ -209,6 +217,22 @@ openclaw models doctor
 ```
 
 Plain `openclaw run "hello"` requests work as prompt-only chat with non-tool Ollama profiles when no explicit tool preset is requested. Tool-heavy routes and explicit presets still need a tool-capable model profile or configured fallback. The doctor now warns when an Ollama profile still points at `/v1` or when a local agentic profile is missing a deterministic fallback.
+
+For a DeepSeek hosted setup, use the named provider. It configures the OpenAI-compatible DeepSeek endpoint automatically and defaults to `deepseek-v4-flash`:
+
+```bash
+export DEEPSEEK_API_KEY="sk-..."
+openclaw setup --non-interactive \
+  --profile local \
+  --workspace ./workspace \
+  --provider deepseek \
+  --api-key env:DEEPSEEK_API_KEY
+
+openclaw setup verify --config ~/.openclaw/config/openclaw.settings.json --require-provider
+openclaw setup launch --config ~/.openclaw/config/openclaw.settings.json
+```
+
+Pass `--model deepseek-v4-pro` when you want the higher-capability hosted model.
 
 ## Optional Embedded Local Model
 

--- a/src/OpenClaw.Cli/Program.cs
+++ b/src/OpenClaw.Cli/Program.cs
@@ -160,6 +160,7 @@ internal static class Program
               openclaw start
               openclaw start --with-companion --open-browser
               openclaw start --non-interactive --profile local --workspace ./workspace --provider openai --model gpt-4o --api-key env:MODEL_PROVIDER_KEY
+              openclaw start --non-interactive --profile local --workspace ./workspace --provider deepseek --model deepseek-v4-flash --api-key env:DEEPSEEK_API_KEY
               openclaw start --non-interactive --profile local --workspace ./workspace --provider ollama --model llama3.2 --model-preset ollama-general
               openclaw run "summarize this README" --file ./README.md
               OPENCLAW_AUTH_TOKEN=... openclaw run "summarize this README" --file ./README.md
@@ -175,6 +176,7 @@ internal static class Program
               openclaw upgrade check --config ~/.openclaw/config/openclaw.settings.json --offline
               openclaw upgrade rollback --config ~/.openclaw/config/openclaw.settings.json --offline
               openclaw setup --non-interactive --profile local --workspace ./workspace --provider openai --model gpt-4o --api-key env:MODEL_PROVIDER_KEY
+              openclaw setup --non-interactive --profile local --workspace ./workspace --provider deepseek --model deepseek-v4-flash --api-key env:DEEPSEEK_API_KEY
               openclaw setup --non-interactive --profile local --workspace ./workspace --provider ollama --model llama3.2 --model-preset ollama-general
               openclaw setup provider aperture --endpoint https://YOUR_APERTURE_ENDPOINT --model YOUR_APERTURE_MODEL_ROUTE --auth-mode tailnet-identity
               openclaw setup verify --config ~/.openclaw/config/openclaw.settings.json

--- a/src/OpenClaw.Cli/SetupCommand.cs
+++ b/src/OpenClaw.Cli/SetupCommand.cs
@@ -173,7 +173,7 @@ internal static class SetupCommand
             ?? GetDefaultModel(provider, discoveredOllama.Models);
         var model = Prompt(output, input, "Model", modelDefault);
         var apiKey = ProviderRequiresApiKey(provider)
-            ? Prompt(output, input, "API key or env: reference", parsed.GetOption("--api-key") ?? DefaultApiKeyRef)
+            ? Prompt(output, input, "API key or env: reference", parsed.GetOption("--api-key") ?? GetDefaultApiKeyRef(provider))
             : parsed.GetOption("--api-key");
 
         var bindDefault = parsed.GetOption("--bind") ?? GetDefaultBindAddress(profile);
@@ -244,7 +244,7 @@ internal static class SetupCommand
             ModelPresetId = GetDefaultModelPreset(parsed.GetOption("--provider") ?? DefaultProvider, parsed.GetOption("--model-preset")),
             Model = parsed.GetOption("--model") ?? GetDefaultModel(parsed.GetOption("--provider") ?? DefaultProvider, []),
             ApiKey = ProviderRequiresApiKey(parsed.GetOption("--provider"))
-                ? parsed.GetOption("--api-key") ?? DefaultApiKeyRef
+                ? parsed.GetOption("--api-key") ?? GetDefaultApiKeyRef(parsed.GetOption("--provider") ?? DefaultProvider)
                 : parsed.GetOption("--api-key"),
             BindAddress = parsed.GetOption("--bind") ?? GetDefaultBindAddress(profile),
             Port = ParsePort(parsed.GetOption("--port") ?? "18789"),
@@ -459,10 +459,16 @@ internal static class SetupCommand
     private static string GetDefaultModel(string? provider, IReadOnlyList<string> discoveredOllamaModels)
         => provider?.Trim().ToLowerInvariant() switch
         {
+            DeepSeekProviderDefaults.ProviderId => DeepSeekProviderDefaults.DefaultModel,
             "embedded" => DefaultEmbeddedModelId,
             "ollama" when discoveredOllamaModels.Count > 0 => discoveredOllamaModels[0],
             _ => new GatewayConfig().Llm.Model
         };
+
+    private static string GetDefaultApiKeyRef(string? provider)
+        => string.Equals(provider?.Trim(), DeepSeekProviderDefaults.ProviderId, StringComparison.OrdinalIgnoreCase)
+            ? DeepSeekProviderDefaults.DefaultApiKeyRef
+            : DefaultApiKeyRef;
 
     private static OllamaDiscoveryResult TryDiscoverOllamaModels()
     {

--- a/src/OpenClaw.Core/Setup/DeepSeekProviderDefaults.cs
+++ b/src/OpenClaw.Core/Setup/DeepSeekProviderDefaults.cs
@@ -1,0 +1,34 @@
+using OpenClaw.Core.Models;
+
+namespace OpenClaw.Core.Setup;
+
+public static class DeepSeekProviderDefaults
+{
+    public const string ProviderId = "deepseek";
+    public const string OpenAiBaseUrl = "https://api.deepseek.com";
+    public const string DefaultApiKeyRef = "env:DEEPSEEK_API_KEY";
+    public const string DefaultModel = "deepseek-v4-flash";
+    public const string ProModel = "deepseek-v4-pro";
+
+    public static ModelCapabilities BuildCapabilities()
+        => new()
+        {
+            SupportsTools = true,
+            SupportsVision = false,
+            SupportsJsonSchema = false,
+            SupportsStructuredOutputs = true,
+            SupportsStreaming = true,
+            SupportsParallelToolCalls = true,
+            SupportsReasoningEffort = true,
+            SupportsSystemMessages = true,
+            SupportsImageInput = false,
+            SupportsVideoInput = false,
+            SupportsAudioInput = false,
+            SupportsPromptCaching = false,
+            SupportsExplicitCacheRetention = false,
+            ReportsCacheReadTokens = false,
+            ReportsCacheWriteTokens = false,
+            MaxContextTokens = 64000,
+            MaxOutputTokens = 8192
+        };
+}

--- a/src/OpenClaw.Core/Setup/GatewaySetupProfileFactory.cs
+++ b/src/OpenClaw.Core/Setup/GatewaySetupProfileFactory.cs
@@ -111,6 +111,12 @@ public static class GatewaySetupProfileFactory
                 return;
             }
 
+            if (provider.Equals(DeepSeekProviderDefaults.ProviderId, StringComparison.OrdinalIgnoreCase))
+            {
+                ConfigureDeepSeekModelProfile(config, model);
+                return;
+            }
+
             if (!string.IsNullOrWhiteSpace(modelPresetId))
                 warnings?.Add($"Ignoring model preset '{modelPresetId}' because local presets currently apply only to Ollama or embedded providers.");
             return;
@@ -200,6 +206,24 @@ public static class GatewaySetupProfileFactory
                 Model = modelId,
                 Tags = package?.Tags?.ToArray() ?? ["local", "private", "offline", "cheap"],
                 Capabilities = CloneCapabilities(capabilities)
+            }
+        ];
+    }
+
+    private static void ConfigureDeepSeekModelProfile(GatewayConfig config, string model)
+    {
+        config.Llm.Endpoint = DeepSeekProviderDefaults.OpenAiBaseUrl;
+        config.Models.DefaultProfile = "deepseek-default";
+        config.Models.Profiles =
+        [
+            new ModelProfileConfig
+            {
+                Id = "deepseek-default",
+                Provider = DeepSeekProviderDefaults.ProviderId,
+                Model = model,
+                BaseUrl = DeepSeekProviderDefaults.OpenAiBaseUrl,
+                Tags = ["cloud", "openai-compatible", "deepseek"],
+                Capabilities = DeepSeekProviderDefaults.BuildCapabilities()
             }
         ];
     }

--- a/src/OpenClaw.Core/Validation/ModelDoctorEvaluator.cs
+++ b/src/OpenClaw.Core/Validation/ModelDoctorEvaluator.cs
@@ -209,6 +209,9 @@ public static class ModelDoctorEvaluator
             };
         }
 
+        if (provider == DeepSeekProviderDefaults.ProviderId)
+            return DeepSeekProviderDefaults.BuildCapabilities();
+
         var supportsTools = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai" or "groq" or "together" or "lmstudio" or "anthropic" or "claude" or "anthropic-vertex" or "amazon-bedrock" or "gemini" or "google";
         var supportsVision = provider is "openai" or "openai-compatible" or "aperture" or "azure-openai" or "gemini" or "google" or "ollama" or "amazon-bedrock";
         var supportsPromptCaching = provider is "openai" or "azure-openai" or "anthropic" or "claude" or "anthropic-vertex" or "gemini" or "google";

--- a/src/OpenClaw.Core/Validation/ProviderSmokeProbe.cs
+++ b/src/OpenClaw.Core/Validation/ProviderSmokeProbe.cs
@@ -4,6 +4,7 @@ using System.Text;
 using OpenClaw.Core.Http;
 using OpenClaw.Core.Models;
 using OpenClaw.Core.Security;
+using OpenClaw.Core.Setup;
 
 namespace OpenClaw.Core.Validation;
 
@@ -148,7 +149,7 @@ public static class ProviderSmokeProbe
     {
         return provider switch
         {
-            "openai" or "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" or "azure-openai"
+            "openai" or "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" or "deepseek" or "azure-openai"
                 => BuildOpenAiStyleRequest(
                     provider,
                     config,
@@ -175,6 +176,7 @@ public static class ProviderSmokeProbe
             "groq" => AppendPath(config.Endpoint, "https://api.groq.com/openai/v1", "chat/completions"),
             "together" => AppendPath(config.Endpoint, "https://api.together.xyz/v1", "chat/completions"),
             "lmstudio" => AppendPath(config.Endpoint, "http://127.0.0.1:1234/v1", "chat/completions"),
+            "deepseek" => AppendPath(config.Endpoint, DeepSeekProviderDefaults.OpenAiBaseUrl, "chat/completions"),
             "azure-openai" => AppendPath(config.Endpoint, null, "chat/completions"),
             "aperture" => AppendPath(config.Endpoint, null, "chat/completions"),
             _ => AppendPath(config.Endpoint, null, "chat/completions")

--- a/src/OpenClaw.Gateway/Extensions/LlmClientFactory.cs
+++ b/src/OpenClaw.Gateway/Extensions/LlmClientFactory.cs
@@ -8,6 +8,7 @@ using GeminiDotnet;
 using GeminiDotnet.Extensions.AI;
 using Microsoft.Extensions.AI;
 using OpenClaw.Core.Models;
+using OpenClaw.Core.Setup;
 using OpenClaw.Core.Validation;
 
 namespace OpenClaw.Gateway.Extensions;
@@ -133,7 +134,7 @@ public static class LlmClientFactory
             "azure-openai" => CreateAzureOpenAiClient(config)
                 .GetChatClient(config.Model)
                 .AsIChatClient(),
-            "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" =>
+            "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" or "deepseek" =>
                 CreateOpenAiCompatibleClient(new LlmProviderConfig
                 {
                     Provider = config.Provider,
@@ -142,6 +143,9 @@ public static class LlmClientFactory
                     SendRequestMetadata = config.SendRequestMetadata,
                     Model = config.Model,
                     Endpoint = config.Endpoint
+                        ?? (config.Provider.Equals(DeepSeekProviderDefaults.ProviderId, StringComparison.OrdinalIgnoreCase)
+                            ? DeepSeekProviderDefaults.OpenAiBaseUrl
+                            : null)
                         ?? throw new InvalidOperationException(
                             $"Endpoint must be set for provider '{config.Provider}'. " +
                             "Set OpenClaw:Llm:Endpoint or MODEL_PROVIDER_ENDPOINT.")
@@ -158,7 +162,7 @@ public static class LlmClientFactory
                 .AsIChatClient(config.Model),
             _ => throw new InvalidOperationException(
                 $"Unsupported LLM provider: {config.Provider}. " +
-                "Supported: openai, anthropic, claude, anthropic-vertex, gemini, google, ollama, embedded, azure-openai, openai-compatible, aperture, groq, together, lmstudio, amazon-bedrock")
+                "Supported: openai, anthropic, claude, anthropic-vertex, gemini, google, ollama, embedded, azure-openai, openai-compatible, aperture, groq, together, lmstudio, deepseek, amazon-bedrock")
         };
     }
 
@@ -182,7 +186,7 @@ public static class LlmClientFactory
                 Model = config.Model
             }, embeddingModel!),
             "gemini" or "google" => CreateGeminiEmbeddingClient(config, embeddingModel!),
-            "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" =>
+            "openai-compatible" or "aperture" or "groq" or "together" or "lmstudio" or "deepseek" =>
                 CreateOpenAiEmbeddingClient(new LlmProviderConfig
                 {
                     Provider = config.Provider,
@@ -191,6 +195,9 @@ public static class LlmClientFactory
                     SendRequestMetadata = config.SendRequestMetadata,
                     Model = config.Model,
                     Endpoint = config.Endpoint
+                        ?? (config.Provider.Equals(DeepSeekProviderDefaults.ProviderId, StringComparison.OrdinalIgnoreCase)
+                            ? DeepSeekProviderDefaults.OpenAiBaseUrl
+                            : null)
                 }, embeddingModel!),
             "anthropic-vertex" or "amazon-bedrock" => null,
             _ => null

--- a/src/OpenClaw.Tests/LlmClientFactoryTests.cs
+++ b/src/OpenClaw.Tests/LlmClientFactoryTests.cs
@@ -149,6 +149,27 @@ public sealed class LlmClientFactoryTests
     }
 
     [Fact]
+    public async Task DeepSeekProvider_UsesOpenAiCompatibleTransport()
+    {
+        await using var server = await StartOpenAiCompatibleServerAsync();
+        var client = LlmClientFactory.CreateChatClient(new LlmProviderConfig
+        {
+            Provider = "deepseek",
+            Endpoint = server.BaseUrl,
+            Model = "deepseek-v4-flash",
+            ApiKey = "test-deepseek-key"
+        });
+
+        var response = await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, "ready?")],
+            new ChatOptions { ModelId = "deepseek-v4-flash" },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("READY", response.Text);
+        Assert.Equal("Bearer test-deepseek-key", server.Headers["Authorization"]);
+    }
+
+    [Fact]
     public void ApertureTailnetIdentity_EmbeddingsFailFastWithoutApiKey()
     {
         var ex = Assert.Throws<InvalidOperationException>(() =>
@@ -205,13 +226,32 @@ public sealed class LlmClientFactoryTests
         Assert.Equal("Bearer provider-token", server.Headers["Authorization"]);
     }
 
+    [Fact]
+    public async Task DeepSeekProvider_SmokeProbeUsesOpenAiCompatibleEndpoint()
+    {
+        await using var server = await StartOpenAiCompatibleServerAsync();
+
+        var result = await ProviderSmokeProbe.ProbeAsync(
+            new LlmProviderConfig
+            {
+                Provider = "deepseek",
+                Endpoint = server.BaseUrl,
+                Model = "deepseek-v4-flash",
+                ApiKey = "deepseek-token"
+            },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(SetupCheckStates.Pass, result.Status);
+        Assert.Equal("Bearer deepseek-token", server.Headers["Authorization"]);
+    }
+
     private static async Task<OpenAiCompatibleTestServer> StartOpenAiCompatibleServerAsync()
     {
         var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var builder = WebApplication.CreateSlimBuilder();
         builder.WebHost.UseUrls("http://127.0.0.1:0");
         var app = builder.Build();
-        app.MapPost("/v1/chat/completions", (HttpContext ctx) =>
+        IResult HandleChatCompletions(HttpContext ctx)
         {
             headers.Clear();
             foreach (var header in ctx.Request.Headers)
@@ -233,7 +273,10 @@ public sealed class LlmClientFactoryTests
                     }
                 }
             });
-        });
+        }
+
+        app.MapPost("/v1/chat/completions", HandleChatCompletions);
+        app.MapPost("/chat/completions", HandleChatCompletions);
 
         await app.StartAsync();
         var address = app.Services

--- a/src/OpenClaw.Tests/ModelProfileSelectionTests.cs
+++ b/src/OpenClaw.Tests/ModelProfileSelectionTests.cs
@@ -739,6 +739,31 @@ public sealed class ModelProfileSelectionTests
     }
 
     [Fact]
+    public void ModelDoctor_DeepSeekProfile_UsesNamedProviderCapabilities()
+    {
+        var config = new GatewayConfig
+        {
+            Llm = new LlmProviderConfig
+            {
+                Provider = "deepseek",
+                Model = "deepseek-v4-flash",
+                ApiKey = "env:DEEPSEEK_API_KEY"
+            }
+        };
+
+        var doctor = ModelDoctorEvaluator.Build(config);
+        var profile = Assert.Single(doctor.Profiles);
+
+        Assert.Empty(profile.ValidationIssues);
+        Assert.Equal("deepseek", profile.ProviderId);
+        Assert.Equal("deepseek-v4-flash", profile.ModelId);
+        Assert.True(profile.Capabilities.SupportsTools);
+        Assert.True(profile.Capabilities.SupportsStructuredOutputs);
+        Assert.True(profile.Capabilities.SupportsReasoningEffort);
+        Assert.False(profile.Capabilities.SupportsVision);
+    }
+
+    [Fact]
     public void Registry_ApertureProfileFailure_IsolatedFromDefaultProvider()
     {
         LlmClientFactory.ResetDynamicProviders();

--- a/src/OpenClaw.Tests/SetupCommandTests.cs
+++ b/src/OpenClaw.Tests/SetupCommandTests.cs
@@ -196,6 +196,62 @@ public sealed class SetupCommandTests
     }
 
     [Fact]
+    public async Task RunAsync_NonInteractiveDeepSeekProvider_WritesNamedOpenAiCompatibleProfile()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            var configPath = Path.Combine(root, "config", "openclaw.deepseek.json");
+            var workspace = Path.Combine(root, "workspace");
+            using var output = new StringWriter();
+            using var error = new StringWriter();
+
+            var exitCode = await SetupCommand.RunAsync(
+                [
+                    "--non-interactive",
+                    "--profile", "local",
+                    "--config", configPath,
+                    "--workspace", workspace,
+                    "--provider", "deepseek"
+                ],
+                new StringReader(string.Empty),
+                output,
+                error,
+                root,
+                canPrompt: false);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(string.Empty, error.ToString());
+
+            using var document = JsonDocument.Parse(await File.ReadAllTextAsync(configPath));
+            var openClaw = document.RootElement.GetProperty("OpenClaw");
+            var llm = openClaw.GetProperty("llm");
+            Assert.Equal("deepseek", llm.GetProperty("provider").GetString());
+            Assert.Equal("deepseek-v4-flash", llm.GetProperty("model").GetString());
+            Assert.Equal("https://api.deepseek.com", llm.GetProperty("endpoint").GetString());
+            Assert.Equal("env:DEEPSEEK_API_KEY", llm.GetProperty("apiKey").GetString());
+
+            var models = openClaw.GetProperty("models");
+            Assert.Equal("deepseek-default", models.GetProperty("defaultProfile").GetString());
+            var profile = Assert.Single(models.GetProperty("profiles").EnumerateArray());
+            Assert.Equal("deepseek-default", profile.GetProperty("id").GetString());
+            Assert.Equal("deepseek", profile.GetProperty("provider").GetString());
+            Assert.Equal("deepseek-v4-flash", profile.GetProperty("model").GetString());
+            Assert.Equal("https://api.deepseek.com", profile.GetProperty("baseUrl").GetString());
+            Assert.True(profile.GetProperty("capabilities").GetProperty("supportsTools").GetBoolean());
+            Assert.True(profile.GetProperty("capabilities").GetProperty("supportsReasoningEffort").GetBoolean());
+
+            var envExample = await File.ReadAllTextAsync(Path.Combine(root, "config", "openclaw.deepseek.env.example"));
+            Assert.Contains("DEEPSEEK_API_KEY=replace-me", envExample, StringComparison.Ordinal);
+            Assert.DoesNotContain("MODEL_PROVIDER_KEY=replace-me", envExample, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task RunAsync_NonInteractiveEmbeddedPreset_WritesKeylessLocalInferenceProfile()
     {
         var root = CreateTempRoot();


### PR DESCRIPTION
## Summary
- add DeepSeek as a named OpenAI-compatible provider with the current DeepSeek API endpoint and default model
- generate first-run config and env examples using DEEPSEEK_API_KEY
- wire DeepSeek through model doctor, provider smoke probes, runtime client creation, CLI help, and docs

Closes #182

## Validation
- dotnet test src/OpenClaw.Tests --filter "FullyQualifiedName~SetupCommandTests|FullyQualifiedName~LlmClientFactoryTests|FullyQualifiedName~ModelProfileSelectionTests"
- dotnet build OpenClaw.Net.slnx -c Release
- dotnet test OpenClaw.Net.slnx -c Release --no-build (first run: one unrelated ToolGovernance sidecar race failed, single test passed on rerun)
- dotnet test OpenClaw.Net.slnx -c Release --no-build (rerun: 2395 passed)
- dotnet run --project src/OpenClaw.Cli -c Release -- setup --non-interactive --profile local --workspace /tmp/openclaw-deepseek-workspace --config /tmp/openclaw-deepseek-config/openclaw.settings.json --provider deepseek

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek as a supported hosted LLM provider.
  * Added setup support with `DEEPSEEK_API_KEY`, automatic endpoint configuration, and default `deepseek-v4-flash` model selection.
  * Added support for the higher-capability `deepseek-v4-pro` model.
  * Added DeepSeek examples to CLI help and setup documentation.

* **Bug Fixes**
  * Improved provider-specific API key and model defaults during setup.
  * Added DeepSeek compatibility for chat, embeddings, model validation, and connectivity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->