### PR TITLE
Handle WebSocket heartbeats end-to-end

### DIFF
--- a/src/OpenClaw.Channels/WebSocketChannel.cs
+++ b/src/OpenClaw.Channels/WebSocketChannel.cs
@@ -123,6 +123,9 @@ public sealed class WebSocketChannel : IChannelAdapter
                         continue;
                 }
 
+                if (IsIgnorableClientEnvelope(parsed.Type))
+                    continue;
+
                 var msg = new InboundMessage
                 {
                     ChannelId = ChannelId,
@@ -142,8 +145,7 @@ public sealed class WebSocketChannel : IChannelAdapter
                     ValueJson = parsed.CanvasEnvelope?.ValueJson,
                     Sequence = parsed.CanvasEnvelope?.Sequence,
                     ApprovalId = parsed.ApprovalId,
-                    Approved = parsed.Approved,
-                    RequestCancellation = ct
+                    Approved = parsed.Approved
                 };
 
                 if (OnMessageReceived is not null)
@@ -558,6 +560,11 @@ public sealed class WebSocketChannel : IChannelAdapter
                 return new ParsedWsInbound(true, env.Type, "", env.SessionId, env.MessageId, env.ReplyToMessageId, env.ApprovalId, env.Approved);
             }
 
+            if (env is not null && IsIgnorableClientEnvelope(env.Type))
+            {
+                return new ParsedWsInbound(true, env.Type, "", env.SessionId, env.MessageId, env.ReplyToMessageId, null, null);
+            }
+
             if (env is not null && IsCanvasClientEnvelope(env.Type))
             {
                 var text = env.Type switch
@@ -585,6 +592,9 @@ public sealed class WebSocketChannel : IChannelAdapter
 
         return new ParsedWsInbound(false, null, payload, null, null, null, null, null, null);
     }
+
+    private static bool IsIgnorableClientEnvelope(string? type)
+        => type is "heartbeat";
 
     private async ValueTask HandleCanvasClientEnvelopeAsync(string clientId, WsClientEnvelope envelope, CancellationToken ct)
     {

--- a/src/OpenClaw.Channels/WebSocketChannel.cs
+++ b/src/OpenClaw.Channels/WebSocketChannel.cs
@@ -130,6 +130,7 @@ public sealed class WebSocketChannel : IChannelAdapter
                 {
                     ChannelId = ChannelId,
                     SenderId = clientId,
+                    RequestCancellation = ct,
                     AuthenticatedUserId = authenticatedUserId,
                     SessionId = parsed.SessionId,
                     Type = parsed.Type,

--- a/src/OpenClaw.Gateway/wwwroot/webchat.js
+++ b/src/OpenClaw.Gateway/wwwroot/webchat.js
@@ -173,7 +173,11 @@ let pendingFileUrls = []; // non-image files queued for upload
 
 const WEBCHAT_CONFIG = {
     streamRenderDebounceMs: Math.max(20, Number(window.OPENCLAW_WEBCHAT_CONFIG?.streamRenderDebounceMs ?? 120)),
-    heartbeatIntervalMs: Math.max(1000, Number(window.OPENCLAW_WEBCHAT_CONFIG?.heartbeatIntervalMs ?? 45000)),
+    heartbeatIntervalMs: (() => {
+        const raw = Number(window.OPENCLAW_WEBCHAT_CONFIG?.heartbeatIntervalMs ?? 45000);
+        const safe = Number.isFinite(raw) ? raw : 45000;
+        return Math.min(2147483647, Math.max(1000, safe));
+    })(),
     initialReconnectDelayMs: Math.max(250, Number(window.OPENCLAW_WEBCHAT_CONFIG?.initialReconnectDelayMs ?? 1000)),
     maxReconnectDelayMs: Math.max(1000, Number(window.OPENCLAW_WEBCHAT_CONFIG?.maxReconnectDelayMs ?? 30000)),
     reconnectBackoffFactor: Math.max(1.1, Number(window.OPENCLAW_WEBCHAT_CONFIG?.reconnectBackoffFactor ?? 2)),

--- a/src/OpenClaw.Gateway/wwwroot/webchat.js
+++ b/src/OpenClaw.Gateway/wwwroot/webchat.js
@@ -145,6 +145,7 @@ let activeRawContent = "";
 let isAwaitingResponse = false;
 let reconnectAttempts = 0;
 let reconnectTimer = null;
+let heartbeatTimer = null;
 let streamRenderTimer = null;
 let liveResponseHasAudio = false;
 let liveAudioQueue = [];
@@ -172,6 +173,7 @@ let pendingFileUrls = []; // non-image files queued for upload
 
 const WEBCHAT_CONFIG = {
     streamRenderDebounceMs: Math.max(20, Number(window.OPENCLAW_WEBCHAT_CONFIG?.streamRenderDebounceMs ?? 120)),
+    heartbeatIntervalMs: Math.max(1000, Number(window.OPENCLAW_WEBCHAT_CONFIG?.heartbeatIntervalMs ?? 45000)),
     initialReconnectDelayMs: Math.max(250, Number(window.OPENCLAW_WEBCHAT_CONFIG?.initialReconnectDelayMs ?? 1000)),
     maxReconnectDelayMs: Math.max(1000, Number(window.OPENCLAW_WEBCHAT_CONFIG?.maxReconnectDelayMs ?? 30000)),
     reconnectBackoffFactor: Math.max(1.1, Number(window.OPENCLAW_WEBCHAT_CONFIG?.reconnectBackoffFactor ?? 2)),
@@ -944,6 +946,31 @@ function resetActiveResponse() {
     }
     activeResponseDiv = null;
     activeRawContent = '';
+}
+
+function clearHeartbeatTimer() {
+    if (!heartbeatTimer) {
+        return;
+    }
+
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+}
+
+function startHeartbeatLoop() {
+    clearHeartbeatTimer();
+
+    heartbeatTimer = setInterval(() => {
+        if (!ws || ws.readyState !== WebSocket.OPEN) {
+            return;
+        }
+
+        try {
+            ws.send(JSON.stringify({ type: 'heartbeat' }));
+        } catch (_) {
+            clearHeartbeatTimer();
+        }
+    }, WEBCHAT_CONFIG.heartbeatIntervalMs);
 }
 
 function createRow(type) {
@@ -2406,6 +2433,7 @@ async function openDoctorDiagnostics(addToChat = false) {
 }
 
 function connect() {
+    clearHeartbeatTimer();
     setConnectionState(reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
     appendSystem('Connecting to OpenClaw.NET Gateway...');
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -2427,6 +2455,7 @@ function connect() {
             reconnectTimer = null;
         }
         dismissFirstRunCard();
+        startHeartbeatLoop();
         refreshChatState();
         appendSystem('Connected successfully.');
         sendCanvasReady();
@@ -2566,6 +2595,7 @@ function connect() {
     };
 
     ws.onclose = (event) => {
+        clearHeartbeatTimer();
         updateComposerAvailability();
         resetActiveResponse();
 

--- a/src/OpenClaw.Tests/WebSocketChannelTests.cs
+++ b/src/OpenClaw.Tests/WebSocketChannelTests.cs
@@ -239,6 +239,27 @@ public sealed class WebSocketChannelTests
     }
 
     [Fact]
+    public async Task HandleConnectionAsync_IgnoresHeartbeatEnvelopeWithoutUserMessage()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig { MaxMessageBytes = 1024 });
+        var ws = new TestWebSocket();
+
+        ws.QueueReceiveText("""{"type":"heartbeat"}""");
+        ws.QueueClose();
+
+        var messageObserved = false;
+        channel.OnMessageReceived += (_, _) =>
+        {
+            messageObserved = true;
+            return ValueTask.CompletedTask;
+        };
+
+        await channel.HandleConnectionAsync(ws, "client", IPAddress.Loopback, TestContext.Current.CancellationToken);
+
+        Assert.False(messageObserved);
+    }
+
+    [Fact]
     public async Task HandleConnectionAsync_RoutesCanvasAckAndResultsWithoutUserMessage()
     {
         var channel = new WebSocketChannel(new WebSocketConfig { MaxMessageBytes = 2048 });

--- a/src/OpenClaw.Tests/WebSocketChannelTests.cs
+++ b/src/OpenClaw.Tests/WebSocketChannelTests.cs
@@ -209,6 +209,35 @@ public sealed class WebSocketChannelTests
     }
 
     [Fact]
+    public async Task HandleConnectionAsync_ForwardsRequestCancellationToken()
+    {
+        var channel = new WebSocketChannel(new WebSocketConfig { MaxMessageBytes = 1024 });
+        var ws = new TestWebSocket();
+
+        ws.QueueReceiveText("hello");
+        ws.QueueClose();
+
+        InboundMessage? received = null;
+        channel.OnMessageReceived += (msg, _) =>
+        {
+            received = msg;
+            return ValueTask.CompletedTask;
+        };
+
+        using var requestCts = new CancellationTokenSource();
+        await channel.HandleConnectionAsync(
+            ws,
+            "client",
+            IPAddress.Loopback,
+            requestCts.Token,
+            authenticatedUserId: null);
+
+        Assert.NotNull(received);
+        Assert.Equal(requestCts.Token, received!.RequestCancellation);
+        Assert.True(received.RequestCancellation.CanBeCanceled);
+    }
+
+    [Fact]
     public async Task HandleConnectionAsync_RoutesCanvasReadyWithoutUserMessage()
     {
         var channel = new WebSocketChannel(new WebSocketConfig { MaxMessageBytes = 1024 });


### PR DESCRIPTION
## Description
Adds a periodic heartbeat sender in `webchat.js` (configurable via `heartbeatIntervalMs`) and ensures heartbeat timers are started/stopped with socket lifecycle events. On the server side, `WebSocketChannel` now treats `heartbeat` envelopes as ignorable so they do not emit inbound user messages. Includes a new test to verify heartbeat envelopes are ignored.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Tests
- [ ] Build/CI
- [ ] Governance/process
- [ ] Refactoring (no functional changes)

## Validation

- [x] `dotnet restore OpenClaw.Net.slnx`
- [x] `dotnet build OpenClaw.Net.slnx --configuration Release --no-restore`
- [x] `dotnet test OpenClaw.Net.slnx --configuration Release --no-build`
- [ ] `dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build`

## Review Notes

- [x] I considered NativeAOT compatibility
- [x] I considered security posture and unsafe defaults
- [ ] I updated docs/tests where needed
- [ ] This PR is scoped and does not mix unrelated changes

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style implementation of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed locally (`dotnet test`)
- [ ] I have updated the documentation (README.md, comments) if required
- [ ] I have checked for security implications (input validation, authorization)
- [ ] I have checked the relevant [maintainer review checklist](../docs/maintainers/review-checklist.md)
- [ ] I have disclosed whether this directly supports a company or customer use case



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic WebSocket heartbeat messages to keep web chat connections active.
  * Heartbeat interval is configurable, with a safe, bounded default.

* **Bug Fixes**
  * Heartbeat envelopes are ignored and no longer surface as user messages.
  * Properly forwards the request cancellation token for inbound message processing.

* **Tests**
  * Added coverage ensuring heartbeat envelopes don’t trigger incoming user messages.
  * Added coverage verifying the cancellation token is passed through correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->