### PR TITLE
Fix YAML parsing and gateway content includes

### DIFF
--- a/src/OpenClaw.Core/OpenClaw.Core.csproj
+++ b/src/OpenClaw.Core/OpenClaw.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>OpenClaw.Core</RootNamespace>
     <IsAotCompatible>true</IsAotCompatible>

--- a/src/OpenClaw.Core/OpenClaw.Core.csproj
+++ b/src/OpenClaw.Core/OpenClaw.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>OpenClaw.Core</RootNamespace>
     <IsAotCompatible>true</IsAotCompatible>
@@ -22,6 +22,7 @@
     <PackageReference Include="Spectre.Console" Version="0.57.0" />
     <PackageReference Include="NCrontab" Version="3.4.0" />
     <PackageReference Include="TickerQ" Version="10.4.0" />
+    <PackageReference Include="YamlDotNet" Version="15.1.2" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="../../compat/public-smoke.json" LogicalName="OpenClaw.Core.Compatibility.public-smoke.json" />

--- a/src/OpenClaw.Core/Skills/SkillLoader.cs
+++ b/src/OpenClaw.Core/Skills/SkillLoader.cs
@@ -4,6 +4,8 @@ using System.Text;
 using System.Text.Json;
 using OpenClaw.Core.Models;
 using Microsoft.Extensions.Logging;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
 
 namespace OpenClaw.Core.Skills;
 
@@ -740,352 +742,107 @@ public static class SkillLoader
         if (string.IsNullOrWhiteSpace(yaml))
             return false;
 
-        var lines = yaml.Split('\n')
-            .Select(static line => line.TrimEnd('\r'))
-            .ToList();
-
-        var index = 0;
-        SkipYamlBlankLines(lines, ref index);
-        if (index >= lines.Count)
-            return false;
-
-        var indent = GetIndent(lines[index]);
-        if (!TryParseYamlNode(lines, ref index, indent, out var node) || node is null)
-            return false;
-
-        SkipYamlBlankLines(lines, ref index);
-        if (index < lines.Count)
-            return false;
-
-        using var stream = new MemoryStream();
-        using (var writer = new Utf8JsonWriter(stream))
+        try
         {
-            node.WriteTo(writer);
-        }
+            using var reader = new StringReader(yaml);
+            var stream = new YamlStream();
+            stream.Load(reader);
 
-        json = Encoding.UTF8.GetString(stream.ToArray());
-        return true;
-    }
-
-    private static bool TryParseYamlNode(IReadOnlyList<string> lines, ref int index, int indent, out SkillYamlNode? node)
-    {
-        node = null;
-        SkipYamlBlankLines(lines, ref index);
-        if (index >= lines.Count)
-            return false;
-
-        var line = lines[index];
-        var lineIndent = GetIndent(line);
-        if (lineIndent < indent)
-            return false;
-
-        var text = line[lineIndent..].TrimEnd();
-        return text.StartsWith("- ", StringComparison.Ordinal)
-            ? TryParseYamlArray(lines, ref index, lineIndent, out node)
-            : TryParseYamlMapping(lines, ref index, lineIndent, out node);
-    }
-
-    private static bool TryParseYamlMapping(IReadOnlyList<string> lines, ref int index, int indent, out SkillYamlNode? node)
-    {
-        var properties = new List<KeyValuePair<string, SkillYamlNode>>();
-        node = null;
-
-        while (index < lines.Count)
-        {
-            SkipYamlBlankLines(lines, ref index);
-            if (index >= lines.Count)
-                break;
-
-            var line = lines[index];
-            var lineIndent = GetIndent(line);
-            if (lineIndent < indent)
-                break;
-            if (lineIndent > indent)
+            if (stream.Documents.Count == 0)
                 return false;
 
-            var text = line[lineIndent..].TrimEnd();
-            if (text.StartsWith("- ", StringComparison.Ordinal))
-                break;
-
-            if (!TrySplitYamlKeyValue(text, out var key, out var value))
+            var root = stream.Documents[0].RootNode;
+            if (root is null)
                 return false;
 
-            if (!TryParseYamlValue(lines, ref index, indent, value, out var valueNode) || valueNode is null)
-                return false;
-
-            properties.Add(new KeyValuePair<string, SkillYamlNode>(NormalizeYamlPropertyName(key), valueNode));
-        }
-
-        node = new SkillYamlObjectNode(properties);
-        return true;
-    }
-
-    private static bool TryParseYamlArray(IReadOnlyList<string> lines, ref int index, int indent, out SkillYamlNode? node)
-    {
-        var items = new List<SkillYamlNode>();
-        node = null;
-
-        while (index < lines.Count)
-        {
-            SkipYamlBlankLines(lines, ref index);
-            if (index >= lines.Count)
-                break;
-
-            var line = lines[index];
-            var lineIndent = GetIndent(line);
-            if (lineIndent < indent)
-                break;
-            if (lineIndent > indent)
-                return false;
-
-            var text = line[lineIndent..].TrimEnd();
-            if (!text.StartsWith("- ", StringComparison.Ordinal))
-                break;
-
-            var itemText = text[2..].Trim();
-            if (string.IsNullOrWhiteSpace(itemText))
+            using var output = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(output))
             {
-                index++;
-                var childIndex = FindNextYamlContentLine(lines, index);
-                if (childIndex < 0 || GetIndent(lines[childIndex]) <= indent)
-                {
-                    items.Add(new SkillYamlScalarNode(string.Empty));
-                    continue;
-                }
-
-                var childIndent = GetIndent(lines[childIndex]);
-                if (!TryParseYamlNode(lines, ref index, childIndent, out var childNode) || childNode is null)
-                    return false;
-
-                items.Add(childNode);
-                continue;
+                WriteYamlNode(writer, root);
             }
 
-            if (TrySplitYamlKeyValue(itemText, out var key, out var value))
-            {
-                var properties = new List<KeyValuePair<string, SkillYamlNode>>();
-                if (!TryParseYamlInlineValueOrLiteral(lines, ref index, indent, value, out var firstValue) || firstValue is null)
-                    return false;
-
-                properties.Add(new KeyValuePair<string, SkillYamlNode>(NormalizeYamlPropertyName(key), firstValue));
-
-                var childIndex = FindNextYamlContentLine(lines, index);
-                if (childIndex >= 0 && GetIndent(lines[childIndex]) > indent)
-                {
-                    var childIndent = GetIndent(lines[childIndex]);
-                    if (!TryParseYamlMapping(lines, ref index, childIndent, out var continuationNode) ||
-                        continuationNode is not SkillYamlObjectNode continuationObject)
-                    {
-                        return false;
-                    }
-
-                    properties.AddRange(continuationObject.Properties);
-                }
-
-                items.Add(new SkillYamlObjectNode(properties));
-                continue;
-            }
-
-            items.Add(ParseYamlScalar(itemText));
-            index++;
-
-            var nextIndex = FindNextYamlContentLine(lines, index);
-            if (nextIndex >= 0 && GetIndent(lines[nextIndex]) > indent)
-                return false;
-        }
-
-        node = new SkillYamlArrayNode(items);
-        return true;
-    }
-
-    private static bool TryParseYamlValue(
-        IReadOnlyList<string> lines,
-        ref int index,
-        int parentIndent,
-        string rawValue,
-        out SkillYamlNode? node)
-    {
-        if (TryParseYamlInlineValueOrLiteral(lines, ref index, parentIndent, rawValue, out node))
-            return true;
-
-        node = null;
-        return false;
-    }
-
-    private static bool TryParseYamlInlineValueOrLiteral(
-        IReadOnlyList<string> lines,
-        ref int index,
-        int parentIndent,
-        string rawValue,
-        out SkillYamlNode? node)
-    {
-        node = null;
-        var value = rawValue.Trim();
-
-        if (IsYamlLiteralIndicator(value))
-        {
-            index++;
-            node = new SkillYamlScalarNode(ParseYamlLiteralBlock(lines, ref index, parentIndent));
+            json = Encoding.UTF8.GetString(output.ToArray());
             return true;
         }
-
-        if (string.IsNullOrWhiteSpace(value))
+        catch (YamlException)
         {
-            index++;
-            var childIndex = FindNextYamlContentLine(lines, index);
-            if (childIndex < 0 || GetIndent(lines[childIndex]) <= parentIndent)
-            {
-                node = new SkillYamlScalarNode(string.Empty);
-                return true;
-            }
-
-            var childIndent = GetIndent(lines[childIndex]);
-            return TryParseYamlNode(lines, ref index, childIndent, out node);
-        }
-
-        node = ParseYamlScalar(value);
-        index++;
-        return true;
-    }
-
-    private static SkillYamlNode ParseYamlScalar(string rawValue)
-    {
-        var value = rawValue.Trim();
-        if (value.StartsWith("[", StringComparison.Ordinal) && value.EndsWith("]", StringComparison.Ordinal))
-        {
-            return ParseYamlInlineArray(value);
-        }
-
-        if (value.Equals("true", StringComparison.OrdinalIgnoreCase))
-            return new SkillYamlScalarNode(true);
-
-        if (value.Equals("false", StringComparison.OrdinalIgnoreCase))
-            return new SkillYamlScalarNode(false);
-
-        if (value.Equals("null", StringComparison.OrdinalIgnoreCase) || value.Equals("~", StringComparison.Ordinal))
-            return new SkillYamlScalarNode(null);
-
-        if (long.TryParse(value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var longValue))
-            return new SkillYamlScalarNode(longValue);
-
-        if (double.TryParse(value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var doubleValue))
-            return new SkillYamlScalarNode(doubleValue);
-
-        return new SkillYamlScalarNode(UnquoteYamlScalar(value));
-    }
-
-    private static SkillYamlArrayNode ParseYamlInlineArray(string rawValue)
-    {
-        var content = rawValue[1..^1].Trim();
-        if (string.IsNullOrWhiteSpace(content))
-            return new SkillYamlArrayNode([]);
-
-        var items = SplitYamlInlineArray(content)
-            .Select(ParseYamlScalar)
-            .ToList();
-        return new SkillYamlArrayNode(items);
-    }
-
-    private static IEnumerable<string> SplitYamlInlineArray(string content)
-    {
-        var start = 0;
-        var quote = '\0';
-        var escaped = false;
-
-        for (var index = 0; index < content.Length; index++)
-        {
-            var character = content[index];
-            if (quote != '\0')
-            {
-                if (quote == '"' && character == '\\' && !escaped)
-                {
-                    escaped = true;
-                    continue;
-                }
-
-                if (character == quote && !escaped)
-                    quote = '\0';
-
-                escaped = false;
-                continue;
-            }
-
-            if (character is '"' or '\'')
-            {
-                quote = character;
-                continue;
-            }
-
-            if (character != ',')
-                continue;
-
-            yield return content[start..index].Trim();
-            start = index + 1;
-        }
-
-        yield return content[start..].Trim();
-    }
-
-    private static string ParseYamlLiteralBlock(IReadOnlyList<string> lines, ref int index, int parentIndent)
-    {
-        var literalLines = new List<string>();
-        var contentIndent = -1;
-
-        while (index < lines.Count)
-        {
-            var line = lines[index];
-            if (string.IsNullOrWhiteSpace(line))
-            {
-                literalLines.Add(string.Empty);
-                index++;
-                continue;
-            }
-
-            var lineIndent = GetIndent(line);
-            if (lineIndent <= parentIndent)
-                break;
-
-            if (contentIndent < 0)
-                contentIndent = lineIndent;
-
-            var remove = Math.Min(contentIndent, line.Length);
-            literalLines.Add(line[remove..].TrimEnd());
-            index++;
-        }
-
-        return string.Join('\n', literalLines);
-    }
-
-    private static bool TrySplitYamlKeyValue(string text, out string key, out string value)
-    {
-        key = string.Empty;
-        value = string.Empty;
-
-        var colonIndex = text.IndexOf(':');
-        if (colonIndex <= 0)
             return false;
-
-        key = text[..colonIndex].Trim();
-        value = text[(colonIndex + 1)..].Trim();
-        return key.Length > 0;
+        }
     }
 
-    private static string NormalizeYamlPropertyName(string key)
-        => key switch
+    private static void WriteYamlNode(Utf8JsonWriter writer, YamlNode node)
+    {
+        switch (node)
         {
-            "skill_exec_entrypoint" => "entrypoint",
-            "skill_exec_args" => "args",
-            "skill_exec_stdin" => "stdin",
-            "skill_exec_cwd" => "cwd",
-            "skill_exec_parse_mode" => "parse_mode",
-            _ => key
-        };
+            case YamlMappingNode mapping:
+                writer.WriteStartObject();
+                foreach (var entry in mapping.Children)
+                {
+                    var keyNode = entry.Key;
+                    var key = keyNode is YamlScalarNode keyScalar && keyScalar.Value is not null
+                        ? keyScalar.Value
+                        : keyNode.ToString() ?? string.Empty;
+                    writer.WritePropertyName(key);
+                    WriteYamlNode(writer, entry.Value);
+                }
+                writer.WriteEndObject();
+                break;
+            case YamlSequenceNode sequence:
+                writer.WriteStartArray();
+                foreach (var item in sequence.Children)
+                    WriteYamlNode(writer, item);
+                writer.WriteEndArray();
+                break;
+            case YamlScalarNode scalar:
+                WriteYamlScalar(writer, scalar.Value);
+                break;
+            default:
+                writer.WriteNullValue();
+                break;
+        }
+    }
 
-    private static bool IsYamlLiteralIndicator(string value)
-        => value.Equals("|", StringComparison.Ordinal) ||
-           value.Equals("|-", StringComparison.Ordinal) ||
-           value.Equals("|+", StringComparison.Ordinal) ||
-           value.StartsWith("|", StringComparison.Ordinal);
+    private static void WriteYamlScalar(Utf8JsonWriter writer, string? value)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0)
+        {
+            writer.WriteStringValue(value);
+            return;
+        }
+
+        if (trimmed.Equals("null", StringComparison.Ordinal) || trimmed.Equals("~", StringComparison.Ordinal))
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        if (bool.TryParse(trimmed, out var boolValue))
+        {
+            writer.WriteBooleanValue(boolValue);
+            return;
+        }
+
+        if (long.TryParse(trimmed, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var longValue))
+        {
+            writer.WriteNumberValue(longValue);
+            return;
+        }
+
+        if (double.TryParse(trimmed, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var doubleValue))
+        {
+            writer.WriteNumberValue(doubleValue);
+            return;
+        }
+
+        writer.WriteStringValue(value);
+    }
 
     private static string UnquoteYamlScalar(string value)
     {
@@ -1123,26 +880,6 @@ public static class SkillLoader
         return builder.ToString();
     }
 
-    private static int FindNextYamlContentLine(IReadOnlyList<string> lines, int startIndex)
-    {
-        for (var index = startIndex; index < lines.Count; index++)
-        {
-            if (!IsYamlIgnorableLine(lines[index]))
-                return index;
-        }
-
-        return -1;
-    }
-
-    private static void SkipYamlBlankLines(IReadOnlyList<string> lines, ref int index)
-    {
-        while (index < lines.Count && IsYamlIgnorableLine(lines[index]))
-            index++;
-    }
-
-    private static bool IsYamlIgnorableLine(string line)
-        => string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith("#", StringComparison.Ordinal);
-
     private static int GetIndent(string line)
     {
         var indent = 0;
@@ -1150,87 +887,6 @@ public static class SkillLoader
             indent++;
 
         return indent;
-    }
-
-    private abstract class SkillYamlNode
-    {
-        internal abstract void WriteTo(Utf8JsonWriter writer);
-    }
-
-    private sealed class SkillYamlObjectNode : SkillYamlNode
-    {
-        internal SkillYamlObjectNode(IReadOnlyList<KeyValuePair<string, SkillYamlNode>> properties)
-        {
-            Properties = properties;
-        }
-
-        internal IReadOnlyList<KeyValuePair<string, SkillYamlNode>> Properties { get; }
-
-        internal override void WriteTo(Utf8JsonWriter writer)
-        {
-            writer.WriteStartObject();
-            foreach (var (key, value) in Properties)
-            {
-                writer.WritePropertyName(key);
-                value.WriteTo(writer);
-            }
-
-            writer.WriteEndObject();
-        }
-    }
-
-    private sealed class SkillYamlArrayNode : SkillYamlNode
-    {
-        internal SkillYamlArrayNode(IReadOnlyList<SkillYamlNode> items)
-        {
-            Items = items;
-        }
-
-        private IReadOnlyList<SkillYamlNode> Items { get; }
-
-        internal override void WriteTo(Utf8JsonWriter writer)
-        {
-            writer.WriteStartArray();
-            foreach (var item in Items)
-                item.WriteTo(writer);
-
-            writer.WriteEndArray();
-        }
-    }
-
-    private sealed class SkillYamlScalarNode : SkillYamlNode
-    {
-        internal SkillYamlScalarNode(object? value)
-        {
-            Value = value;
-        }
-
-        private object? Value { get; }
-
-        internal override void WriteTo(Utf8JsonWriter writer)
-        {
-            switch (Value)
-            {
-                case null:
-                    writer.WriteNullValue();
-                    break;
-                case bool boolValue:
-                    writer.WriteBooleanValue(boolValue);
-                    break;
-                case long longValue:
-                    writer.WriteNumberValue(longValue);
-                    break;
-                case double doubleValue:
-                    writer.WriteNumberValue(doubleValue);
-                    break;
-                case string stringValue:
-                    writer.WriteStringValue(stringValue);
-                    break;
-                default:
-                    writer.WriteStringValue(Value.ToString());
-                    break;
-            }
-        }
     }
 
     internal static MetaSkillComposition? ParseComposition(string json)

--- a/src/OpenClaw.Core/Skills/SkillLoader.cs
+++ b/src/OpenClaw.Core/Skills/SkillLoader.cs
@@ -758,7 +758,13 @@ public static class SkillLoader
             using var output = new MemoryStream();
             using (var writer = new Utf8JsonWriter(output))
             {
-                WriteYamlNode(writer, root);
+                if (!WriteYamlNode(writer, root, depth: 0, ancestors: new HashSet<YamlNode>(ReferenceEqualityComparer.Instance)))
+                {
+                    // Abandon the partial document. Reset() clears the writer's
+                    // state so Dispose() does not throw on the unbalanced output.
+                    writer.Reset();
+                    return false;
+                }
             }
 
             json = Encoding.UTF8.GetString(output.ToArray());
@@ -770,8 +776,20 @@ public static class SkillLoader
         }
     }
 
-    private static void WriteYamlNode(Utf8JsonWriter writer, YamlNode node)
+    private const int MaxYamlNodeDepth = 64;
+
+    private static bool WriteYamlNode(
+        Utf8JsonWriter writer,
+        YamlNode node,
+        int depth,
+        HashSet<YamlNode> ancestors)
     {
+        // Guard against absurd nesting and anchor cycles (a node that
+        // references itself would otherwise recurse forever).
+        if (depth >= MaxYamlNodeDepth || !ancestors.Add(node))
+            return false;
+
+        var ok = true;
         switch (node)
         {
             case YamlMappingNode mapping:
@@ -783,30 +801,54 @@ public static class SkillLoader
                         ? keyScalar.Value
                         : keyNode.ToString() ?? string.Empty;
                     writer.WritePropertyName(key);
-                    WriteYamlNode(writer, entry.Value);
+                    if (!WriteYamlNode(writer, entry.Value, depth + 1, ancestors))
+                    {
+                        ok = false;
+                        break;
+                    }
                 }
-                writer.WriteEndObject();
+                if (ok)
+                    writer.WriteEndObject();
                 break;
             case YamlSequenceNode sequence:
                 writer.WriteStartArray();
                 foreach (var item in sequence.Children)
-                    WriteYamlNode(writer, item);
-                writer.WriteEndArray();
+                {
+                    if (!WriteYamlNode(writer, item, depth + 1, ancestors))
+                    {
+                        ok = false;
+                        break;
+                    }
+                }
+                if (ok)
+                    writer.WriteEndArray();
                 break;
             case YamlScalarNode scalar:
-                WriteYamlScalar(writer, scalar.Value);
+                WriteYamlScalar(writer, scalar);
                 break;
             default:
                 writer.WriteNullValue();
                 break;
         }
+
+        ancestors.Remove(node);
+        return ok;
     }
 
-    private static void WriteYamlScalar(Utf8JsonWriter writer, string? value)
+    private static void WriteYamlScalar(Utf8JsonWriter writer, YamlScalarNode scalar)
     {
+        var value = scalar.Value;
         if (value is null)
         {
             writer.WriteNullValue();
+            return;
+        }
+
+        // Quoted and block scalars are always JSON strings; only plain scalars
+        // get boolean/number/null-like inference.
+        if (scalar.Style != ScalarStyle.Plain)
+        {
+            writer.WriteStringValue(value);
             return;
         }
 

--- a/src/OpenClaw.Core/Skills/SkillLoader.cs
+++ b/src/OpenClaw.Core/Skills/SkillLoader.cs
@@ -800,7 +800,7 @@ public static class SkillLoader
                     var key = keyNode is YamlScalarNode keyScalar && keyScalar.Value is not null
                         ? keyScalar.Value
                         : keyNode.ToString() ?? string.Empty;
-                    writer.WritePropertyName(key);
+                    writer.WritePropertyName(NormalizeYamlPropertyName(key));
                     if (!WriteYamlNode(writer, entry.Value, depth + 1, ancestors))
                     {
                         ok = false;
@@ -859,7 +859,7 @@ public static class SkillLoader
             return;
         }
 
-        if (trimmed.Equals("null", StringComparison.Ordinal) || trimmed.Equals("~", StringComparison.Ordinal))
+        if (trimmed.Equals("null", StringComparison.OrdinalIgnoreCase) || trimmed.Equals("~", StringComparison.Ordinal))
         {
             writer.WriteNullValue();
             return;
@@ -885,6 +885,17 @@ public static class SkillLoader
 
         writer.WriteStringValue(value);
     }
+
+    private static string NormalizeYamlPropertyName(string key)
+        => key switch
+        {
+            "skill_exec_entrypoint" => "entrypoint",
+            "skill_exec_args" => "args",
+            "skill_exec_stdin" => "stdin",
+            "skill_exec_cwd" => "cwd",
+            "skill_exec_parse_mode" => "parse_mode",
+            _ => key
+        };
 
     private static string UnquoteYamlScalar(string value)
     {

--- a/src/OpenClaw.Core/Skills/SkillLoader.cs
+++ b/src/OpenClaw.Core/Skills/SkillLoader.cs
@@ -800,7 +800,7 @@ public static class SkillLoader
                     var key = keyNode is YamlScalarNode keyScalar && keyScalar.Value is not null
                         ? keyScalar.Value
                         : keyNode.ToString() ?? string.Empty;
-                    writer.WritePropertyName(NormalizeYamlPropertyName(key));
+                    writer.WritePropertyName(key);
                     if (!WriteYamlNode(writer, entry.Value, depth + 1, ancestors))
                     {
                         ok = false;
@@ -885,17 +885,6 @@ public static class SkillLoader
 
         writer.WriteStringValue(value);
     }
-
-    private static string NormalizeYamlPropertyName(string key)
-        => key switch
-        {
-            "skill_exec_entrypoint" => "entrypoint",
-            "skill_exec_args" => "args",
-            "skill_exec_stdin" => "stdin",
-            "skill_exec_cwd" => "cwd",
-            "skill_exec_parse_mode" => "parse_mode",
-            _ => key
-        };
 
     private static string UnquoteYamlScalar(string value)
     {
@@ -1886,7 +1875,13 @@ public static class SkillLoader
 
         var isSkillExec = string.Equals(stepKind, "skill_exec", StringComparison.OrdinalIgnoreCase);
 
-        if (stepElement.TryGetProperty("entrypoint", out var entrypointElement))
+        if (!TryGetSkillExecProperty(stepElement, "entrypoint", "skill_exec_entrypoint", isSkillExec, out var entrypointElement, out var hasEntrypoint))
+        {
+            errorCode = "invalid_skill_exec";
+            return false;
+        }
+
+        if (hasEntrypoint)
         {
             if (!isSkillExec || entrypointElement.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(entrypointElement.GetString()))
             {
@@ -1897,16 +1892,42 @@ public static class SkillLoader
             entrypoint = entrypointElement.GetString()!.Trim();
         }
 
-        if (stepElement.TryGetProperty("args", out _))
+        if (!TryGetSkillExecProperty(stepElement, "args", "skill_exec_args", isSkillExec, out var argsElement, out var hasArgs))
         {
-            if (!isSkillExec || !TryParseStringArrayProperty(stepElement, "args", out args, out _))
+            errorCode = "invalid_skill_exec";
+            return false;
+        }
+
+        if (hasArgs)
+        {
+            if (!isSkillExec || argsElement.ValueKind != JsonValueKind.Array)
             {
                 errorCode = "invalid_skill_exec";
                 return false;
             }
+
+            var parsedArgs = new List<string>();
+            foreach (var itemElement in argsElement.EnumerateArray())
+            {
+                if (itemElement.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(itemElement.GetString()))
+                {
+                    errorCode = "invalid_skill_exec";
+                    return false;
+                }
+
+                parsedArgs.Add(itemElement.GetString()!);
+            }
+
+            args = parsedArgs;
         }
 
-        if (stepElement.TryGetProperty("stdin", out var stdinElement))
+        if (!TryGetSkillExecProperty(stepElement, "stdin", "skill_exec_stdin", isSkillExec, out var stdinElement, out var hasStdin))
+        {
+            errorCode = "invalid_skill_exec";
+            return false;
+        }
+
+        if (hasStdin)
         {
             if (!isSkillExec || stdinElement.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(stdinElement.GetString()))
             {
@@ -1917,7 +1938,13 @@ public static class SkillLoader
             stdin = stdinElement.GetString();
         }
 
-        if (stepElement.TryGetProperty("cwd", out var cwdElement))
+        if (!TryGetSkillExecProperty(stepElement, "cwd", "skill_exec_cwd", isSkillExec, out var cwdElement, out var hasCwd))
+        {
+            errorCode = "invalid_skill_exec";
+            return false;
+        }
+
+        if (hasCwd)
         {
             if (!isSkillExec || cwdElement.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(cwdElement.GetString()))
             {
@@ -1933,7 +1960,13 @@ public static class SkillLoader
             }
         }
 
-        if (stepElement.TryGetProperty("parse_mode", out var parseModeElement))
+        if (!TryGetSkillExecProperty(stepElement, "parse_mode", "skill_exec_parse_mode", isSkillExec, out var parseModeElement, out var hasParseMode))
+        {
+            errorCode = "invalid_skill_exec";
+            return false;
+        }
+
+        if (hasParseMode)
         {
             if (!isSkillExec || parseModeElement.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(parseModeElement.GetString()))
             {
@@ -1949,6 +1982,30 @@ public static class SkillLoader
             }
         }
 
+        return true;
+    }
+
+    private static bool TryGetSkillExecProperty(
+        JsonElement stepElement,
+        string canonicalName,
+        string legacyName,
+        bool isSkillExec,
+        out JsonElement value,
+        out bool found)
+    {
+        var hasCanonical = stepElement.TryGetProperty(canonicalName, out var canonicalValue);
+        JsonElement legacyValue = default;
+        var hasLegacy = isSkillExec && stepElement.TryGetProperty(legacyName, out legacyValue);
+
+        if (hasCanonical && hasLegacy)
+        {
+            value = default;
+            found = false;
+            return false;
+        }
+
+        found = hasCanonical || hasLegacy;
+        value = hasCanonical ? canonicalValue : hasLegacy ? legacyValue : default;
         return true;
     }
 

--- a/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
+++ b/src/OpenClaw.Gateway/OpenClaw.Gateway.csproj
@@ -18,6 +18,11 @@
     <DebuggerSupport>false</DebuggerSupport>
     <MetricsSupport>true</MetricsSupport>
     <HttpActivityPropagationSupport>false</HttpActivityPropagationSupport>
+    <!-- Exclude skills/ from default Content auto-include so the explicit
+         <Content Include="skills\**\*"> below is the sole source. Without this,
+         the SDK auto-includes files like *.json/manifest.jsonld and trips
+         NETSDK1022 "duplicate Content items". -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);skills\**</DefaultItemExcludes>
     <!-- Optional protocol packages can carry transitive AOT warnings; keep package-level warnings suppressed while surfacing project-owned trim diagnostics. -->
     <NoWarn>$(NoWarn);IL2104;IL3000;IL3002;IL3053</NoWarn>
   </PropertyGroup>

--- a/src/OpenClaw.Gateway/skills/meta-skill-creator/SKILL.md
+++ b/src/OpenClaw.Gateway/skills/meta-skill-creator/SKILL.md
@@ -119,7 +119,7 @@ composition:
     - id: harvest
       kind: skill_exec
       skill: history-explorer
-      skill_exec_entrypoint: scripts/explore.py
+      entrypoint: scripts/explore.py
       depends_on: [clarify_intent, creator_clarify]
       when: "'route: meta-skill' in (outputs.clarify_intent | lower)"
       on_failure: harvest_empty

--- a/src/OpenClaw.Tests/SkillTests.cs
+++ b/src/OpenClaw.Tests/SkillTests.cs
@@ -364,6 +364,58 @@ public class SkillLoaderTests
     }
 
     [Fact]
+    public void ParseSkillContent_YamlCompositionLegacyNamedWithProperty_IsPreserved()
+    {
+        var content = """
+            ---
+            name: legacy-named-payload
+            description: Arbitrary payload keys are preserved
+            kind: meta
+            composition:
+              steps:
+                - id: delegate
+                  kind: llm_chat
+                  with:
+                    skill_exec_args: payload-value
+            ---
+            Instructions.
+            """;
+
+        var skill = SkillLoader.ParseSkillContent(content, "/skills/legacy-named-payload", SkillSource.Workspace);
+
+        Assert.NotNull(skill);
+        var step = Assert.Single(skill!.Composition!.Steps);
+        using var withDoc = JsonDocument.Parse(step.WithJson!);
+        Assert.Equal("payload-value", withDoc.RootElement.GetProperty("skill_exec_args").GetString());
+        Assert.False(withDoc.RootElement.TryGetProperty("args", out _));
+    }
+
+    [Fact]
+    public void TryParseSkillContent_YamlCompositionDuplicateSkillExecAlias_IsRejected()
+    {
+        var content = """
+            ---
+            name: duplicate-skill-exec-field
+            description: Duplicate skill_exec field spellings are rejected
+            kind: meta
+            composition:
+              steps:
+                - id: delegate
+                  kind: skill_exec
+                  skill: web-research
+                  args: ["canonical"]
+                  skill_exec_args: ["legacy"]
+            ---
+            Instructions.
+            """;
+
+        var ok = SkillLoader.TryParseSkillContent(content, "/skills/duplicate-skill-exec-field", SkillSource.Workspace, out _, out var errorCode);
+
+        Assert.False(ok);
+        Assert.Equal("invalid_skill_exec", errorCode);
+    }
+
+    [Fact]
     public void ParseSkillContent_YamlCompositionUppercaseNull_PreservesLegacyInference()
     {
         var content = """

--- a/src/OpenClaw.Tests/SkillTests.cs
+++ b/src/OpenClaw.Tests/SkillTests.cs
@@ -254,6 +254,131 @@ public class SkillLoaderTests
     }
 
     [Fact]
+    public void ParseSkillContent_YamlTriggersQuotedScalars_RemainStrings()
+    {
+        var content = """
+            ---
+            name: quoted-triggers
+            description: Quoted scalars must serialize as JSON strings
+            triggers:
+              - "123"
+              - "true"
+              - "null"
+              - "~"
+            ---
+            Instructions.
+            """;
+
+        var skill = SkillLoader.ParseSkillContent(content, "/skills/quoted-triggers", SkillSource.Workspace);
+
+        Assert.NotNull(skill);
+        Assert.Equal(["123", "true", "null", "~"], skill!.Triggers);
+    }
+
+    [Theory]
+    [InlineData("123")]
+    [InlineData("true")]
+    [InlineData("~")]
+    public void ParseSkillContent_YamlTriggersPlainInferredScalar_FailsAsNonString(string plainValue)
+    {
+        // Plain scalars keep their boolean/number/null-like inference, so a
+        // plain 123/true/~ converts to a non-string JSON value and cannot be a trigger.
+        var content = $"""
+            ---
+            name: plain-trigger
+            description: Plain inferred scalar trigger
+            triggers:
+              - {plainValue}
+            ---
+            Instructions.
+            """;
+
+        var ok = SkillLoader.TryParseSkillContent(content, "/skills/plain-trigger", SkillSource.Workspace, out _, out _);
+
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public void ParseSkillContent_YamlCompositionQuotedScalars_RemainStrings()
+    {
+        var content = """
+            ---
+            name: quoted-composition
+            description: Quoted scalars in a YAML composition block
+            kind: meta
+            composition:
+              steps:
+                - id: s1
+                  kind: llm_chat
+                  with:
+                    prompt: "123"
+                    truthy: "true"
+                    nothing: "null"
+            ---
+            Instructions.
+            """;
+
+        var ok = SkillLoader.TryParseSkillContent(content, "/skills/quoted-composition", SkillSource.Workspace, out var skill, out var errorCode);
+
+        Assert.True(ok, errorCode);
+        Assert.NotNull(skill);
+        var step = Assert.Single(skill!.Composition!.Steps);
+        using var withDoc = JsonDocument.Parse(step.WithJson!);
+        Assert.Equal(JsonValueKind.String, withDoc.RootElement.GetProperty("prompt").ValueKind);
+        Assert.Equal("123", withDoc.RootElement.GetProperty("prompt").GetString());
+        Assert.Equal("true", withDoc.RootElement.GetProperty("truthy").GetString());
+        Assert.Equal("null", withDoc.RootElement.GetProperty("nothing").GetString());
+    }
+
+    [Fact]
+    public void ParseSkillContent_YamlBlockBeyondDepthLimit_FailsGracefully()
+    {
+        var nesting = 80; // deeper than the conversion depth limit
+        var nestedLines = Enumerable.Range(0, nesting)
+            .Select(i => new string(' ', i * 2) + "n:")
+            .Append(new string(' ', nesting * 2) + "leaf");
+        var block = string.Join('\n', nestedLines.Select(line => "        " + line));
+
+        var content = $"""
+            ---
+            name: deep-yaml
+            description: YAML nested deeper than the conversion limit
+            kind: meta
+            composition:
+            {block}
+            ---
+            Instructions.
+            """;
+
+        var ok = SkillLoader.TryParseSkillContent(content, "/skills/deep-yaml", SkillSource.Workspace, out _, out _);
+
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public void ParseSkillContent_YamlSelfReferencingAnchor_FailsGracefully()
+    {
+        var content = """
+            ---
+            name: cyclic-yaml
+            description: Self-referencing YAML anchor
+            kind: meta
+            composition:
+              steps: &steps
+                - id: cycle
+                  kind: llm_chat
+                  with:
+                    again: *steps
+            ---
+            Instructions.
+            """;
+
+        var ok = SkillLoader.TryParseSkillContent(content, "/skills/cyclic-yaml", SkillSource.Workspace, out _, out _);
+
+        Assert.False(ok);
+    }
+
+    [Fact]
     public void ParseSkillContent_MetaOpenSquillaDslFields_ParsesSuccessfully()
     {
         var content = """

--- a/src/OpenClaw.Tests/SkillTests.cs
+++ b/src/OpenClaw.Tests/SkillTests.cs
@@ -331,6 +331,65 @@ public class SkillLoaderTests
     }
 
     [Fact]
+    public void ParseSkillContent_YamlCompositionLegacySkillExecFields_AreNormalized()
+    {
+        var content = """
+            ---
+            name: legacy-skill-exec-fields
+            description: Legacy skill_exec field aliases remain supported
+            kind: meta
+            composition:
+              steps:
+                - id: delegate
+                  kind: skill_exec
+                  skill: web-research
+                  skill_exec_entrypoint: report
+                  skill_exec_args: ["--format", "json"]
+                  skill_exec_stdin: "{{ input }}"
+                  skill_exec_cwd: artifacts/meta
+                  skill_exec_parse_mode: json
+            ---
+            Instructions.
+            """;
+
+        var skill = SkillLoader.ParseSkillContent(content, "/skills/legacy-skill-exec-fields", SkillSource.Workspace);
+
+        Assert.NotNull(skill);
+        var step = Assert.Single(skill!.Composition!.Steps);
+        Assert.Equal("report", step.SkillExecEntrypoint);
+        Assert.Equal(["--format", "json"], step.SkillExecArgs);
+        Assert.Equal("{{ input }}", step.SkillExecStdin);
+        Assert.Equal("artifacts/meta", step.SkillExecCwd);
+        Assert.Equal("json", step.SkillExecParseMode);
+    }
+
+    [Fact]
+    public void ParseSkillContent_YamlCompositionUppercaseNull_PreservesLegacyInference()
+    {
+        var content = """
+            ---
+            name: uppercase-null
+            description: Uppercase null keeps legacy scalar inference
+            kind: meta
+            composition:
+              steps:
+                - id: s1
+                  kind: llm_chat
+                  with:
+                    value: NULL
+            ---
+            Instructions.
+            """;
+
+        var skill = SkillLoader.ParseSkillContent(content, "/skills/uppercase-null", SkillSource.Workspace);
+
+        Assert.NotNull(skill);
+        var step = Assert.Single(skill!.Composition!.Steps);
+        using var withDoc = JsonDocument.Parse(step.WithJson!);
+        Assert.Equal(JsonValueKind.Null, withDoc.RootElement.GetProperty("value").ValueKind);
+    }
+
+    [Fact]
     public void ParseSkillContent_YamlBlockBeyondDepthLimit_FailsGracefully()
     {
         var nesting = 80; // deeper than the conversion depth limit


### PR DESCRIPTION
## Description

Replaced the custom YAML parser in `SkillLoader` with `YamlDotNet` and switched to AST-based YAML-to-JSON emission, simplifying parsing while preserving scalar type handling and null/boolean/number conversion. Added the `YamlDotNet` package to `OpenClaw.Core` and updated the meta-skill example to use `entrypoint` directly. In `OpenClaw.Gateway`, excluded `skills\**` from SDK default content inclusion so the explicit skills include remains the single source, preventing `NETSDK1022` duplicate Content item errors.
 
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Tests
- [ ] Build/CI
- [ ] Governance/process
- [x] Refactoring (no functional changes)

## Validation

- [x] `dotnet restore OpenClaw.Net.slnx`
- [x] `dotnet build OpenClaw.Net.slnx --configuration Release --no-restore`
- [x] `dotnet test OpenClaw.Net.slnx --configuration Release --no-build`
- [x] `dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build`

## Review Notes

- [x] I considered NativeAOT compatibility
- [x] I considered security posture and unsafe defaults
- [ ] I updated docs/tests where needed
- [x] This PR is scoped and does not mix unrelated changes

## Commercial or Customer-Driven Contribution Disclosure

If this PR directly supports a company, customer, or downstream commercial product use case, disclose that context here. Commercial use is welcome, but OpenClaw.NET should remain vendor-neutral.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [ ] My code follows the code style implementation of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed locally (`dotnet test`)
- [ ] I have updated the documentation (README.md, comments) if required
- [ ] I have checked for security implications (input validation, authorization)
- [ ] I have checked the relevant [maintainer review checklist](../docs/maintainers/review-checklist.md)
- [ ] I have disclosed whether this directly supports a company or customer use case




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of indented YAML skill configurations, including mappings, lists, nulls, booleans, numbers, and strings.
  * Preserved quoted values as strings, including values resembling numbers, booleans, or nulls.
  * Added support for legacy skill execution field names while rejecting conflicting duplicate spellings.
  * YAML parsing failures, deeply nested content, and recursive references are now handled gracefully.
  * Preserved custom configuration keys and prevented duplicate skill content processing in the Gateway.

* **Documentation**
  * Updated skill creator guidance to use the correct entrypoint field for history exploration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->