### PR TITLE
Explain session blockers and recovery steps

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,8 @@
 
 ## Recently Completed
 
+- **Run explanation and recovery view**: admin console, Dashboard, and Companion session details combine recorded run/goal state, goal notes, session-scoped pending approvals, checkpoints, and recent tool failure evidence with contextual recovery guidance. Existing timelines remain available for investigation; the view does not authorize or replay actions.
+
 - Browser sessions invalidate after local operator account updates, deletion, or disablement.
 - Goal completion accepts completed tool work; model status updates run alone and blocked transitions require three observations. Resume resets continuation and blocker counters.
 - Goal state is persisted atomically under the configured memory storage directory and restored lazily after restart.
@@ -63,7 +65,7 @@ The runtime already includes CLI insights, URL safety validation, and trajectory
 1. **Durable action reconciliation**: supplement persisted goals and completed-batch checkpoints with an action journal and provider idempotency keys. An interrupted external action with an unknown outcome must be reconciled before replay.
 2. **Real-run regression capture**: extend `RuntimeScenarioRunner` with redacted trajectory import and deterministic provider/tool replay fixtures.
 3. **Full-instance backup and restore**: extend upgrade rollback to include sessions, goals, schedules, governance records, and secret-reference manifests; validate restores in an isolated instance without dispatching actions.
-4. **Run explanation and recovery view**: connect existing timelines, approvals, and evidence to show the exact blocker and valid next recovery actions.
+4. **Guided recovery actions**: extend the completed explanation view with permission-aware recovery controls and action reconciliation once durable action outcomes are available.
 
 ## Security Hardening (Likely Breaking)
 

--- a/docs/RUN_RECOVERY.md
+++ b/docs/RUN_RECOVERY.md
@@ -35,3 +35,5 @@ The existing authenticated session detail endpoints now include an additive `rec
 It contains `status`, `summary`, `evidence`, and `nextSteps`. The arrays contain display text, not executable commands or action authorization. Older gateways may omit this object; clients continue showing their existing session details.
 
 Tool arguments and raw results are not copied into the explanation. Goal notes and failure messages retain the same operator access boundary as session details. A missing or corrupt goal store can prevent loading details; it is not silently represented as a healthy goal.
+
+Unavailable or corrupt goal data produces an unknown explanation; session details remain readable. An exhausted background continuation cap requires a new session for further automatic continuation.

--- a/docs/RUN_RECOVERY.md
+++ b/docs/RUN_RECOVERY.md
@@ -34,6 +34,6 @@ The existing authenticated session detail endpoints now include an additive `rec
 
 It contains `status`, `summary`, `evidence`, and `nextSteps`. The arrays contain display text, not executable commands or action authorization. Older gateways may omit this object; clients continue showing their existing session details.
 
-Tool arguments and raw results are not copied into the explanation. Goal notes and failure messages retain the same operator access boundary as session details. A missing or corrupt goal store can prevent loading details; it is not silently represented as a healthy goal.
+Tool arguments and raw results are not copied into the explanation. Goal notes and failure messages retain the same operator access boundary as session details. A corrupt or unavailable goal store yields an unknown explanation while session details remain readable.
 
 Unavailable or corrupt goal data produces an unknown explanation; session details remain readable. An exhausted background continuation cap requires a new session for further automatic continuation.

--- a/docs/RUN_RECOVERY.md
+++ b/docs/RUN_RECOVERY.md
@@ -1,0 +1,37 @@
+# Run explanation and recovery
+
+Open a session in the admin console, Dashboard, or Companion's Sessions tab. The **Run explanation and recovery** section shows a snapshot of the recorded state and the next steps appropriate to it. Refresh the session to see changes.
+
+The view combines:
+
+- Run state and the last recorded background stop reason.
+- Goal status, its status note, token usage, and budget when goals are enabled.
+- Pending approvals for this exact session, identified by approval ID and tool name.
+- The latest native tool-batch checkpoint and its recorded state.
+- Recorded failure codes and messages from the last tool batch for failed or blocked runs.
+
+Use the existing session timeline and approval history for the surrounding events. Missing evidence is not a diagnosis: a saved running state does not prove a worker is still alive, and an old checkpoint cannot establish whether a later interrupted external action took effect.
+
+## Recovery guidance
+
+| State | Next step |
+| --- | --- |
+| Approval pending | Inspect the matching IDs in Approvals and decide whether each action should proceed. Refresh after deciding. |
+| Goal paused or blocked | Resolve the recorded condition, send `/goal resume` in the same session, then send a follow-up message. |
+| Budget limited | Review token usage or continuation limits first. `/goal resume` does not increase a goal's token budget. Preserve its objective and results before replacing an exhausted goal. |
+| Failed | Inspect the timeline and failed tool evidence, resolve the cause, and verify any external effects before retrying. |
+| Running or continuing | Refresh the timeline for new activity before submitting duplicate work. |
+| Completed | Review the result; create a new goal for additional work. |
+
+These are instructions for an operator, not automatic recovery controls. Reading the view never changes a goal, decides an approval, dispatches a message, or replays a tool. Decisions remain subject to the existing permissions and approval policies.
+
+## API compatibility
+
+The existing authenticated session detail endpoints now include an additive `recovery` object:
+
+- `GET /admin/sessions/{id}`
+- `GET /api/integration/sessions/{id}` (also used by Companion and the client SDK)
+
+It contains `status`, `summary`, `evidence`, and `nextSteps`. The arrays contain display text, not executable commands or action authorization. Older gateways may omit this object; clients continue showing their existing session details.
+
+Tool arguments and raw results are not copied into the explanation. Goal notes and failure messages retain the same operator access boundary as session details. A missing or corrupt goal store can prevent loading details; it is not silently represented as a healthy goal.

--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Sessions.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.Sessions.cs
@@ -188,6 +188,13 @@ public sealed partial class MainWindowViewModel
                 $"History turns: {row.HistoryTurns}",
                 $"Tokens: {row.TotalTokens}"
             });
+            if (detail.Recovery is { } recovery)
+                SelectedSessionDetail += Environment.NewLine + Environment.NewLine
+                    + "Run explanation and recovery" + Environment.NewLine + recovery.Summary
+                    + Environment.NewLine + "Recorded evidence:" + Environment.NewLine
+                    + string.Join(Environment.NewLine, recovery.Evidence.Select(item => "• " + item))
+                    + Environment.NewLine + "Next steps:" + Environment.NewLine
+                    + string.Join(Environment.NewLine, recovery.NextSteps.Select(item => "• " + item));
             ReplaceItems(SessionTimelineRows, timeline.Events.Select(RuntimeEventRow.FromEntry));
             OnPropertyChanged(nameof(HasSessionTimelineRows));
         }

--- a/src/OpenClaw.Core/Models/AdminApiModels.cs
+++ b/src/OpenClaw.Core/Models/AdminApiModels.cs
@@ -160,6 +160,7 @@ public sealed class SessionBranchListResponse
 
 public sealed class AdminSessionDetailResponse
 {
+    public SessionRecoveryExplanation? Recovery { get; init; }
     public Session? Session { get; init; }
     public bool IsActive { get; init; }
     public int BranchCount { get; init; }

--- a/src/OpenClaw.Core/Models/IntegrationApiModels.cs
+++ b/src/OpenClaw.Core/Models/IntegrationApiModels.cs
@@ -19,6 +19,7 @@ public sealed class IntegrationSessionsResponse
 
 public sealed class IntegrationSessionDetailResponse
 {
+    public SessionRecoveryExplanation? Recovery { get; init; }
     public Session? Session { get; init; }
     public bool IsActive { get; init; }
     public int BranchCount { get; init; }

--- a/src/OpenClaw.Core/Models/Session.cs
+++ b/src/OpenClaw.Core/Models/Session.cs
@@ -1614,6 +1614,7 @@ public sealed class SessionDelegationChildSummary
 [JsonSerializable(typeof(SessionPromotionRequest))]
 [JsonSerializable(typeof(SessionPromotionResponse))]
 [JsonSerializable(typeof(SessionDiffResponse))]
+[JsonSerializable(typeof(SessionRecoveryExplanation))]
 [JsonSerializable(typeof(SessionTimelineResponse))]
 [JsonSerializable(typeof(SessionExportItem))]
 [JsonSerializable(typeof(List<SessionExportItem>))]

--- a/src/OpenClaw.Core/Models/SessionRecoveryExplanation.cs
+++ b/src/OpenClaw.Core/Models/SessionRecoveryExplanation.cs
@@ -1,0 +1,10 @@
+namespace OpenClaw.Core.Models;
+
+/// <summary>A read-only explanation of recorded run state, not a replay authorization.</summary>
+public sealed class SessionRecoveryExplanation
+{
+    public string Status { get; init; } = "unknown";
+    public string Summary { get; init; } = "";
+    public string[] Evidence { get; init; } = [];
+    public string[] NextSteps { get; init; } = [];
+}

--- a/src/OpenClaw.Core/Services/SessionRecoveryExplainer.cs
+++ b/src/OpenClaw.Core/Services/SessionRecoveryExplainer.cs
@@ -1,4 +1,6 @@
 using OpenClaw.Core.Models;
+using OpenClaw.Core.Abstractions;
+using System.Text.Json;
 using OpenClaw.Core.Models.Goal;
 using OpenClaw.Core.Pipeline;
 
@@ -6,6 +8,18 @@ namespace OpenClaw.Core.Services;
 
 public static class SessionRecoveryExplainer
 {
+    public static SessionRecoveryExplanation ExplainWithGoalStore(Session session, IGoalService? goals,
+        IEnumerable<ToolApprovalRequest> approvals)
+    {
+        try { return Explain(session, goals?.GetGoal(session.Id), approvals); }
+        catch (Exception ex) when (ex is IOException or InvalidDataException or JsonException or UnauthorizedAccessException)
+        {
+            return new() { Status = "unknown", Summary = "Goal state could not be loaded.",
+                Evidence = ["Persisted goal data is unavailable or corrupt; session history remains available."],
+                NextSteps = ["Inspect and restore the goal data before resuming. Do not treat unavailable goal state as a completed or absent goal."] };
+        }
+    }
+
     public static SessionRecoveryExplanation Explain(Session session, SessionGoal? goal,
         IEnumerable<ToolApprovalRequest> pendingApprovals)
     {
@@ -25,9 +39,11 @@ public static class SessionRecoveryExplainer
         }
         if (session.ExecutionCheckpoint is { } checkpoint)
             evidence.Add($"Checkpoint {checkpoint.CheckpointId}: {checkpoint.State}; {checkpoint.ToolCalls.Count} tool result(s); recorded {checkpoint.CreatedAtUtc:O}. A checkpoint does not prove the outcome of actions interrupted before it was saved.");
-        if (session.RunState is SessionRunState.Failed or SessionRunState.Blocked)
+        if (session.RunState is SessionRunState.Failed or SessionRunState.Blocked || goal?.Status == GoalStatus.Blocked)
         {
-            var lastToolTurn = session.History.LastOrDefault(turn => turn.ToolCalls is { Count: > 0 });
+            var lastToolTurn = session.History.LastOrDefault(turn => turn.Role == "assistant");
+            if (session.BackgroundRun is { } background && lastToolTurn?.Timestamp < background.LastContinuedAtUtc)
+                lastToolTurn = null;
             foreach (var tool in (lastToolTurn?.ToolCalls ?? []).Where(tool =>
                          !string.IsNullOrWhiteSpace(tool.FailureCode) || !string.IsNullOrWhiteSpace(tool.FailureMessage)).Take(5))
                 evidence.Add($"Last tool batch ({lastToolTurn!.Timestamp:O}): {tool.ToolName}; {tool.FailureCode ?? "failure"}; {tool.FailureMessage ?? "No failure message recorded."}");
@@ -51,7 +67,7 @@ public static class SessionRecoveryExplainer
         {
             if (session.BackgroundRun?.LastStopReason == "MaxContinuationTurnsReached")
                 return Result("budget_limited", "The background continuation limit stopped automatic progress.",
-                    "Review the completed work and continuation limit before sending a follow-up in this session.");
+                    "Preserve the completed work and start a new session for further automatic continuation. A follow-up in this session runs one turn but does not reset its exhausted continuation limit.");
             return Result("budget_limited", "A recorded budget limit stopped automatic progress.",
                 "Review token usage and the configured limits before continuing. Resuming a goal does not increase its token budget.",
                 "Preserve the current objective and results before replacing an exhausted goal with a newly budgeted goal.");

--- a/src/OpenClaw.Core/Services/SessionRecoveryExplainer.cs
+++ b/src/OpenClaw.Core/Services/SessionRecoveryExplainer.cs
@@ -1,0 +1,80 @@
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Models.Goal;
+using OpenClaw.Core.Pipeline;
+
+namespace OpenClaw.Core.Services;
+
+public static class SessionRecoveryExplainer
+{
+    public static SessionRecoveryExplanation Explain(Session session, SessionGoal? goal,
+        IEnumerable<ToolApprovalRequest> pendingApprovals)
+    {
+        var evidence = new List<string> { $"Recorded run state: {session.RunState}." };
+        var approvals = pendingApprovals.Where(a => a.SessionId == session.Id).ToArray();
+        if (goal is not null)
+        {
+            evidence.Add($"Goal: {goal.Status.ToDisplayName()}; tokens used: {goal.TokensUsed}; budget: {(goal.TokenBudget > 0 ? goal.TokenBudget.ToString() : "unlimited")}.");
+            if (!string.IsNullOrWhiteSpace(goal.StatusNote))
+                evidence.Add($"Goal status note: {goal.StatusNote}");
+        }
+        if (session.BackgroundRun is { } run)
+        {
+            evidence.Add($"Background continuations: {run.ContinuationCount}.");
+            if (!string.IsNullOrWhiteSpace(run.LastStopReason))
+                evidence.Add($"Last recorded stop reason: {run.LastStopReason}.");
+        }
+        if (session.ExecutionCheckpoint is { } checkpoint)
+            evidence.Add($"Checkpoint {checkpoint.CheckpointId}: {checkpoint.State}; {checkpoint.ToolCalls.Count} tool result(s); recorded {checkpoint.CreatedAtUtc:O}. A checkpoint does not prove the outcome of actions interrupted before it was saved.");
+        if (session.RunState is SessionRunState.Failed or SessionRunState.Blocked)
+        {
+            var lastToolTurn = session.History.LastOrDefault(turn => turn.ToolCalls is { Count: > 0 });
+            foreach (var tool in (lastToolTurn?.ToolCalls ?? []).Where(tool =>
+                         !string.IsNullOrWhiteSpace(tool.FailureCode) || !string.IsNullOrWhiteSpace(tool.FailureMessage)).Take(5))
+                evidence.Add($"Last tool batch ({lastToolTurn!.Timestamp:O}): {tool.ToolName}; {tool.FailureCode ?? "failure"}; {tool.FailureMessage ?? "No failure message recorded."}");
+        }
+        foreach (var approval in approvals)
+            evidence.Add($"Pending approval {approval.ApprovalId}: {approval.ToolName}.");
+
+        SessionRecoveryExplanation Result(string status, string summary, params string[] nextSteps)
+            => new() { Status = status, Summary = summary, Evidence = evidence.ToArray(), NextSteps = nextSteps };
+
+        if (approvals.Length > 0)
+            return Result("approval_pending", "This session has tool actions awaiting an operator decision.",
+                "Open Approvals and inspect the matching approval IDs. Approve or reject each action according to its intended effect.",
+                "Refresh this session after the decision; an approval can expire while this view is open.");
+        if (session.State == SessionState.Expired)
+            return Result("expired", "This session is expired.", "Inspect its history and start a new session if more work is needed.");
+        if (session.State == SessionState.Paused)
+            return Result("session_paused", "The session itself is paused.", "Review the session policy and history before resuming work through its original channel.");
+        // Run-level limits still apply even if a goal remains active.
+        if (session.RunState == SessionRunState.BudgetLimited || goal?.Status == GoalStatus.BudgetLimited || (goal?.IsBudgetExceeded == true && goal.Status != GoalStatus.Complete))
+        {
+            if (session.BackgroundRun?.LastStopReason == "MaxContinuationTurnsReached")
+                return Result("budget_limited", "The background continuation limit stopped automatic progress.",
+                    "Review the completed work and continuation limit before sending a follow-up in this session.");
+            return Result("budget_limited", "A recorded budget limit stopped automatic progress.",
+                "Review token usage and the configured limits before continuing. Resuming a goal does not increase its token budget.",
+                "Preserve the current objective and results before replacing an exhausted goal with a newly budgeted goal.");
+        }
+        if (goal?.Status == GoalStatus.UsageLimited)
+            return Result("usage_limited", "The goal is stopped by a recorded usage limit.", "Check provider availability and usage limits. After resolving them, send /goal resume in this session, then a follow-up message.");
+        if (session.RunState == SessionRunState.Failed)
+            return Result("failed", "The last run failed; review the evidence before retrying.",
+                "Inspect the session timeline and failed tool results to identify the cause.",
+                "Verify whether any interrupted external action took effect before sending a follow-up. Do not blindly repeat it.");
+        if (session.RunState == SessionRunState.Blocked || goal?.Status == GoalStatus.Blocked)
+            return Result("blocked", "Progress is blocked. The recorded goal note and timeline contain the available explanation.",
+                "Resolve the missing input, access, or external condition shown in the evidence.",
+                goal?.Status == GoalStatus.Blocked ? "Send /goal resume in this session, then a follow-up describing what changed." : "Send a follow-up in this session describing what changed.");
+        if (session.RunState == SessionRunState.Paused || goal?.Status == GoalStatus.Paused)
+            return Result("paused", "Automatic progress is paused.",
+                goal?.Status == GoalStatus.Paused ? "Review the goal status note, send /goal resume in this session, then a follow-up message." : "Review the timeline and send a follow-up when ready to continue.");
+        if (session.RunState is SessionRunState.Running or SessionRunState.Continuing)
+            return Result("in_progress", "The recorded state indicates work in progress; it is not proof of a live worker.", "Refresh the timeline to check for new activity before sending duplicate work.");
+        if (goal?.Status == GoalStatus.Active)
+            return Result("goal_active", "The goal is active, but the session has no recorded run in progress.", "Send a follow-up in this session to continue the active goal.");
+        if (goal?.Status == GoalStatus.Complete || session.RunState == SessionRunState.Completed)
+            return Result("completed", "The recorded run or goal is complete.", "Review the result and its evidence. Start a new goal for additional work.");
+        return Result("idle", "No active run or recorded blocker is available.", "Send a message in this session to start or continue work.");
+    }
+}

--- a/src/OpenClaw.Dashboard/Models/SessionInfo.cs
+++ b/src/OpenClaw.Dashboard/Models/SessionInfo.cs
@@ -28,7 +28,8 @@ public record SessionDetail(
     List<SessionMessage>? Messages,
     string? RunState = null,
     string? BackgroundRunObjective = null,
-    int BackgroundContinuationCount = 0
+    int BackgroundContinuationCount = 0,
+    OpenClaw.Core.Models.SessionRecoveryExplanation? Recovery = null
 );
 
 public record SessionMessage(

--- a/src/OpenClaw.Dashboard/OpenClaw.Dashboard.csproj
+++ b/src/OpenClaw.Dashboard/OpenClaw.Dashboard.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="../OpenClaw.Core/Models/SessionRecoveryExplanation.cs" Link="Models/SessionRecoveryExplanation.cs" />
     <Compile Include="../OpenClaw.Core/Models/AuthSessionRequest.cs" Link="Models/AuthSessionRequest.cs" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />

--- a/src/OpenClaw.Dashboard/Pages/Sessions.razor
+++ b/src/OpenClaw.Dashboard/Pages/Sessions.razor
@@ -1310,7 +1310,7 @@
             BackgroundRunObjective: backgroundRunObjective,
             BackgroundContinuationCount: backgroundContinuationCount,
             Recovery: root.TryGetProperty("recovery", out var recovery) && recovery.ValueKind == System.Text.Json.JsonValueKind.Object
-                ? System.Text.Json.JsonSerializer.Deserialize<OpenClaw.Core.Models.SessionRecoveryExplanation>(recovery.GetRawText(), new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                ? System.Text.Json.JsonSerializer.Deserialize<OpenClaw.Core.Models.SessionRecoveryExplanation>(recovery.GetRawText(), Api.JsonOptions)
                 : null);
     }
 

--- a/src/OpenClaw.Dashboard/Pages/Sessions.razor
+++ b/src/OpenClaw.Dashboard/Pages/Sessions.razor
@@ -177,6 +177,20 @@
                         </div>
                     </div>
 
+                    @if (_selectedDetail.Recovery is { } recovery)
+                    {
+                        <MudDivider Class="my-3" />
+                        <section class="sx-section">
+                            <MudText Typo="Typo.subtitle2">Run explanation and recovery</MudText>
+                            <MudText Typo="Typo.body2">@recovery.Summary</MudText>
+                            <MudText Typo="Typo.subtitle2" Class="mt-3">Recorded evidence</MudText>
+                            <ul>@foreach (var item in recovery.Evidence) { <li>@item</li> }</ul>
+                            <MudText Typo="Typo.subtitle2">Next steps</MudText>
+                            <ol>@foreach (var item in recovery.NextSteps) { <li>@item</li> }</ol>
+                            <MudText Typo="Typo.caption">Refresh to check for changes. These steps do not execute or approve actions.</MudText>
+                        </section>
+                    }
+
                     @if (!string.IsNullOrEmpty(_selectedDetail.RunState) && _selectedDetail.RunState is not "Idle")
                     {
                         <MudDivider Class="my-3" />
@@ -1294,7 +1308,10 @@
             metadata.Count == 0 ? null : metadata, messages,
             RunState: runState,
             BackgroundRunObjective: backgroundRunObjective,
-            BackgroundContinuationCount: backgroundContinuationCount);
+            BackgroundContinuationCount: backgroundContinuationCount,
+            Recovery: root.TryGetProperty("recovery", out var recovery) && recovery.ValueKind == System.Text.Json.JsonValueKind.Object
+                ? System.Text.Json.JsonSerializer.Deserialize<OpenClaw.Core.Models.SessionRecoveryExplanation>(recovery.GetRawText(), new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                : null);
     }
 
     private async Task LoadSessionTimeline(string sessionId)

--- a/src/OpenClaw.Dashboard/Pages/Sessions.razor
+++ b/src/OpenClaw.Dashboard/Pages/Sessions.razor
@@ -1233,7 +1233,7 @@
     /// <c>Session</c> with <c>history</c> of <c>ChatTurn</c>, plus <c>isActive</c> /
     /// <c>branchCount</c> / <c>metadata</c>) into the Dashboard <see cref="SessionDetail"/> shape.
     /// </summary>
-    private static SessionDetail BuildSessionDetailFromAdmin(
+    private SessionDetail BuildSessionDetailFromAdmin(
         SessionInfo fallback,
         System.Text.Json.JsonElement root,
         System.Text.Json.JsonElement sessionEl)

--- a/src/OpenClaw.Gateway/Composition/IntegrationApiFacade.cs
+++ b/src/OpenClaw.Gateway/Composition/IntegrationApiFacade.cs
@@ -159,8 +159,8 @@ internal sealed class IntegrationApiFacade
             Session = session,
             IsActive = _runtime.SessionManager.IsActive(id),
             BranchCount = branches.Count,
-            Recovery = OpenClaw.Core.Services.SessionRecoveryExplainer.Explain(session,
-                _goalService?.GetGoal(id), _runtime.ToolApprovalService.ListPending()),
+            Recovery = OpenClaw.Core.Services.SessionRecoveryExplainer.ExplainWithGoalStore(session,
+                _goalService, _runtime.ToolApprovalService.ListPending()),
             Metadata = _runtime.Operations.SessionMetadata.Get(id)
         };
     }

--- a/src/OpenClaw.Gateway/Composition/IntegrationApiFacade.cs
+++ b/src/OpenClaw.Gateway/Composition/IntegrationApiFacade.cs
@@ -22,6 +22,7 @@ internal sealed class IntegrationApiFacade
     private readonly TextToSpeechService? _textToSpeechService;
     private readonly GatewayMaintenanceRuntimeService? _maintenanceService;
     private readonly AgentWorkflowRegistry _workflows;
+    private readonly IGoalService? _goalService;
 
     public static IntegrationApiFacade Create(
         GatewayStartupContext startup,
@@ -55,7 +56,7 @@ internal sealed class IntegrationApiFacade
             toolPresetResolver,
             textToSpeechService,
             maintenanceService,
-            workflows);
+            workflows, services.GetService<IGoalService>());
     }
 
     public IntegrationApiFacade(
@@ -70,8 +71,10 @@ internal sealed class IntegrationApiFacade
         IToolPresetResolver? toolPresetResolver,
         TextToSpeechService? textToSpeechService,
         GatewayMaintenanceRuntimeService? maintenanceService,
-        AgentWorkflowRegistry workflows)
+        AgentWorkflowRegistry workflows,
+        IGoalService? goalService = null)
     {
+        _goalService = goalService;
         _startup = startup;
         _runtime = runtime;
         _sessionAdminStore = sessionAdminStore;
@@ -156,6 +159,8 @@ internal sealed class IntegrationApiFacade
             Session = session,
             IsActive = _runtime.SessionManager.IsActive(id),
             BranchCount = branches.Count,
+            Recovery = OpenClaw.Core.Services.SessionRecoveryExplainer.Explain(session,
+                _goalService?.GetGoal(id), _runtime.ToolApprovalService.ListPending()),
             Metadata = _runtime.Operations.SessionMetadata.Get(id)
         };
     }

--- a/src/OpenClaw.Gateway/Endpoints/AdminEndpoints.Sessions.cs
+++ b/src/OpenClaw.Gateway/Endpoints/AdminEndpoints.Sessions.cs
@@ -113,6 +113,8 @@ internal static partial class AdminEndpoints
                 Session = session,
                 IsActive = runtime.SessionManager.IsActive(id),
                 BranchCount = branches.Count,
+                Recovery = OpenClaw.Core.Services.SessionRecoveryExplainer.Explain(session,
+                    ctx.RequestServices.GetService<IGoalService>()?.GetGoal(id), runtime.ToolApprovalService.ListPending()),
                 Metadata = operations.SessionMetadata.Get(id)
             }, CoreJsonContext.Default.AdminSessionDetailResponse);
         });

--- a/src/OpenClaw.Gateway/Endpoints/AdminEndpoints.Sessions.cs
+++ b/src/OpenClaw.Gateway/Endpoints/AdminEndpoints.Sessions.cs
@@ -113,8 +113,8 @@ internal static partial class AdminEndpoints
                 Session = session,
                 IsActive = runtime.SessionManager.IsActive(id),
                 BranchCount = branches.Count,
-                Recovery = OpenClaw.Core.Services.SessionRecoveryExplainer.Explain(session,
-                    ctx.RequestServices.GetService<IGoalService>()?.GetGoal(id), runtime.ToolApprovalService.ListPending()),
+                Recovery = OpenClaw.Core.Services.SessionRecoveryExplainer.ExplainWithGoalStore(session,
+                    ctx.RequestServices.GetService<IGoalService>(), runtime.ToolApprovalService.ListPending()),
                 Metadata = operations.SessionMetadata.Get(id)
             }, CoreJsonContext.Default.AdminSessionDetailResponse);
         });

--- a/src/OpenClaw.Gateway/Extensions/GatewayInboundMessageWorker.cs
+++ b/src/OpenClaw.Gateway/Extensions/GatewayInboundMessageWorker.cs
@@ -904,6 +904,7 @@ internal sealed class GatewayInboundMessageWorker
                                 // Lifecycle notifications for background task terminal states
                                 if (session.BackgroundRun is not null && !turnResult.ShouldContinue)
                                 {
+                                    session.BackgroundRun.LastStopReason = turnResult.StopReason.ToString();
                                     // Map StopReason to final SessionRunState and persist
                                     session.RunState = turnResult.StopReason switch
                                     {

--- a/src/OpenClaw.Gateway/wwwroot/admin.html
+++ b/src/OpenClaw.Gateway/wwwroot/admin.html
@@ -5323,6 +5323,17 @@
 
             sessionDetailOutput.innerHTML = `
                 <div class="pill-row">${metadataPills.map(value => `<span class="pill">${escapeHtml(value)}</span>`).join('')}</div>
+                ${detail.recovery ? `
+                    <div class="card" style="margin-top:0.75rem;">
+                        <h4>Run explanation and recovery</h4>
+                        <p>${escapeHtml(detail.recovery.summary)}</p>
+                        <h4>Recorded evidence</h4>
+                        <ul>${(detail.recovery.evidence || []).map(item => `<li>${escapeHtml(item)}</li>`).join('')}</ul>
+                        <h4>Next steps</h4>
+                        <ol>${(detail.recovery.nextSteps || []).map(item => `<li>${escapeHtml(item)}</li>`).join('')}</ol>
+                        <p class="muted">Refresh to check for changes. These steps do not execute or approve actions.</p>
+                    </div>
+                ` : ''}
                 ${delegation ? `
                     <div class="card" style="margin-top:0.75rem;">
                         <strong>Delegated Session</strong>

--- a/src/OpenClaw.Tests/CompanionRuntimeConsoleTests.cs
+++ b/src/OpenClaw.Tests/CompanionRuntimeConsoleTests.cs
@@ -208,7 +208,7 @@ public sealed class CompanionRuntimeConsoleTests : IDisposable
             {
                 return request.RequestUri!.AbsolutePath switch
                 {
-                    "/api/integration/sessions/sess-a" => JsonResponse("""{ "session": null, "isActive": true, "branchCount": 3, "metadata": null }"""),
+                    "/api/integration/sessions/sess-a" => JsonResponse("""{ "session": null, "isActive": true, "branchCount": 3, "metadata": null, "recovery": { "status": "blocked", "summary": "Access is missing", "evidence": ["Goal is blocked"], "nextSteps": ["Resolve access first"] } }"""),
                     "/api/integration/sessions/sess-a/timeline" => JsonResponse("""
                     {
                       "sessionId": "sess-a",
@@ -241,6 +241,8 @@ public sealed class CompanionRuntimeConsoleTests : IDisposable
 
         Assert.Contains("Session: sess-a", viewModel.SelectedSessionDetail, StringComparison.Ordinal);
         Assert.Contains("Branches: 3", viewModel.SelectedSessionDetail, StringComparison.Ordinal);
+        Assert.Contains("Access is missing", viewModel.SelectedSessionDetail, StringComparison.Ordinal);
+        Assert.Contains("Resolve access first", viewModel.SelectedSessionDetail, StringComparison.Ordinal);
         var timeline = Assert.Single(viewModel.SessionTimelineRows);
         Assert.Equal("chat", timeline.Component);
         Assert.True(viewModel.HasSessionTimelineRows);

--- a/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
+++ b/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
@@ -5568,6 +5568,26 @@ public sealed class GatewayAdminEndpointTests
         Assert.Equal("queued message", queued.Text);
     }
 
+    [Theory]
+    [InlineData("/admin/sessions/")]
+    [InlineData("/api/integration/sessions/")]
+    public async Task SessionDetail_ExplainsRecordedFailure(string route)
+    {
+        await using var harness = await CreateHarnessAsync(nonLoopbackBind: true);
+        var session = await harness.Runtime.SessionManager.GetOrCreateByIdAsync("recovery-test", "api", "operator", TestContext.Current.CancellationToken);
+        session.RunState = SessionRunState.Failed;
+        session.BackgroundRun = new() { LastStopReason = "Failed" };
+        await harness.Runtime.SessionManager.PersistAsync(session, TestContext.Current.CancellationToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, route + session.Id);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+        using var response = await harness.Client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using var payload = await ReadJsonAsync(response);
+        var recovery = payload.RootElement.GetProperty("recovery");
+        Assert.Equal("failed", recovery.GetProperty("status").GetString());
+        Assert.Contains("Do not blindly repeat", recovery.GetProperty("nextSteps").ToString());
+    }
+
     [Fact]
     public async Task SessionDetail_And_Promotion_Surface_Work()
     {

--- a/src/OpenClaw.Tests/SessionRecoveryExplainerTests.cs
+++ b/src/OpenClaw.Tests/SessionRecoveryExplainerTests.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Models.Goal;
+using OpenClaw.Core.Pipeline;
+using OpenClaw.Core.Services;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class SessionRecoveryExplainerTests
+{
+    private static Session Session(SessionRunState state = SessionRunState.Idle)
+        => new() { Id = "s1", ChannelId = "test", SenderId = "user", RunState = state };
+    private static SessionGoal Goal(GoalStatus state)
+        => new() { SessionId = "s1", Objective = "Fix the issue", Status = state, StatusNote = "Access is missing" };
+
+    [Fact]
+    public void Approvals_AreScopedToExactSession_AndDoNotExposeArguments()
+    {
+        var own = new ToolApprovalRequest { ApprovalId = "a1", SessionId = "s1", ChannelId = "test", SenderId = "user", ToolName = "shell", Arguments = "secret", Summary = "private" };
+        var other = own with { ApprovalId = "a2", SessionId = "s2" };
+        var result = SessionRecoveryExplainer.Explain(Session(SessionRunState.Running), null, [other, own]);
+        Assert.Equal("approval_pending", result.Status);
+        var json = JsonSerializer.Serialize(result, CoreJsonContext.Default.SessionRecoveryExplanation);
+        Assert.Contains("a1", json);
+        Assert.DoesNotContain("a2", json);
+        Assert.DoesNotContain("secret", json);
+        Assert.DoesNotContain("private", json);
+        Assert.Equal("idle", SessionRecoveryExplainer.Explain(Session(), null, [other]).Status);
+    }
+
+    [Theory]
+    [InlineData(GoalStatus.Paused, "paused")]
+    [InlineData(GoalStatus.Blocked, "blocked")]
+    [InlineData(GoalStatus.BudgetLimited, "budget_limited")]
+    [InlineData(GoalStatus.UsageLimited, "usage_limited")]
+    [InlineData(GoalStatus.Complete, "completed")]
+    public void GoalStateExplainsIdleSession(GoalStatus state, string expected)
+    {
+        var goal = Goal(state);
+        var result = SessionRecoveryExplainer.Explain(Session(), goal, []);
+        Assert.Equal(expected, result.Status);
+        Assert.Contains(result.Evidence, item => item.Contains("Access is missing"));
+        Assert.Equal(state, goal.Status); // Explanation must never mutate state.
+    }
+
+    [Fact]
+    public void ExhaustedBudget_DoesNotSuggestResumeAsSolution()
+    {
+        var goal = new SessionGoal { SessionId = "s1", Objective = "Work", Status = GoalStatus.Paused, TokenBudget = 100, TokensUsed = 100 };
+        var result = SessionRecoveryExplainer.Explain(Session(), goal, []);
+        Assert.Equal("budget_limited", result.Status);
+        Assert.DoesNotContain(result.NextSteps, step => step.Contains("/goal resume"));
+        goal.Status = GoalStatus.Complete;
+        Assert.Equal("completed", SessionRecoveryExplainer.Explain(Session(), goal, []).Status);
+    }
+
+    [Fact]
+    public void ContinuationCap_DoesNotMisreportAsGoalBudgetExhaustion()
+    {
+        var session = Session(SessionRunState.BudgetLimited);
+        session.BackgroundRun = new() { LastStopReason = "MaxContinuationTurnsReached", ContinuationCount = 8 };
+        var result = SessionRecoveryExplainer.Explain(session, Goal(GoalStatus.Active), []);
+        Assert.Equal("budget_limited", result.Status);
+        Assert.Contains(result.NextSteps, step => step.Contains("continuation limit"));
+    }
+
+    [Fact]
+    public void FailedCheckpoint_DoesNotAuthorizeReplay()
+    {
+        var session = Session(SessionRunState.Failed);
+        session.ExecutionCheckpoint = new() { CheckpointId = "checkpoint1", State = SessionCheckpointStates.ReadyToResume };
+        var result = SessionRecoveryExplainer.Explain(session, null, []);
+        Assert.Equal("failed", result.Status);
+        Assert.Contains(result.Evidence, step => step.Contains("does not prove"));
+        Assert.Contains(result.NextSteps, step => step.Contains("Do not blindly repeat"));
+    }
+
+    [Fact]
+    public void FailedRun_ShowsLatestToolFailureWithoutArgumentsOrResults()
+    {
+        var session = Session(SessionRunState.Failed);
+        session.History.Add(new ChatTurn { Role = "assistant", Content = "", ToolCalls =
+            [new() { ToolName = "upload", Arguments = "private-argument", Result = "private-result", FailureCode = "access_denied", FailureMessage = "Permission missing" }] });
+        var result = SessionRecoveryExplainer.Explain(session, null, []);
+        Assert.Contains(result.Evidence, item => item.Contains("access_denied") && item.Contains("Permission missing"));
+        Assert.DoesNotContain(result.Evidence, item => item.Contains("private-"));
+    }
+
+    [Theory]
+    [InlineData(SessionRunState.Running)]
+    [InlineData(SessionRunState.Continuing)]
+    public void PersistedRunningState_IsNotClaimedAsLiveWorker(SessionRunState state)
+    {
+        Assert.Contains("not proof of a live worker", SessionRecoveryExplainer.Explain(Session(state), null, []).Summary);
+    }
+
+    [Fact]
+    public void NewActiveGoal_IsNotHiddenByPreviousCompletedRun()
+    {
+        var result = SessionRecoveryExplainer.Explain(Session(SessionRunState.Completed), Goal(GoalStatus.Active), []);
+        Assert.Equal("goal_active", result.Status);
+        Assert.DoesNotContain(result.NextSteps, step => step.Contains("new goal"));
+    }
+
+    [Fact]
+    public void ExpiredSession_DoesNotSuggestGoalResume()
+    {
+        var session = Session();
+        session.State = SessionState.Expired;
+        var result = SessionRecoveryExplainer.Explain(session, Goal(GoalStatus.Paused), []);
+        Assert.Equal("expired", result.Status);
+        Assert.DoesNotContain(result.NextSteps, step => step.Contains("/goal resume"));
+    }
+}

--- a/src/OpenClaw.Tests/SessionRecoveryExplainerTests.cs
+++ b/src/OpenClaw.Tests/SessionRecoveryExplainerTests.cs
@@ -15,6 +15,14 @@ public sealed class SessionRecoveryExplainerTests
         => new() { SessionId = "s1", Objective = "Fix the issue", Status = state, StatusNote = "Access is missing" };
 
     [Fact]
+    public void CorruptGoalStateLeavesExplanationAvailable()
+    {
+        var goals = NSubstitute.Substitute.For<OpenClaw.Core.Abstractions.IGoalService>();
+        NSubstitute.SubstituteExtensions.Returns(goals.GetGoal("s1"), _ => throw new InvalidDataException("bad goal"));
+        Assert.Equal("unknown", SessionRecoveryExplainer.ExplainWithGoalStore(Session(), goals, []).Status);
+    }
+
+    [Fact]
     public void Approvals_AreScopedToExactSession_AndDoNotExposeArguments()
     {
         var own = new ToolApprovalRequest { ApprovalId = "a1", SessionId = "s1", ChannelId = "test", SenderId = "user", ToolName = "shell", Arguments = "secret", Summary = "private" };
@@ -27,6 +35,19 @@ public sealed class SessionRecoveryExplainerTests
         Assert.DoesNotContain("secret", json);
         Assert.DoesNotContain("private", json);
         Assert.Equal("idle", SessionRecoveryExplainer.Explain(Session(), null, [other]).Status);
+    }
+
+    [Fact]
+    public void BlockedGoalIncludesCurrentFailureButNotAnOlderResolvedBatch()
+    {
+        var session = Session(SessionRunState.Completed);
+        session.History.Add(new ChatTurn { Role = "assistant", Content = "", ToolCalls =
+            [new() { ToolName = "upload", Arguments = "{}", FailureCode = "access_denied" }] });
+        Assert.Contains(SessionRecoveryExplainer.Explain(session, Goal(GoalStatus.Blocked), []).Evidence,
+            item => item.Contains("access_denied"));
+        session.History.Add(new ChatTurn { Role = "assistant", Content = "Resolved." });
+        Assert.DoesNotContain(SessionRecoveryExplainer.Explain(session, Goal(GoalStatus.Blocked), []).Evidence,
+            item => item.Contains("access_denied"));
     }
 
     [Theory]


### PR DESCRIPTION
## Description

Operators could see a session's state and timeline without a consolidated explanation of why work stopped or how to recover. Session details now combine recorded goal/run state, goal notes, checkpoints, session-specific pending approvals, and recent tool failure evidence with contextual next steps in the admin console, Dashboard, and Companion.

For example, an exhausted token budget no longer leaves the operator guessing whether `/goal resume` will help: the explanation states that resuming does not increase the budget. A saved running state is explicitly distinguished from a live worker, and a checkpoint never authorizes replay of an interrupted external action.

## Summary

- Add a shared, read-only explanation builder and additive `recovery` field to both authenticated session-detail contracts, using source-generated JSON in the gateway/client path.
- Display the explanation in all three operator surfaces, retaining compatibility with older gateways that omit it.
- Persist the terminal background stop reason so the view does not show an earlier continuation reason.
- Document recovery guidance and mark the roadmap explanation view complete; permission-aware recovery controls and durable action reconciliation remain follow-on work.

## Related Issues

Implements the run explanation and recovery view in `docs/ROADMAP.md`.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [x] Documentation update
- [x] Tests

## Validation

- [x] `dotnet restore OpenClaw.Net.slnx`
- [x] `dotnet build OpenClaw.Net.slnx --configuration Release --no-restore` — zero warnings and errors.
- [x] `dotnet test OpenClaw.Net.slnx --configuration Release --no-build` — 2,519 passed, zero failures or skips (16 more cases than the v0.2.0 standard suite).
- [x] `dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build` — deterministic echo smoke passed.
- [x] Dashboard build — zero warnings and errors.
- [x] Admin JavaScript syntax, recovery rendering, HTML escaping, and older-response fallback checks passed; sample-data layout inspected in browser.

The first no-restore solution build found missing locally cached Semantic Kernel sample dependencies. A solution restore resolved this; the final full Release build and test suite above passed. Hosted checks are running on this PR.

## Review Notes

- [x] NativeAOT compatibility considered: explicit CoreJsonContext registration; no new runtime dependencies or reflection in the core/gateway path.
- [x] Security considered: existing authentication scopes retained, exact-session approval filtering, tool arguments/results excluded from the explanation, and escaped/encoded display text.
- [x] Docs and regression tests updated.
- [x] Scoped to operator explanation and the stop-reason evidence it consumes.

The view offers guidance only. It does not decide approvals, dispatch messages, change goals, or replay tools. Goal notes and tool failure messages retain the existing session-detail access boundary.

## Commercial or Customer-Driven Contribution Disclosure

General repository roadmap work requested by the maintainer; no company-specific integration or downstream customer workflow was supplied.

## Checklist

- [x] Read CONTRIBUTING and the maintainer review checklist.
- [x] Added regression tests for state precedence, budget guidance, approval isolation, failure evidence, HTTP contracts, and Companion display.
- [x] Updated documentation and reviewed authorization and output encoding.

## Screenshots

Visually inspected the admin renderer with an isolated sample-data preview. This was a rendering check; authenticated endpoint behavior is covered separately by gateway tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Run explanation and recovery” view to session details in the Admin Console, Dashboard, and Companion.
  * Session details show recorded run status, evidence, and recommended next steps.
  * Guidance covers approvals, failures, limits, paused or blocked runs, expiration, and completion.
  * Guidance is informational only and does not execute or approve actions.
  * Recovery details remain readable when goal data is unavailable or corrupt.

* **Documentation**
  * Added documentation covering recovery details, operator guidance, and API compatibility.
  * Updated the roadmap to reflect completed recovery explanations and future guided recovery actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->