### PR TITLE
fix: avoid command session lock reentry

### DIFF
--- a/src/OpenClaw.Core/Pipeline/ChatCommandProcessor.cs
+++ b/src/OpenClaw.Core/Pipeline/ChatCommandProcessor.cs
@@ -84,7 +84,7 @@ public sealed class ChatCommandProcessor
     /// Returns true if a command was handled (and thus the pipeline should short-circuit the LLM).
     /// </summary>
     public async Task<(bool Handled, string? Response)> TryProcessCommandAsync(
-        Session session, string text, CancellationToken ct)
+        Session session, string text, CancellationToken ct, bool sessionLockHeld = false)
     {
         if (string.IsNullOrWhiteSpace(text) || !text.StartsWith('/'))
             return (false, null);
@@ -106,7 +106,7 @@ public sealed class ChatCommandProcessor
                 session.TotalInputTokens = 0;
                 session.TotalOutputTokens = 0;
                 _goalService?.ClearGoal(session.Id);
-                await _sessionManager.PersistAsync(session, ct);
+                await _sessionManager.PersistAsync(session, ct, sessionLockHeld);
                 return (true, "Session history has been reset. Starting fresh!");
 
             case "/model":
@@ -116,12 +116,12 @@ public sealed class ChatCommandProcessor
                 if (args.Equals("reset", StringComparison.OrdinalIgnoreCase) || args.Equals("clear", StringComparison.OrdinalIgnoreCase))
                 {
                     session.ModelOverride = null;
-                    await _sessionManager.PersistAsync(session, ct);
+                    await _sessionManager.PersistAsync(session, ct, sessionLockHeld);
                     return (true, "Model override cleared. Back to default.");
                 }
 
                 session.ModelOverride = args;
-                await _sessionManager.PersistAsync(session, ct);
+                await _sessionManager.PersistAsync(session, ct, sessionLockHeld);
                 return (true, $"Model override set to: {args}");
 
             case "/usage":
@@ -136,7 +136,7 @@ public sealed class ChatCommandProcessor
                 if (level is "off" or "low" or "medium" or "high")
                 {
                     session.ReasoningEffort = level == "off" ? null : level;
-                    await _sessionManager.PersistAsync(session, ct);
+                    await _sessionManager.PersistAsync(session, ct, sessionLockHeld);
                     return (true, level == "off"
                         ? "Extended thinking disabled."
                         : $"Reasoning effort set to: {level}");
@@ -151,7 +151,7 @@ public sealed class ChatCommandProcessor
                 if (_compactCallback is not null)
                 {
                     var remainingTurns = await _compactCallback(session, ct);
-                    await _sessionManager.PersistAsync(session, ct);
+                    await _sessionManager.PersistAsync(session, ct, sessionLockHeld);
                     return (true, $"Compacted: {turnsBefore} turns → {remainingTurns} turns remaining.");
                 }
 
@@ -160,7 +160,7 @@ public sealed class ChatCommandProcessor
                 var removeCount = session.History.Count - keepRecent;
                 if (removeCount > 0)
                     session.History.RemoveRange(0, removeCount);
-                await _sessionManager.PersistAsync(session, ct);
+                await _sessionManager.PersistAsync(session, ct, sessionLockHeld);
                 return (true, $"Trimmed: {turnsBefore} turns → {session.History.Count} turns (kept last {keepRecent}).");
 
             case "/verbose":
@@ -170,13 +170,13 @@ public sealed class ChatCommandProcessor
                 if (args.Equals("on", StringComparison.OrdinalIgnoreCase))
                 {
                     session.VerboseMode = true;
-                    await _sessionManager.PersistAsync(session, ct);
+                    await _sessionManager.PersistAsync(session, ct, sessionLockHeld);
                     return (true, "Verbose mode enabled. Tool calls and token counts will be shown.");
                 }
                 if (args.Equals("off", StringComparison.OrdinalIgnoreCase))
                 {
                     session.VerboseMode = false;
-                    await _sessionManager.PersistAsync(session, ct);
+                    await _sessionManager.PersistAsync(session, ct, sessionLockHeld);
                     return (true, "Verbose mode disabled.");
                 }
                 return (true, "Usage: /verbose on|off");
@@ -196,19 +196,19 @@ public sealed class ChatCommandProcessor
                 if (args.Equals("on", StringComparison.OrdinalIgnoreCase))
                 {
                     session.ResponseMode = SessionResponseModes.ConciseOps;
-                    await _sessionManager.PersistAsync(session, ct);
+                    await _sessionManager.PersistAsync(session, ct, sessionLockHeld);
                     return (true, "Concise operational mode enabled.");
                 }
                 if (args.Equals("off", StringComparison.OrdinalIgnoreCase))
                 {
                     session.ResponseMode = SessionResponseModes.Full;
-                    await _sessionManager.PersistAsync(session, ct);
+                    await _sessionManager.PersistAsync(session, ct, sessionLockHeld);
                     return (true, "Concise operational mode disabled for this session.");
                 }
                 if (args.Equals("auto", StringComparison.OrdinalIgnoreCase))
                 {
                     session.ResponseMode = SessionResponseModes.Default;
-                    await _sessionManager.PersistAsync(session, ct);
+                    await _sessionManager.PersistAsync(session, ct, sessionLockHeld);
                     return (true, "Concise mode reset to automatic behavior.");
                 }
                 return (true, "Usage: /concise on|off|auto");

--- a/src/OpenClaw.Gateway/A2A/OpenClawA2AExecutionBridge.cs
+++ b/src/OpenClaw.Gateway/A2A/OpenClawA2AExecutionBridge.cs
@@ -35,7 +35,8 @@ internal sealed class OpenClawA2AExecutionBridge : IOpenClawA2AExecutionBridge
         var (handled, commandResponse) = await runtime.CommandProcessor.TryProcessCommandAsync(
             session,
             request.UserText,
-            cancellationToken);
+            cancellationToken,
+            sessionLockHeld: true);
         if (handled)
         {
             if (!string.IsNullOrWhiteSpace(commandResponse))

--- a/src/OpenClaw.Gateway/Extensions/GatewayInboundMessageWorker.cs
+++ b/src/OpenClaw.Gateway/Extensions/GatewayInboundMessageWorker.cs
@@ -387,7 +387,11 @@ internal sealed class GatewayInboundMessageWorker
                                 }
                             }
 
-                            var (handled, cmdResponse) = await commandProcessor.TryProcessCommandAsync(session, msg.Text, processingCt);
+                            var (handled, cmdResponse) = await commandProcessor.TryProcessCommandAsync(
+                                session,
+                                msg.Text,
+                                processingCt,
+                                sessionLockHeld: true);
                             if (handled)
                             {
                                 if (cmdResponse is not null)

--- a/src/OpenClaw.Tests/ChatCommandProcessorTests.cs
+++ b/src/OpenClaw.Tests/ChatCommandProcessorTests.cs
@@ -91,6 +91,53 @@ public sealed class ChatCommandProcessorTests
         Assert.Contains("Prompt Cache: 512 read / 0 write", response, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("/new")]
+    [InlineData("/reset")]
+    [InlineData("/model deepseek-v4-flash")]
+    [InlineData("/model reset")]
+    [InlineData("/think low")]
+    [InlineData("/think off")]
+    [InlineData("/compact")]
+    [InlineData("/verbose on")]
+    [InlineData("/verbose off")]
+    [InlineData("/concise on")]
+    [InlineData("/concise off")]
+    [InlineData("/concise auto")]
+    public async Task PersistentCommand_WhenSessionLockAlreadyHeld_DoesNotReenterSessionLock(string commandText)
+    {
+        var store = new FileMemoryStore(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "openclaw-command-tests", Guid.NewGuid().ToString("N")), 4);
+        var sessionManager = new SessionManager(store, new GatewayConfig(), NullLogger.Instance);
+        var processor = new ChatCommandProcessor(sessionManager);
+        var session = new Session
+        {
+            Id = "sess-held-lock-command",
+            ChannelId = "websocket",
+            SenderId = "user1",
+            ModelOverride = "previous-model",
+            VerboseMode = true
+        };
+        session.History.AddRange(
+        [
+            new ChatTurn { Role = "user", Content = "u1" },
+            new ChatTurn { Role = "assistant", Content = "a1" },
+            new ChatTurn { Role = "user", Content = "u2" },
+            new ChatTurn { Role = "assistant", Content = "a2" }
+        ]);
+
+        await using var sessionLock = await sessionManager.AcquireSessionLockAsync(session.Id, TestContext.Current.CancellationToken);
+
+        var commandTask = processor.TryProcessCommandAsync(
+            session,
+            commandText,
+            TestContext.Current.CancellationToken,
+            sessionLockHeld: true);
+        var (handled, response) = await commandTask.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+
+        Assert.True(handled);
+        Assert.False(string.IsNullOrWhiteSpace(response));
+    }
+
     [Fact]
     public async Task Concise_Command_TogglesSessionResponseMode()
     {


### PR DESCRIPTION
## Summary
- pass session lock ownership through `ChatCommandProcessor` persistence paths
- mark gateway inbound and A2A command execution as already holding the session lock
- add regression coverage for persistent slash commands under a held session lock

## Root Cause
Gateway and A2A command execution acquire the per-session `SemaphoreSlim` before invoking `ChatCommandProcessor`. Persistent slash commands then called the `PersistAsync(session, ct)` overload, which attempted to acquire the same non-reentrant lock again and could deadlock.

Closes #185

## Validation
- `dotnet test src/OpenClaw.Tests --filter FullyQualifiedName~ChatCommandProcessorTests`
- `dotnet build src/OpenClaw.Gateway/OpenClaw.Gateway.csproj`
- `dotnet test src/OpenClaw.Tests --filter "FullyQualifiedName~ChatCommandProcessorTests|FullyQualifiedName~GatewayWorkersTests"`
- `dotnet test src/OpenClaw.Tests --no-build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of chat commands when a session is already locked.
  * Prevented certain commands from re-entering the session lock while saving session changes.
  * Maintained reliable processing for commands such as reset, model, thinking, compaction, and verbosity controls.

* **Tests**
  * Added coverage for persistent commands executed during an active session lock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->