### PR TITLE
Fix owner-qualified ClawHub compatibility smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Restore
         run: dotnet restore src/OpenClaw.Tests

--- a/compat/public-smoke.json
+++ b/compat/public-smoke.json
@@ -6,8 +6,9 @@
       "category": "pure-skill",
       "kind": "clawhub-skill",
       "slug": "peekaboo",
+      "ref": "@steipete/peekaboo",
       "version": "1.0.0",
-      "expectedRelativePath": "skills/peekaboo/SKILL.md"
+      "expectedRelativePath": "skills/@steipete/peekaboo/SKILL.md"
     },
     {
       "id": "agentseo",

--- a/src/OpenClaw.Core/Compatibility/PublicCompatibilityCatalog.cs
+++ b/src/OpenClaw.Core/Compatibility/PublicCompatibilityCatalog.cs
@@ -85,6 +85,7 @@ public static class PublicCompatibilityCatalog
             PackageName = entry.PackageName,
             PluginId = entry.PluginId,
             SkillSlug = entry.Slug,
+            SkillRef = entry.Ref,
             PackageVersion = entry.Version,
             ExpectedRelativePath = entry.ExpectedRelativePath,
             ConfigJsonExample = entry.ConfigJson,
@@ -100,11 +101,12 @@ public static class PublicCompatibilityCatalog
     {
         if (string.Equals(entry.Kind, "clawhub-skill", StringComparison.Ordinal))
         {
-            var slug = RequireField(entry.Slug, entry, "slug");
+            _ = RequireField(entry.Slug, entry, "slug");
+            var skillRef = RequireField(entry.Ref, entry, "ref");
             var suffix = string.IsNullOrWhiteSpace(entry.Version)
                 ? string.Empty
                 : $" --version {entry.Version}";
-            return $"openclaw clawhub install {slug}{suffix}";
+            return $"openclaw clawhub install {skillRef}{suffix}";
         }
 
         var spec = RequireField(entry.Spec, entry, "spec");
@@ -204,6 +206,7 @@ internal sealed class CompatibilityCatalogManifestEntry
     public string? PackageName { get; set; }
     public string? PluginId { get; set; }
     public string? Slug { get; set; }
+    public string? Ref { get; set; }
     public string? Version { get; set; }
     public string? ExpectedStatus { get; set; }
     public string? ExpectedRelativePath { get; set; }

--- a/src/OpenClaw.Core/Models/CompatibilityCatalogModels.cs
+++ b/src/OpenClaw.Core/Models/CompatibilityCatalogModels.cs
@@ -22,6 +22,7 @@ public sealed class CompatibilityCatalogEntry
     public string? PackageName { get; init; }
     public string? PluginId { get; init; }
     public string? SkillSlug { get; init; }
+    public string? SkillRef { get; init; }
     public string? PackageVersion { get; init; }
     public string? ExpectedRelativePath { get; init; }
     public string? ConfigJsonExample { get; init; }

--- a/src/OpenClaw.Core/Skills/SkillLoader.cs
+++ b/src/OpenClaw.Core/Skills/SkillLoader.cs
@@ -160,8 +160,9 @@ public static class SkillLoader
 
     /// <summary>
     /// Scan a directory for subdirectories containing SKILL.md.
-    /// When <paramref name="scanSubdirectories"/> is true, descends into nested
-    /// subdirectories (e.g. subskills/docx/SKILL.md) so that parent skill
+    /// Owner-qualified ClawHub paths (for example @owner/skill/SKILL.md) are
+    /// always recognized. When <paramref name="scanSubdirectories"/> is true,
+    /// also descends into arbitrary nested subdirectories so parent skill
     /// directories can bundle sub-skills.
     /// </summary>
     private static void ScanDirectory(
@@ -193,11 +194,14 @@ public static class SkillLoader
                 }
             }
 
-            var searchOption = scanSubdirectories
-                ? SearchOption.AllDirectories
-                : SearchOption.TopDirectoryOnly;
+            var skillDirectories = scanSubdirectories
+                ? Directory.GetDirectories(rootDir, "*", SearchOption.AllDirectories)
+                : Directory.GetDirectories(rootDir, "*", SearchOption.TopDirectoryOnly)
+                    .Concat(Directory.GetDirectories(rootDir, "@*", SearchOption.TopDirectoryOnly)
+                        .SelectMany(ownerDir => Directory.GetDirectories(ownerDir, "*", SearchOption.TopDirectoryOnly)))
+                    .Distinct(StringComparer.Ordinal);
 
-            foreach (var skillDir in Directory.GetDirectories(rootDir, "*", searchOption))
+            foreach (var skillDir in skillDirectories)
             {
                 var skillFile = Path.Combine(skillDir, "SKILL.md");
                 if (!File.Exists(skillFile))

--- a/src/OpenClaw.Core/Skills/SkillLoader.cs
+++ b/src/OpenClaw.Core/Skills/SkillLoader.cs
@@ -194,12 +194,31 @@ public static class SkillLoader
                 }
             }
 
-            var skillDirectories = scanSubdirectories
-                ? Directory.GetDirectories(rootDir, "*", SearchOption.AllDirectories)
-                : Directory.GetDirectories(rootDir, "*", SearchOption.TopDirectoryOnly)
-                    .Concat(Directory.GetDirectories(rootDir, "@*", SearchOption.TopDirectoryOnly)
-                        .SelectMany(ownerDir => Directory.GetDirectories(ownerDir, "*", SearchOption.TopDirectoryOnly)))
-                    .Distinct(StringComparer.Ordinal);
+            var enumerationOptions = new EnumerationOptions
+            {
+                RecurseSubdirectories = scanSubdirectories,
+                IgnoreInaccessible = true,
+                AttributesToSkip = FileAttributes.ReparsePoint
+            };
+            var topLevelDirectories = EnumerateSkillDirectories(rootDir, "*", enumerationOptions, logger);
+            var ownerQualifiedDirectories = scanSubdirectories
+                ? []
+                : EnumerateSkillDirectories(rootDir, "@*", enumerationOptions, logger)
+                    .SelectMany(ownerDir => EnumerateSkillDirectories(ownerDir, "*", enumerationOptions, logger))
+                    .ToArray();
+            var duplicateOwnerSlugs = ownerQualifiedDirectories
+                .GroupBy(Path.GetFileName, StringComparer.OrdinalIgnoreCase)
+                .Where(static group => group.Count() > 1)
+                .Select(static group => group.Key)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var duplicateSlug in duplicateOwnerSlugs.OrderBy(static slug => slug, StringComparer.OrdinalIgnoreCase))
+                logger.LogWarning("Skipping duplicate owner-qualified skill slug '{Slug}' under {Dir}", duplicateSlug, rootDir);
+
+            var skillDirectories = topLevelDirectories
+                .Concat(ownerQualifiedDirectories.Where(dir => !duplicateOwnerSlugs.Contains(Path.GetFileName(dir))))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(static dir => dir, StringComparer.Ordinal);
 
             foreach (var skillDir in skillDirectories)
             {
@@ -228,6 +247,23 @@ public static class SkillLoader
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to scan skill directory {Dir}", rootDir);
+        }
+    }
+
+    private static string[] EnumerateSkillDirectories(
+        string rootDir,
+        string searchPattern,
+        EnumerationOptions options,
+        ILogger logger)
+    {
+        try
+        {
+            return Directory.EnumerateDirectories(rootDir, searchPattern, options).ToArray();
+        }
+        catch (Exception ex) when (IsPathException(ex))
+        {
+            logger.LogWarning(ex, "Skipping inaccessible skill directory {Dir}", rootDir);
+            return [];
         }
     }
 

--- a/src/OpenClaw.Tests/CompatibilityCatalogTests.cs
+++ b/src/OpenClaw.Tests/CompatibilityCatalogTests.cs
@@ -35,6 +35,8 @@ public sealed class CompatibilityCatalogTests
         Assert.Equal("compatible", item.CompatibilityStatus);
         Assert.Equal("clawhub-skill", item.Kind);
         Assert.Equal("peekaboo", item.SkillSlug);
+        Assert.Equal("@steipete/peekaboo", item.SkillRef);
+        Assert.Equal("openclaw clawhub install @steipete/peekaboo --version 1.0.0", item.InstallCommand);
     }
 
     [Fact]
@@ -80,5 +82,27 @@ public sealed class CompatibilityCatalogTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => PublicCompatibilityCatalog.CreateCatalog(manifest));
         Assert.Contains("'slug'", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateCatalog_SkillWithoutRef_FailsFast()
+    {
+        var manifest = new CompatibilityCatalogManifest
+        {
+            Version = 1,
+            Entries =
+            [
+                new CompatibilityCatalogManifestEntry
+                {
+                    Id = "missing-ref",
+                    Category = "pure-skill",
+                    Kind = "clawhub-skill",
+                    Slug = "example"
+                }
+            ]
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => PublicCompatibilityCatalog.CreateCatalog(manifest));
+        Assert.Contains("'ref'", ex.Message, StringComparison.Ordinal);
     }
 }

--- a/src/OpenClaw.Tests/CompatibilityCommandsTests.cs
+++ b/src/OpenClaw.Tests/CompatibilityCommandsTests.cs
@@ -18,6 +18,7 @@ public sealed class CompatibilityCommandsTests
         var text = output.ToString();
         Assert.Contains("\"version\":2", text, StringComparison.Ordinal);
         Assert.Contains("\"skillSlug\":\"peekaboo\"", text, StringComparison.Ordinal);
+        Assert.Contains("\"skillRef\":\"@steipete/peekaboo\"", text, StringComparison.Ordinal);
         Assert.DoesNotContain("\"kind\":\"npm-plugin\"", text, StringComparison.Ordinal);
         Assert.Equal(string.Empty, error.ToString());
     }

--- a/src/OpenClaw.Tests/PublicCompatibilitySmokeTests.cs
+++ b/src/OpenClaw.Tests/PublicCompatibilitySmokeTests.cs
@@ -53,6 +53,7 @@ public sealed class PublicCompatibilitySmokeTests : IDisposable
     private async Task VerifyClawHubSkillAsync(CompatibilityCatalogEntry entry)
     {
         Assert.False(string.IsNullOrWhiteSpace(entry.SkillSlug), $"Smoke entry '{entry.Id}' must declare a skill slug.");
+        Assert.False(string.IsNullOrWhiteSpace(entry.SkillRef), $"Smoke entry '{entry.Id}' must declare an owner-qualified skill ref.");
         Assert.False(string.IsNullOrWhiteSpace(entry.PackageVersion), $"Smoke entry '{entry.Id}' must declare a skill version.");
         Assert.False(string.IsNullOrWhiteSpace(entry.ExpectedRelativePath), $"Smoke entry '{entry.Id}' must declare expectedRelativePath.");
 
@@ -64,7 +65,7 @@ public sealed class PublicCompatibilitySmokeTests : IDisposable
             "--workdir", workdir,
             "--dir", "skills",
             "--no-input",
-            "install", entry.SkillSlug!,
+            "install", entry.SkillRef!,
             "--version", entry.PackageVersion!);
 
         var expectedPath = Path.Combine(workdir, entry.ExpectedRelativePath!

--- a/src/OpenClaw.Tests/SkillTests.cs
+++ b/src/OpenClaw.Tests/SkillTests.cs
@@ -1407,6 +1407,43 @@ public class SkillLoaderTests
     }
 
     [Fact]
+    public void LoadAll_DefaultScanSubdirectories_LoadsOwnerQualifiedSkills()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-test-skills-owner-qualified-{Guid.NewGuid():N}");
+        var skillDir = Path.Combine(tempDir, "skills", "@steipete", "peekaboo");
+        Directory.CreateDirectory(skillDir);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), """
+                ---
+                name: peekaboo
+                description: Owner-qualified ClawHub skill
+                ---
+                Peekaboo instructions.
+                """);
+
+            var config = new SkillsConfig
+            {
+                Enabled = true,
+                Load = new SkillLoadConfig { IncludeBundled = false, IncludeManaged = false }
+            };
+            var logger = new TestLogger();
+
+            var skills = SkillLoader.LoadAll(config, tempDir, logger);
+
+            var skill = Assert.Single(skills);
+            Assert.Equal("peekaboo", skill.Name);
+            Assert.Equal(SkillSource.Workspace, skill.Source);
+            Assert.Equal(skillDir, skill.Location);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void LoadAll_ScanSubdirectories_LoadsNestedWorkspaceSkills()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-test-skills-recursive-{Guid.NewGuid():N}");

--- a/src/OpenClaw.Tests/SkillTests.cs
+++ b/src/OpenClaw.Tests/SkillTests.cs
@@ -1411,7 +1411,9 @@ public class SkillLoaderTests
     {
         var tempDir = Path.Join(Path.GetTempPath(), $"openclaw-test-skills-owner-qualified-{Guid.NewGuid():N}");
         var skillDir = Path.Join(tempDir, "skills", "@steipete", "peekaboo");
+        var nestedSkillDir = Path.Join(skillDir, "nested");
         Directory.CreateDirectory(skillDir);
+        Directory.CreateDirectory(nestedSkillDir);
 
         try
         {
@@ -1421,6 +1423,13 @@ public class SkillLoaderTests
                 description: Owner-qualified ClawHub skill
                 ---
                 Peekaboo instructions.
+                """);
+            File.WriteAllText(Path.Join(nestedSkillDir, "SKILL.md"), """
+                ---
+                name: nested-owner-skill
+                description: Must remain excluded from a shallow scan
+                ---
+                Nested instructions.
                 """);
 
             var config = new SkillsConfig
@@ -1436,6 +1445,7 @@ public class SkillLoaderTests
             Assert.Equal("peekaboo", skill.Name);
             Assert.Equal(SkillSource.Workspace, skill.Source);
             Assert.Equal(skillDir, skill.Location);
+            Assert.DoesNotContain(skills, item => item.Name == "nested-owner-skill");
         }
         finally
         {

--- a/src/OpenClaw.Tests/SkillTests.cs
+++ b/src/OpenClaw.Tests/SkillTests.cs
@@ -1409,13 +1409,13 @@ public class SkillLoaderTests
     [Fact]
     public void LoadAll_DefaultScanSubdirectories_LoadsOwnerQualifiedSkills()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"openclaw-test-skills-owner-qualified-{Guid.NewGuid():N}");
-        var skillDir = Path.Combine(tempDir, "skills", "@steipete", "peekaboo");
+        var tempDir = Path.Join(Path.GetTempPath(), $"openclaw-test-skills-owner-qualified-{Guid.NewGuid():N}");
+        var skillDir = Path.Join(tempDir, "skills", "@steipete", "peekaboo");
         Directory.CreateDirectory(skillDir);
 
         try
         {
-            File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), """
+            File.WriteAllText(Path.Join(skillDir, "SKILL.md"), """
                 ---
                 name: peekaboo
                 description: Owner-qualified ClawHub skill
@@ -1436,6 +1436,56 @@ public class SkillLoaderTests
             Assert.Equal("peekaboo", skill.Name);
             Assert.Equal(SkillSource.Workspace, skill.Source);
             Assert.Equal(skillDir, skill.Location);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void LoadAll_DuplicateOwnerQualifiedSlugs_AreRejectedDeterministically()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), $"openclaw-test-skills-owner-collision-{Guid.NewGuid():N}");
+        var firstSkillDir = Path.Join(tempDir, "skills", "@owner-a", "peekaboo");
+        var secondSkillDir = Path.Join(tempDir, "skills", "@owner-b", "peekaboo");
+        var unrelatedSkillDir = Path.Join(tempDir, "skills", "unrelated");
+        Directory.CreateDirectory(firstSkillDir);
+        Directory.CreateDirectory(secondSkillDir);
+        Directory.CreateDirectory(unrelatedSkillDir);
+
+        try
+        {
+            const string peekabooSkill = """
+                ---
+                name: peekaboo
+                description: Duplicate owner-qualified skill
+                ---
+                Peekaboo instructions.
+                """;
+            File.WriteAllText(Path.Join(firstSkillDir, "SKILL.md"), peekabooSkill);
+            File.WriteAllText(Path.Join(secondSkillDir, "SKILL.md"), peekabooSkill);
+            File.WriteAllText(Path.Join(unrelatedSkillDir, "SKILL.md"), """
+                ---
+                name: unrelated
+                description: Adjacent skill
+                ---
+                Unrelated instructions.
+                """);
+
+            var config = new SkillsConfig
+            {
+                Enabled = true,
+                Load = new SkillLoadConfig { IncludeBundled = false, IncludeManaged = false }
+            };
+            var logger = new CapturingTestLogger();
+
+            var skills = SkillLoader.LoadAll(config, tempDir, logger);
+
+            var skill = Assert.Single(skills);
+            Assert.Equal("unrelated", skill.Name);
+            Assert.Contains(logger.WarningMessages, message =>
+                message.Contains("duplicate owner-qualified skill slug 'peekaboo'", StringComparison.OrdinalIgnoreCase));
         }
         finally
         {


### PR DESCRIPTION
## Summary

- pin the public Peekaboo compatibility fixture to the upstream `@steipete/peekaboo` reference
- load ClawHub's owner-qualified `@owner/skill` directory layout without enabling arbitrary recursive scanning
- use Node 22 for the public compatibility smoke job to satisfy the current ClawHub CLI engine requirement

## Validation

- `dotnet test src/OpenClaw.Tests -c Release --no-build --no-restore` (2,438 passed)
- `OPENCLAW_PUBLIC_SMOKE=1 dotnet test src/OpenClaw.Tests -c Release --no-build --no-restore --filter 'Category=PublicSmoke'` (passed against live public packages)
- `git diff --check`

Fixes the scheduled CI failure caused by `AMBIGUOUS_SKILL_SLUG` after ClawHub added a second `peekaboo` slug owner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering skills stored in owner-qualified paths, such as `skills/@owner/skill`.
  * Compatibility catalogs now support explicit skill references for more reliable ClawHub installations.
* **Bug Fixes**
  * Improved skill installation commands to use the correct owner-qualified reference.
  * Added validation to prevent incomplete ClawHub skill entries from being used.
* **Compatibility**
  * Updated the Peekaboo compatibility entry and smoke checks to use its scoped skill reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->