### PR TITLE
fix(companion): stop owned gateway during desktop exit

### DIFF
--- a/src/OpenClaw.Companion/App.axaml.cs
+++ b/src/OpenClaw.Companion/App.axaml.cs
@@ -50,10 +50,11 @@ public partial class App : Application
             desktop.Exit += async (_, _) =>
             {
                 viewModel.StopApprovalsPolling();
+                // Desktop Exit does not await async event handlers. Stop the owned child
+                // synchronously before socket cleanup can yield and the process exits.
+                _managedGateway?.Dispose();
                 if (_client is not null)
                     await _client.DisposeAsync();
-                if (_managedGateway is not null)
-                    await _managedGateway.DisposeAsync();
             };
         }
 


### PR DESCRIPTION
The v0.2.0 desktop smoke reproduced an orphaned gateway: closing Companion exited the parent, but the owned gateway stayed alive on 127.0.0.1:18789 with PPID 1. The desktop Exit event does not await its async handler, so awaiting WebSocket disposal could prevent managed-process cleanup from running.

Stop the owned gateway synchronously before the handler reaches its first await. The existing bounded synchronous disposal also kills child processes. This keeps connection cleanup asynchronous while guaranteeing owned-process cleanup is attempted during shutdown.

Validation: the packaged pre-fix binary reproduced the failure during setup/start/restart/close testing. The locally published fixed candidate passed the same process-level check: it auto-started and connected, then closing the window exited both Companion PID 7938 and owned gateway PID 8138 and freed port 18789. The final release bundle will receive the same check before publication. The v0.2.0 release remains a draft until this passes.
