### PR TITLE
Refresh MiniMax model profile capabilities and endpoints

### DIFF
--- a/src/OpenClaw.Gateway/appsettings.json
+++ b/src/OpenClaw.Gateway/appsettings.json
@@ -176,7 +176,7 @@
           "Id": "minimax-m2-7",
           "Provider": "openai-compatible",
           "Model": "MiniMax-M2.7",
-          "BaseUrl": "",
+          "BaseUrl": "https://api.minimax.io/v1",
           "ApiKey": "env:LLM_API_KEY",
           "Tags": [
             "cheap",
@@ -197,7 +197,7 @@
             "SupportsSystemMessages": true,
             "SupportsImageInput": false,
             "SupportsAudioInput": false,
-            "MaxContextTokens": 128000,
+            "MaxContextTokens": 204800,
             "MaxOutputTokens": 8192
           }
         },
@@ -205,7 +205,7 @@
           "Id": "minimax-m3",
           "Provider": "openai-compatible",
           "Model": "MiniMax-M3",
-          "BaseUrl": "",
+          "BaseUrl": "https://api.minimax.io/v1",
           "ApiKey": "env:LLM_API_KEY",
           "Tags": [
             "balanced",
@@ -225,8 +225,9 @@
             "SupportsReasoningEffort": false,
             "SupportsSystemMessages": true,
             "SupportsImageInput": true,
+            "SupportsVideoInput": true,
             "SupportsAudioInput": false,
-            "MaxContextTokens": 256000,
+            "MaxContextTokens": 1000000,
             "MaxOutputTokens": 16384
           }
         }


### PR DESCRIPTION
Reason: Refresh stale MiniMax model profile capabilities and endpoints to match the current provider parameters.

This updates the two MiniMax OpenAI-compatible model profiles in the gateway sample configuration:

- `MiniMax-M2.7`: set `BaseUrl` to the OpenAI-compatible endpoint (`https://api.minimax.io/v1`) and raise `MaxContextTokens` from `128000` to `204800`.
- `MiniMax-M3`: set `BaseUrl` to the OpenAI-compatible endpoint (`https://api.minimax.io/v1`), raise `MaxContextTokens` from `256000` to `1000000`, and add `SupportsVideoInput: true` so video input support is declared.

The previous profiles declared stale context windows, left both `BaseUrl` values empty, and did not declare video input support for `MiniMax-M3`.

Checks:
- Validated `src/OpenClaw.Gateway/appsettings.json` parses as strict JSON with `jq`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added video-input support for the MiniMax M3 profile.
  * Increased MiniMax M3 context capacity to 1,000,000 tokens.
  * Increased MiniMax M2.7 context capacity to 204,800 tokens.
  * Updated MiniMax profiles to use the current API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->