### PR TITLE
docs: link AgentQi mobile companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Start here:
 - [Architecture](https://agentqi.dev/docs/start-here)
 - [Security](https://agentqi.dev/docs/security)
 - [Roadmap](https://agentqi.dev/docs/roadmap)
+- [AgentQi Mobile companion](https://github.com/agentqi/agentqi-mobile) — open-source Android operator console with build-from-source instructions
 
 ## What Works Now
 
@@ -56,6 +57,7 @@ Start here:
 - **First-class optional Microsoft Agent Framework adapter** for `Runtime.Orchestrator=maf` without a special build
 - **Durable workflow delegation** through supported workflow backends such as `maf-durable-http`
 - **CLI and Companion** setup flows for source checkouts and desktop bundles
+- **AgentQi Mobile companion** for Android gateway health, approvals, session-backed work, chat, runtime events, and security posture ([source and build guide](https://github.com/agentqi/agentqi-mobile))
 - **/loop recurring-prompt command** with TickerQ-backed session-scoped timer injection, idempotent override, and dual-path semantic auto-termination for build health checks, log polling, and other periodic tasks
 - **80+ native and optional tool surfaces** covering file ops, sessions, memory, web, messaging, home automation, databases, email, MCP apps, and more
 - **9 channel adapters** (Telegram, SMS, WhatsApp, Teams, Slack, Discord, Signal, email, webhooks) with DM policy, allowlists, and signature validation

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Use this page as the map. If you are unsure where to go next, the groups below a
 | --- | --- |
 | [USER_GUIDE.md](USER_GUIDE.md) | Providers, tools, skills, channels, and the day-to-day operator surface. |
 | [RELEASES.md](RELEASES.md) | Desktop download bundles, release assets, and signing/notarization status. |
+| [AgentQi Mobile](https://github.com/agentqi/agentqi-mobile) | Open-source .NET MAUI Android companion for monitoring and operating an OpenClaw.NET gateway; includes build-from-source instructions. |
 | [TOOLS_GUIDE.md](TOOLS_GUIDE.md) | Native and optional tool catalog, behavior, and configuration. |
 | [MCPAPP.md](MCPAPP.md) | MCP App manifest discovery, lifecycle management, tool bridging, resources, prompts, and UI bundles. |
 | [tokenjuice.md](tokenjuice.md) | Deterministic, rule-driven tool output reduction before tool results enter model context. |

--- a/docs/SITE_MAP.md
+++ b/docs/SITE_MAP.md
@@ -46,6 +46,7 @@ Use this map when turning the Markdown docs into a documentation website. It kee
 | Reference | Glossary | [GLOSSARY.md](GLOSSARY.md) |
 | Integrations | Semantic Kernel | [SEMANTIC_KERNEL.md](SEMANTIC_KERNEL.md) |
 | Integrations | MCP Apps | [MCPAPP.md](MCPAPP.md) |
+| Integrations | AgentQi Mobile Companion | [agentqi/agentqi-mobile](https://github.com/agentqi/agentqi-mobile) |
 | Integrations | Microsoft Agent Framework | [integrations/microsoft-agent-framework.md](integrations/microsoft-agent-framework.md) |
 | Integrations | Workflow Backends | [workflow-backends.md](workflow-backends.md) |
 | Integrations | Enterprise Channels (Feishu/DingTalk/WeCom) | [ENTERPRISE_CHANNELS.md](ENTERPRISE_CHANNELS.md) |
@@ -132,6 +133,7 @@ Reference
 Integrations
   Semantic Kernel
   MCP Apps
+  AgentQi Mobile Companion
   Microsoft Agent Framework
   Workflow Backends
   Microsoft Teams


### PR DESCRIPTION
## What changed

- link the public AgentQi Mobile repository from the main README
- add the Android companion to the documentation index and site map
- point users to the source repository and build-from-source guide

## Why

AgentQi Mobile is now available as a public, self-buildable .NET MAUI companion for OpenClaw.NET gateways.

## Validation

- `git diff --check`
- public mobile repository CI passed (18 tests plus asset and metadata validation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AgentQi Mobile Companion to the project navigation and feature listings.
  * Documented AgentQi Mobile as an open-source Android companion for monitoring and operating an OpenClaw.NET gateway.
  * Added build-from-source guidance and updated the documentation site map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->