### PR TITLE
Import captured trajectories for offline runtime regression replay

### DIFF
--- a/OpenClaw.Net.slnx
+++ b/OpenClaw.Net.slnx
@@ -16,6 +16,7 @@
     <Project Path="samples/OpenClaw.HelloAgent/OpenClaw.HelloAgent.csproj" />
     <Project Path="samples/OpenClaw.MicrosoftExtensionsAIProvider/OpenClaw.MicrosoftExtensionsAIProvider.csproj" />
     <Project Path="samples/OpenClaw.SemanticKernelInteropHost/OpenClaw.SemanticKernelInteropHost.csproj" />
+    <Project Path="samples/OpenClaw.TrajectoryReplay/OpenClaw.TrajectoryReplay.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/OpenClaw.Cli/OpenClaw.Cli.csproj" />

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,8 @@
 
 ## Recently Completed
 
+- **Real-run regression import and offline replay**: import a redacted, complete text exchange from a gateway trajectory export and run recorded provider/tool fixtures through `RuntimeScenarioRunner`, with independent assertions and strict consumption checks. Includes an executable sample; see [trajectory replay](testing/trajectory-replay.md).
+
 - Browser sessions invalidate after local operator account updates, deletion, or disablement.
 - Goal completion accepts completed tool work; model status updates run alone and blocked transitions require three observations. Resume resets continuation and blocker counters.
 - Goal state is persisted atomically under the configured memory storage directory and restored lazily after restart.
@@ -61,7 +63,7 @@ These are strong candidates for the next roadmap phases because they extend the 
 The runtime already includes CLI insights, URL safety validation, and trajectory export. The next additions build on those capabilities:
 
 1. **Durable action reconciliation**: supplement persisted goals and completed-batch checkpoints with an action journal and provider idempotency keys. An interrupted external action with an unknown outcome must be reconciled before replay.
-2. **Real-run regression capture**: extend `RuntimeScenarioRunner` with redacted trajectory import and deterministic provider/tool replay fixtures.
+2. **Expanded regression capture**: build on completed trajectory import/offline replay with automatic capture and support for structured failures and multimodal exchanges.
 3. **Full-instance backup and restore**: extend upgrade rollback to include sessions, goals, schedules, governance records, and secret-reference manifests; validate restores in an isolated instance without dispatching actions.
 4. **Run explanation and recovery view**: connect existing timelines, approvals, and evidence to show the exact blocker and valid next recovery actions.
 

--- a/docs/testing/trajectory-replay.md
+++ b/docs/testing/trajectory-replay.md
@@ -1,0 +1,49 @@
+# Turn a captured exchange into an offline regression
+
+`OpenClaw.Testing` can import one user exchange from the gateway's version 1 JSONL trajectory export and replay its provider responses and tool outputs through the real runtime. This tests orchestration, tool dispatch, approval behavior, and output assertions without repeating external actions.
+
+The new sample is an executable entry point:
+
+```sh
+dotnet run --project samples/OpenClaw.TrajectoryReplay -- \
+  trajectory.jsonl exported-session-id 0 "expected answer text"
+```
+
+Choose the **session ID as it appears in the export** and the user prompt's `turnIndex`. With anonymized exports, use the anonymized ID. The exchange ends at the next prompt. The expected answer is an independent assertion supplied by the test author, not inferred from the capture. The sample exits nonzero when the assertion fails or replay diverges.
+
+The sample creates isolated temporary memory, uses only recorded provider/tool adapters, and removes its temporary memory afterward. It does not connect to model providers or register real tools. The existing `openclaw test run` command keeps its existing behavior; this sample and the SDK API explicitly select real-runtime replay.
+
+## Import, inspect, and store a fixture
+
+```csharp
+using var reader = File.OpenText("trajectory.jsonl");
+var fixture = await TrajectoryReplayImporter.ImportAsync(
+    reader, exportedSessionId, promptTurnIndex, projectRedactionPipeline, cancellationToken);
+var sanitizedJson = JsonSerializer.Serialize(
+    fixture, ScenarioJsonContext.Default.TrajectoryReplayFixture);
+```
+
+Supply an `IRedactionPipeline` configured for the secrets and private data in your application. Import always applies baseline secret redaction as well, recursively redacts JSON argument/result values, and replaces common credential fields. It discards exported session, sender, channel, call IDs, timestamps, governance records, and evidence bundles. Replay assigns fresh call IDs.
+
+**Inspect the sanitized fixture before sharing or committing it.** Generic patterns cannot recognize every password, personal detail, path, or proprietary value in free text. The `anonymized` flag in the source is not treated as proof that the input is safe. Credential replacement can change JSON value types; fixtures model sanitized behavior rather than the original sensitive inputs.
+
+Use `ScenarioJsonContext.Default.TrajectoryReplayFixture` for deserialization too. Fixtures carry schema version 1. Keep fixture files separate from the directory consumed by `JsonScenarioLoader`, which loads `AgentScenario` documents.
+
+## Run against the runtime
+
+`RuntimeScenarioRunner.RunReplayAsync` accepts a fixture, independent `ScenarioOracleDefinition` assertions, and a factory receiving an `IChatClient` and `IReadOnlyList<ITool>`. Construct the runtime with those supplied replay adapters and isolated memory. Do not add real tools, network-capable hooks, or live providers to a replay factory.
+
+Each replay gets a private snapshot and fresh consumption state. Tool arguments are compared as JSON values, so property ordering does not matter. Independent calls in the same batch can execute in either order. The provider verifies that the runtime returned each recorded tool result before advancing. Missing, extra, mismatched, or repeated calls fail replay, even if a later final answer matches an assertion. Failures remain latched if runtime error handling catches an adapter exception.
+
+The runner evaluates emitted runtime evidence and requires at least one outcome assertion. It does not treat imported records as proof that the runtime executed them.
+
+## Supported boundary
+
+- One complete text exchange: a user prompt, zero or more assistant tool batches, and a final assistant response.
+- Completed tool results, including legacy records with a result but no `resultStatus`.
+- Sequential batches and parallel calls with distinct name/argument combinations.
+- Version 1 gateway exports, bounded to 8 Mi characters and 10,000 records.
+
+Malformed JSON, unmatched calls/results, duplicate prompt selection, incomplete exchanges, unsupported schemas, failed/denied/unknown tool outcomes, and ambiguous identical calls within one batch are rejected. Import does not reconstruct prior conversation context, original tool schemas, model reasoning, token usage, timings, approval decisions, images, or audio. Configure approvals in the test explicitly; they are denied by default. Recorded model outputs test the runtime, not the quality of a live model's next response.
+
+Automatic capture during production execution and replay of structured failures/media remain follow-on work. Durable action reconciliation remains a separate roadmap item; this feature never resumes or repeats a live external action.

--- a/samples/OpenClaw.TrajectoryReplay/OpenClaw.TrajectoryReplay.csproj
+++ b/samples/OpenClaw.TrajectoryReplay/OpenClaw.TrajectoryReplay.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/OpenClaw.Testing/OpenClaw.Testing.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/OpenClaw.TrajectoryReplay/Program.cs
+++ b/samples/OpenClaw.TrajectoryReplay/Program.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using OpenClaw.Agent;
+using OpenClaw.Core.Memory;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Security;
+using OpenClaw.Testing;
+
+if (args.Length != 4 || !int.TryParse(args[2], out var turn) || turn < 0 || string.IsNullOrWhiteSpace(args[3]))
+{
+    Console.Error.WriteLine("Usage: <trajectory.jsonl> <exported-session-id> <prompt-turn-index> <expected-answer-text>");
+    return 2;
+}
+
+// Add project-specific redactors before using captures containing private data.
+var redaction = new RedactionPipeline([new BaselineSecretRedactor()]);
+using var reader = File.OpenText(args[0]);
+var fixture = await TrajectoryReplayImporter.ImportAsync(reader, args[1], turn, redaction);
+var memoryPath = Path.Join(Path.GetTempPath(), "openclaw-replay-" + Guid.NewGuid().ToString("N"));
+try
+{
+    await using var memory = new FileMemoryStore(memoryPath);
+    var result = await RuntimeScenarioRunner.RunReplayAsync(fixture,
+        [new() { Type = ScenarioOracleTypes.FinalAnswerContains, Value = JsonSerializer.SerializeToElement(args[3]) }],
+        (provider, tools) => new AgentRuntime(provider, tools, memory,
+            new LlmProviderConfig { Provider = "deterministic", Model = "trajectory-replay", RetryCount = 0 },
+            maxHistoryTurns: 20, maxIterations: fixture.Responses.Count + 1));
+    Console.WriteLine(result.Passed ? "Replay passed." : "Replay failed: " + result.FailureSummary);
+    return result.Passed ? 0 : 1;
+}
+finally
+{
+    if (Directory.Exists(memoryPath)) Directory.Delete(memoryPath, recursive: true);
+}

--- a/samples/OpenClaw.TrajectoryReplay/Program.cs
+++ b/samples/OpenClaw.TrajectoryReplay/Program.cs
@@ -12,7 +12,7 @@ if (args.Length != 4 || !int.TryParse(args[2], out var turn) || turn < 0 || stri
 }
 
 // Add project-specific redactors before using captures containing private data.
-var redaction = new RedactionPipeline([new BaselineSecretRedactor()]);
+var redaction = new RedactionPipeline([]);
 using var reader = File.OpenText(args[0]);
 var fixture = await TrajectoryReplayImporter.ImportAsync(reader, args[1], turn, redaction);
 var memoryPath = Path.Join(Path.GetTempPath(), "openclaw-replay-" + Guid.NewGuid().ToString("N"));

--- a/src/OpenClaw.Testing/RuntimeScenarioRunner.cs
+++ b/src/OpenClaw.Testing/RuntimeScenarioRunner.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using Microsoft.Extensions.AI;
+using OpenClaw.Core.Abstractions;
 using OpenClaw.Agent;
 using OpenClaw.Core.Models;
 
@@ -14,6 +16,33 @@ public sealed class RuntimeScenarioRunner(
     ToolApprovalCallback? approval = null,
     ScenarioOracleRegistry? oracles = null) : IScenarioRunner
 {
+    /// <summary>Exercises the runtime with isolated recorded provider/tool fixtures and independent outcome assertions.</summary>
+    public static async ValueTask<ScenarioRunResult> RunReplayAsync(TrajectoryReplayFixture fixture,
+        IReadOnlyList<ScenarioOracleDefinition> assertions,
+        Func<IChatClient, IReadOnlyList<ITool>, IAgentRuntime> createRuntime,
+        ToolApprovalCallback? approval = null, CancellationToken cancellationToken = default)
+    {
+        using var replay = new TrajectoryReplay(fixture);
+        var scenario = new AgentScenario
+        {
+            Id = "trajectory-replay", Input = new() { UserMessage = fixture.Prompt }, Oracles = assertions.ToList()
+        };
+        var result = await new RuntimeScenarioRunner(_ => createRuntime(replay, replay.Tools), approval).RunAsync(scenario, cancellationToken);
+        string? divergence = null;
+        try { replay.VerifyComplete(); }
+        catch (InvalidOperationException ex) { divergence = ex.Message; }
+        var outcomes = result.OracleResults.Append(new OracleResult
+        {
+            Name = "replay-consumed", Passed = divergence is null, Message = divergence ?? "All recorded responses and tools were consumed."
+        }).ToList();
+        return new ScenarioRunResult
+        {
+            Scenario = result.Scenario, Trace = result.Trace, OracleResults = outcomes,
+            Passed = outcomes.All(o => o.Passed), StartedAtUtc = result.StartedAtUtc, CompletedAtUtc = result.CompletedAtUtc,
+            FailureSummary = string.Join("; ", outcomes.Where(o => !o.Passed).Select(o => o.Message))
+        };
+    }
+
     public async ValueTask<ScenarioRunResult> RunAsync(AgentScenario scenario, CancellationToken cancellationToken = default)
     {
         var started = DateTimeOffset.UtcNow;

--- a/src/OpenClaw.Testing/ScenarioJsonContext.cs
+++ b/src/OpenClaw.Testing/ScenarioJsonContext.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace OpenClaw.Testing;
 
+[JsonSerializable(typeof(TrajectoryReplayFixture))]
 [JsonSerializable(typeof(AgentScenario))]
 [JsonSerializable(typeof(List<AgentScenario>))]
 [JsonSerializable(typeof(ScenarioInput))]

--- a/src/OpenClaw.Testing/TrajectoryReplay.cs
+++ b/src/OpenClaw.Testing/TrajectoryReplay.cs
@@ -1,0 +1,135 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using OpenClaw.Core.Abstractions;
+
+namespace OpenClaw.Testing;
+
+/// <summary>One-use offline provider and tools. No calls are forwarded to real implementations.</summary>
+public sealed class TrajectoryReplay : IChatClient
+{
+    private readonly TrajectoryReplayFixture _fixture;
+    private readonly object _gate = new();
+    private readonly List<PendingCall> _pending = [];
+    private int _nextResponse;
+    private bool _diverged;
+    public IReadOnlyList<ITool> Tools { get; }
+
+    public TrajectoryReplay(TrajectoryReplayFixture fixture)
+    {
+        // Keep a private snapshot so edits to a fixture cannot change a running replay.
+        _fixture = JsonSerializer.Deserialize(JsonSerializer.Serialize(fixture, ScenarioJsonContext.Default.TrajectoryReplayFixture),
+            ScenarioJsonContext.Default.TrajectoryReplayFixture) ?? throw new InvalidDataException("Missing replay fixture.");
+        if (_fixture.SchemaVersion != 1 || _fixture.Prompt is null || _fixture.Responses is not { Count: > 0 })
+            throw new InvalidDataException("Invalid replay fixture schema or input.");
+        foreach (var response in _fixture.Responses)
+        {
+            if (response is null || response.Text is null || response.ToolCalls is null)
+                throw new InvalidDataException("Invalid replay response.");
+            foreach (var call in response.ToolCalls)
+            {
+                if (call is null || string.IsNullOrWhiteSpace(call.ToolName) || call.Result is null)
+                    throw new InvalidDataException("Invalid replay tool call.");
+                using var args = JsonDocument.Parse(call.ArgumentsJson);
+                if (args.RootElement.ValueKind != JsonValueKind.Object)
+                    throw new InvalidDataException("Replay arguments must be JSON objects.");
+                if (response.ToolCalls.Count(other => other.ToolName == call.ToolName && ArgumentsEqual(other.ArgumentsJson, call.ArgumentsJson)) > 1)
+                    throw new InvalidDataException("Identical calls within a batch are ambiguous; split the fixture into ordered batches.");
+            }
+        }
+        if (_fixture.Responses[^1].ToolCalls.Count != 0 || _fixture.Responses.Take(_fixture.Responses.Count - 1).Any(r => r.ToolCalls.Count == 0))
+            throw new InvalidDataException("A replay needs tool batches followed by one final response.");
+        Tools = _fixture.Responses.SelectMany(r => r.ToolCalls).Select(c => c.ToolName).Distinct(StringComparer.Ordinal)
+            .Select(name => (ITool)new ReplayTool(this, name)).ToArray();
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null)
+        => serviceKey is null && serviceType.IsInstanceOfType(this) ? this : null;
+    public void Dispose() { }
+
+    public Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            var history = messages.ToList();
+            if (_nextResponse == 0 && history.LastOrDefault(m => m.Role == ChatRole.User)?.Text != _fixture.Prompt)
+                throw Divergence("Replay prompt differs from the recorded prompt.");
+            if (_pending.Any(call => !call.Consumed)) throw Divergence("Runtime skipped a recorded tool call.");
+            var results = history.Where(m => m.Role == ChatRole.Tool).SelectMany(m => m.Contents).OfType<FunctionResultContent>().ToArray();
+            foreach (var call in _pending)
+                if (results.Count(result => result.CallId == call.Id) != 1 || !results.Any(result => result.CallId == call.Id && result.Result?.ToString() == call.Call.Result))
+                    throw Divergence("Runtime did not return the recorded tool result to the provider.");
+            if (_nextResponse >= _fixture.Responses.Count) throw Divergence("Runtime requested an unrecorded provider response.");
+            var response = _fixture.Responses[_nextResponse++];
+            _pending.Clear();
+            var content = new List<AIContent>();
+            if (response.Text.Length > 0) content.Add(new TextContent(response.Text));
+            for (var i = 0; i < response.ToolCalls.Count; i++)
+            {
+                var call = response.ToolCalls[i];
+                var id = $"replay_{_nextResponse}_{i}";
+                _pending.Add(new PendingCall(id, call));
+                using var args = JsonDocument.Parse(call.ArgumentsJson);
+                var values = args.RootElement.EnumerateObject().ToDictionary(p => p.Name, p => (object?)p.Value.Clone(), StringComparer.Ordinal);
+                content.Add(new FunctionCallContent(id, call.ToolName, values));
+            }
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, content)));
+        }
+    }
+
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var response = await GetResponseAsync(messages, options, cancellationToken);
+        foreach (var message in response.Messages)
+            yield return new ChatResponseUpdate { Role = message.Role, Contents = message.Contents };
+    }
+
+    public void VerifyComplete()
+    {
+        lock (_gate)
+            if (_diverged || _nextResponse != _fixture.Responses.Count || _pending.Any(call => !call.Consumed))
+                throw new InvalidOperationException("Replay did not consume the complete fixture without divergence.");
+    }
+
+    private string Execute(string tool, string arguments, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            var match = _pending.FirstOrDefault(call => !call.Consumed && call.Call.ToolName == tool && ArgumentsEqual(call.Call.ArgumentsJson, arguments));
+            if (match is null) throw Divergence("Tool name, arguments, or execution count differs from the fixture.");
+            match.Consumed = true;
+            return match.Call.Result;
+        }
+    }
+
+    private InvalidOperationException Divergence(string message) { _diverged = true; return new(message); }
+
+    private static bool ArgumentsEqual(string expected, string actual)
+    {
+        try
+        {
+            using var left = JsonDocument.Parse(expected);
+            using var right = JsonDocument.Parse(actual);
+            return JsonElement.DeepEquals(left.RootElement, right.RootElement);
+        }
+        catch (JsonException) { return false; }
+    }
+
+    private sealed class PendingCall(string id, ReplayToolCall call)
+    {
+        public string Id { get; } = id;
+        public ReplayToolCall Call { get; } = call;
+        public bool Consumed { get; set; }
+    }
+
+    private sealed class ReplayTool(TrajectoryReplay owner, string name) : ITool
+    {
+        public string Name => name;
+        public string Description => "Offline replay stub; returns a recorded result without performing external actions.";
+        public string ParameterSchema => """{"type":"object","additionalProperties":true}""";
+        public ValueTask<string> ExecuteAsync(string argumentsJson, CancellationToken ct) => ValueTask.FromResult(owner.Execute(Name, argumentsJson, ct));
+    }
+}

--- a/src/OpenClaw.Testing/TrajectoryReplay.cs
+++ b/src/OpenClaw.Testing/TrajectoryReplay.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Microsoft.Extensions.AI;
 using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Models;
 
 namespace OpenClaw.Testing;
 
@@ -13,6 +14,7 @@ public sealed class TrajectoryReplay : IChatClient
     private readonly List<PendingCall> _pending = [];
     private int _nextResponse;
     private bool _diverged;
+    private readonly HashSet<string> _issuedIds = new(StringComparer.Ordinal);
     public IReadOnlyList<ITool> Tools { get; }
 
     public TrajectoryReplay(TrajectoryReplayFixture fixture)
@@ -30,7 +32,7 @@ public sealed class TrajectoryReplay : IChatClient
             {
                 if (call is null || string.IsNullOrWhiteSpace(call.ToolName) || call.Result is null)
                     throw new InvalidDataException("Invalid replay tool call.");
-                using var args = JsonDocument.Parse(call.ArgumentsJson);
+                using var args = ParseArguments(call.ArgumentsJson);
                 if (args.RootElement.ValueKind != JsonValueKind.Object)
                     throw new InvalidDataException("Replay arguments must be JSON objects.");
                 if (response.ToolCalls.Count(other => other.ToolName == call.ToolName && ArgumentsEqual(other.ArgumentsJson, call.ArgumentsJson)) > 1)
@@ -53,10 +55,11 @@ public sealed class TrajectoryReplay : IChatClient
         lock (_gate)
         {
             var history = messages.ToList();
-            if (_nextResponse == 0 && history.LastOrDefault(m => m.Role == ChatRole.User)?.Text != _fixture.Prompt)
+            if (_nextResponse == 0 && history.LastOrDefault(m => m.Role == ChatRole.User)?.Text != NormalizePrompt(_fixture.Prompt))
                 throw Divergence("Replay prompt differs from the recorded prompt.");
             if (_pending.Any(call => !call.Consumed)) throw Divergence("Runtime skipped a recorded tool call.");
             var results = history.Where(m => m.Role == ChatRole.Tool).SelectMany(m => m.Contents).OfType<FunctionResultContent>().ToArray();
+            if (results.Any(result => !_issuedIds.Contains(result.CallId))) throw Divergence("Runtime returned a result for an unknown call ID.");
             foreach (var call in _pending)
                 if (results.Count(result => result.CallId == call.Id) != 1 || !results.Any(result => result.CallId == call.Id && result.Result?.ToString() == call.Call.Result))
                     throw Divergence("Runtime did not return the recorded tool result to the provider.");
@@ -69,6 +72,7 @@ public sealed class TrajectoryReplay : IChatClient
             {
                 var call = response.ToolCalls[i];
                 var id = $"replay_{_nextResponse}_{i}";
+                _issuedIds.Add(id);
                 _pending.Add(new PendingCall(id, call));
                 using var args = JsonDocument.Parse(call.ArgumentsJson);
                 var values = args.RootElement.EnumerateObject().ToDictionary(p => p.Name, p => (object?)p.Value.Clone(), StringComparer.Ordinal);
@@ -103,6 +107,18 @@ public sealed class TrajectoryReplay : IChatClient
             match.Consumed = true;
             return match.Call.Result;
         }
+    }
+
+    private static JsonDocument ParseArguments(string json)
+    {
+        try { return JsonDocument.Parse(json); }
+        catch (JsonException) { throw new InvalidDataException("Replay arguments must be valid JSON."); }
+    }
+    private static string NormalizePrompt(string prompt)
+    {
+        var (markers, text) = MediaMarkerProtocol.Extract(prompt);
+        if (markers.Count > 0) throw new InvalidDataException("Text replay does not support media markers.");
+        return string.IsNullOrWhiteSpace(text) ? prompt : text;
     }
 
     private InvalidOperationException Divergence(string message) { _diverged = true; return new(message); }

--- a/src/OpenClaw.Testing/TrajectoryReplayFixture.cs
+++ b/src/OpenClaw.Testing/TrajectoryReplayFixture.cs
@@ -1,0 +1,22 @@
+namespace OpenClaw.Testing;
+
+/// <summary>Sanitized provider responses and tool outputs for one exported user exchange.</summary>
+public sealed class TrajectoryReplayFixture
+{
+    public int SchemaVersion { get; init; } = 1;
+    public string Prompt { get; init; } = "";
+    public List<ReplayResponse> Responses { get; init; } = [];
+}
+
+public sealed class ReplayResponse
+{
+    public string Text { get; init; } = "";
+    public List<ReplayToolCall> ToolCalls { get; init; } = [];
+}
+
+public sealed class ReplayToolCall
+{
+    public string ToolName { get; init; } = "";
+    public string ArgumentsJson { get; init; } = "{}";
+    public string Result { get; init; } = "";
+}

--- a/src/OpenClaw.Testing/TrajectoryReplayImporter.cs
+++ b/src/OpenClaw.Testing/TrajectoryReplayImporter.cs
@@ -14,6 +14,7 @@ public static class TrajectoryReplayImporter
     public static async Task<TrajectoryReplayFixture> ImportAsync(TextReader reader, string sessionId,
         int promptTurnIndex, IRedactionPipeline redaction, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(reader);
         ArgumentNullException.ThrowIfNull(redaction);
         ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
         ArgumentOutOfRangeException.ThrowIfNegative(promptTurnIndex);
@@ -47,7 +48,10 @@ public static class TrajectoryReplayImporter
         var prompt = records[start];
         if (prompt.Role != "user" || prompt.Content is null)
             throw new InvalidDataException("Replay requires a user text prompt.");
-        var fixture = new TrajectoryReplayFixture { Prompt = Redact(prompt.Content, redaction) };
+        var cleanPrompt = Redact(prompt.Content, redaction);
+        if (MediaMarkerProtocol.Extract(cleanPrompt).Markers.Count > 0)
+            throw new InvalidDataException("This text fixture importer does not support media markers.");
+        var fixture = new TrajectoryReplayFixture { Prompt = cleanPrompt };
         ReplayResponse? response = null;
         var turnIndex = promptTurnIndex;
         for (var i = start + 1; i < records.Count; i++)
@@ -131,7 +135,7 @@ public static class TrajectoryReplayImporter
                     if (!keys.Add(key)) throw new InvalidDataException("Duplicate argument keys after redaction.");
                     writer.WritePropertyName(key);
                     var normalized = property.Name.Replace("_", "").Replace("-", "").ToLowerInvariant();
-                    if (normalized is "password" or "secret" or "apikey" or "token" or "accesstoken" or "refreshtoken" or "authorization" or "cookie")
+                    if (normalized is "password" or "secret" or "apikey" or "token" or "accesstoken" or "refreshtoken" or "authorization" or "cookie" or "clientsecret" or "privatekey" or "sessiontoken" or "xapikey")
                         writer.WriteStringValue("[REDACTED]");
                     else WriteRedactedJson(writer, property.Value, pipeline);
                 }
@@ -143,7 +147,11 @@ public static class TrajectoryReplayImporter
                 writer.WriteEndArray();
                 break;
             case JsonValueKind.String: writer.WriteStringValue(Redact(value.GetString()!, pipeline)); break;
-            default: value.WriteTo(writer); break;
+            default:
+                var raw = value.GetRawText();
+                var clean = Redact(raw, pipeline);
+                if (raw == clean) value.WriteTo(writer); else writer.WriteStringValue(clean);
+                break;
         }
     }
 }

--- a/src/OpenClaw.Testing/TrajectoryReplayImporter.cs
+++ b/src/OpenClaw.Testing/TrajectoryReplayImporter.cs
@@ -1,0 +1,149 @@
+using System.Text;
+using System.Text.Json;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Security;
+
+namespace OpenClaw.Testing;
+
+/// <summary>Imports one complete user exchange from the gateway's v1 JSONL trajectory export.</summary>
+public static class TrajectoryReplayImporter
+{
+    public const int MaxInputCharacters = 8 * 1024 * 1024;
+    public const int MaxRecords = 10_000;
+
+    public static async Task<TrajectoryReplayFixture> ImportAsync(TextReader reader, string sessionId,
+        int promptTurnIndex, IRedactionPipeline redaction, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(redaction);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
+        ArgumentOutOfRangeException.ThrowIfNegative(promptTurnIndex);
+        var input = new StringBuilder();
+        var buffer = new char[4096];
+        int count;
+        while ((count = await reader.ReadAsync(buffer.AsMemory(), cancellationToken)) > 0)
+        {
+            if (input.Length + count > MaxInputCharacters)
+                throw new InvalidDataException("Trajectory exceeds the import size limit.");
+            input.Append(buffer, 0, count);
+        }
+        var records = new List<TrajectoryExportRecord>();
+        using var lines = new StringReader(input.ToString());
+        var recordCount = 0;
+        while (lines.ReadLine() is { } line)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            if (++recordCount > MaxRecords) throw new InvalidDataException("Trajectory has too many records.");
+            TrajectoryExportRecord record;
+            try { record = JsonSerializer.Deserialize(line, CoreJsonContext.Default.TrajectoryExportRecord) ?? throw new JsonException(); }
+            catch (JsonException) { throw new InvalidDataException("Invalid trajectory JSON record."); }
+            if (record.SchemaVersion != 1) throw new InvalidDataException("Unsupported trajectory schema version.");
+            if (record.SessionId == sessionId && record.Type is not "evidence_bundle" and not "governance_ledger_entry") records.Add(record);
+        }
+        var start = records.FindIndex(r => r.Type == "prompt" && r.TurnIndex == promptTurnIndex);
+        if (start < 0) throw new InvalidDataException("Selected user prompt was not found.");
+        if (records.Count(r => r.Type == "prompt" && r.TurnIndex == promptTurnIndex) != 1)
+            throw new InvalidDataException("Selected prompt is ambiguous.");
+        var prompt = records[start];
+        if (prompt.Role != "user" || prompt.Content is null)
+            throw new InvalidDataException("Replay requires a user text prompt.");
+        var fixture = new TrajectoryReplayFixture { Prompt = Redact(prompt.Content, redaction) };
+        ReplayResponse? response = null;
+        var turnIndex = promptTurnIndex;
+        for (var i = start + 1; i < records.Count; i++)
+        {
+            var record = records[i];
+            if (record.Type == "prompt") break;
+            if (record.Type == "response")
+            {
+                if (record.Role != "assistant" || record.TurnIndex <= turnIndex || record.Content is null)
+                    throw new InvalidDataException("Response order or role is invalid.");
+                if (response is { ToolCalls.Count: 0 })
+                    throw new InvalidDataException("Multiple final responses are not supported.");
+                turnIndex = record.TurnIndex;
+                response = new ReplayResponse { Text = Redact(record.Content, redaction) };
+                fixture.Responses.Add(response);
+            }
+            else if (record.Type == "tool_call")
+            {
+                if (response is null || record.TurnIndex != turnIndex || ++i >= records.Count)
+                    throw new InvalidDataException("Tool call is missing its response or result.");
+                var result = records[i];
+                if (result.Type != "tool_result" || result.TurnIndex != turnIndex || result.CallId != record.CallId || result.ToolName != record.ToolName || result.Result is null)
+                    throw new InvalidDataException("Tool result does not match its call.");
+                if (result.ResultStatus is not null and not "completed" || result.FailureCode is not null || result.FailureMessage is not null)
+                    throw new InvalidDataException("Only completed tool results can be replayed by this fixture version.");
+                if (string.IsNullOrWhiteSpace(record.ToolName) || record.ToolName.Length > 128 || record.ToolName.Any(c => !char.IsAsciiLetterOrDigit(c) && c is not '_' and not '-' and not '.'))
+                    throw new InvalidDataException("Invalid replay tool name.");
+                string args;
+                try
+                {
+                    using var json = JsonDocument.Parse(record.Arguments ?? "");
+                    if (json.RootElement.ValueKind != JsonValueKind.Object) throw new JsonException();
+                    using var stream = new MemoryStream();
+                    using (var writer = new Utf8JsonWriter(stream)) WriteRedactedJson(writer, json.RootElement, redaction);
+                    args = Encoding.UTF8.GetString(stream.ToArray());
+                }
+                catch (JsonException) { throw new InvalidDataException("Tool arguments must be a valid JSON object."); }
+                response.ToolCalls.Add(new ReplayToolCall { ToolName = record.ToolName, ArgumentsJson = args, Result = RedactPayload(result.Result, redaction) });
+            }
+            else throw new InvalidDataException("Unexpected trajectory record in selected exchange.");
+        }
+        if (fixture.Responses.Count == 0 || fixture.Responses[^1].ToolCalls.Count != 0)
+            throw new InvalidDataException("Selected exchange is incomplete: a final assistant response is required.");
+        for (var i = 0; i < fixture.Responses.Count; i++)
+        {
+            var item = fixture.Responses[i];
+            // Native session history stores this marker instead of provider text for tool batches.
+            if (item.ToolCalls.Count > 0 && item.Text == "[tool_use]")
+                fixture.Responses[i] = new ReplayResponse { ToolCalls = item.ToolCalls };
+        }
+        // Validate replay-only constraints (including ambiguous parallel calls) before returning a fixture.
+        using var validation = new TrajectoryReplay(fixture);
+        return fixture;
+    }
+
+    private static string RedactPayload(string text, IRedactionPipeline pipeline)
+    {
+        try
+        {
+            using var json = JsonDocument.Parse(text);
+            using var stream = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(stream)) WriteRedactedJson(writer, json.RootElement, pipeline);
+            return Encoding.UTF8.GetString(stream.ToArray());
+        }
+        catch (JsonException) { return Redact(text, pipeline); }
+    }
+
+    private static string Redact(string text, IRedactionPipeline pipeline)
+        => new BaselineSecretRedactor().Redact(pipeline.Redact(text));
+
+    private static void WriteRedactedJson(Utf8JsonWriter writer, JsonElement value, IRedactionPipeline pipeline)
+    {
+        switch (value.ValueKind)
+        {
+            case JsonValueKind.Object:
+                writer.WriteStartObject();
+                var keys = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var property in value.EnumerateObject())
+                {
+                    var key = Redact(property.Name, pipeline);
+                    if (!keys.Add(key)) throw new InvalidDataException("Duplicate argument keys after redaction.");
+                    writer.WritePropertyName(key);
+                    var normalized = property.Name.Replace("_", "").Replace("-", "").ToLowerInvariant();
+                    if (normalized is "password" or "secret" or "apikey" or "token" or "accesstoken" or "refreshtoken" or "authorization" or "cookie")
+                        writer.WriteStringValue("[REDACTED]");
+                    else WriteRedactedJson(writer, property.Value, pipeline);
+                }
+                writer.WriteEndObject();
+                break;
+            case JsonValueKind.Array:
+                writer.WriteStartArray();
+                foreach (var item in value.EnumerateArray()) WriteRedactedJson(writer, item, pipeline);
+                writer.WriteEndArray();
+                break;
+            case JsonValueKind.String: writer.WriteStringValue(Redact(value.GetString()!, pipeline)); break;
+            default: value.WriteTo(writer); break;
+        }
+    }
+}

--- a/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
+++ b/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
@@ -1447,6 +1447,34 @@ public sealed class GatewayAdminEndpointTests
     }
 
     [Fact]
+    public async Task AdminTrajectoryExport_CanReplayACompleteNativeExchange()
+    {
+        await using var harness = await CreateHarnessAsync(nonLoopbackBind: true);
+        var session = await harness.Runtime.SessionManager.GetOrCreateByIdAsync("replay-export", "api", "operator", TestContext.Current.CancellationToken);
+        session.History.Add(new ChatTurn { Role = "user", Content = "Look up the answer" });
+        session.History.Add(new ChatTurn { Role = "assistant", Content = "[tool_use]", ToolCalls =
+            [new() { CallId = "original-call", ToolName = "lookup", Arguments = "{}", Result = "42", ResultStatus = ToolResultStatuses.Completed }] });
+        session.History.Add(new ChatTurn { Role = "assistant", Content = "The answer is 42" });
+        await harness.Runtime.SessionManager.PersistAsync(session, TestContext.Current.CancellationToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/admin/trajectory/export?sessionId=replay-export&anonymize=true");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", harness.AuthToken);
+        using var response = await harness.Client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var jsonl = await response.Content.ReadAsStringAsync();
+        using var first = JsonDocument.Parse(jsonl.Split('\n', StringSplitOptions.RemoveEmptyEntries)[0]);
+        var exportedId = first.RootElement.GetProperty("sessionId").GetString()!;
+        var fixture = await OpenClaw.Testing.TrajectoryReplayImporter.ImportAsync(new StringReader(jsonl), exportedId, 0,
+            new RedactionPipeline([new BaselineSecretRedactor()]), TestContext.Current.CancellationToken);
+        Assert.Empty(fixture.Responses[0].Text);
+        var result = await OpenClaw.Testing.RuntimeScenarioRunner.RunReplayAsync(fixture,
+            [new() { Type = OpenClaw.Testing.ScenarioOracleTypes.FinalAnswerContains, Value = JsonSerializer.SerializeToElement("42") }],
+            (provider, tools) => new AgentRuntime(provider, tools, Substitute.For<IMemoryStore>(), new LlmProviderConfig { Model = "offline" }, maxHistoryTurns: 20),
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(result.Passed, result.FailureSummary);
+        Assert.Equal("The answer is 42", result.Trace.FinalAnswer);
+    }
+
+    [Fact]
     public async Task AdminTrajectoryExport_ExportsJsonlAndAnonymizes()
     {
         await using var harness = await CreateHarnessAsync(nonLoopbackBind: true);

--- a/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
+++ b/src/OpenClaw.Tests/GatewayAdminEndpointTests.cs
@@ -1463,7 +1463,8 @@ public sealed class GatewayAdminEndpointTests
         var jsonl = await response.Content.ReadAsStringAsync();
         using var first = JsonDocument.Parse(jsonl.Split('\n', StringSplitOptions.RemoveEmptyEntries)[0]);
         var exportedId = first.RootElement.GetProperty("sessionId").GetString()!;
-        var fixture = await OpenClaw.Testing.TrajectoryReplayImporter.ImportAsync(new StringReader(jsonl), exportedId, 0,
+        using var trajectoryReader = new StringReader(jsonl);
+        var fixture = await OpenClaw.Testing.TrajectoryReplayImporter.ImportAsync(trajectoryReader, exportedId, 0,
             new RedactionPipeline([new BaselineSecretRedactor()]), TestContext.Current.CancellationToken);
         Assert.Empty(fixture.Responses[0].Text);
         var result = await OpenClaw.Testing.RuntimeScenarioRunner.RunReplayAsync(fixture,

--- a/src/OpenClaw.Tests/TrajectoryReplayTests.cs
+++ b/src/OpenClaw.Tests/TrajectoryReplayTests.cs
@@ -267,7 +267,9 @@ public sealed class TrajectoryReplayTests
     public async Task Import_HonorsCancellationAndSizeLimit()
     {
         using var canceled = new CancellationTokenSource(); canceled.Cancel();
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => TrajectoryReplayImporter.ImportAsync(new StringReader("data"), "s", 0, Redaction, canceled.Token));
-        await Assert.ThrowsAsync<InvalidDataException>(() => TrajectoryReplayImporter.ImportAsync(new StringReader(new string('x', TrajectoryReplayImporter.MaxInputCharacters + 1)), "s", 0, Redaction, Ct));
+        using var cancelledReader = new StringReader("data");
+        using var oversizedReader = new StringReader(new string('x', TrajectoryReplayImporter.MaxInputCharacters + 1));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => TrajectoryReplayImporter.ImportAsync(cancelledReader, "s", 0, Redaction, canceled.Token));
+        await Assert.ThrowsAsync<InvalidDataException>(() => TrajectoryReplayImporter.ImportAsync(oversizedReader, "s", 0, Redaction, Ct));
     }
 }

--- a/src/OpenClaw.Tests/TrajectoryReplayTests.cs
+++ b/src/OpenClaw.Tests/TrajectoryReplayTests.cs
@@ -47,6 +47,30 @@ public sealed class TrajectoryReplayTests
     ];
 
     [Theory]
+    [InlineData("Find private-person\n")]
+    [InlineData("Find private-person\r\n")]
+    public async Task ReplayNormalizesChannelPromptWhitespace(string prompt)
+    {
+        var records = Records(); records[0] = Record("prompt", 0, prompt);
+        var result = await RuntimeScenarioRunner.RunReplayAsync(await Import(records), Assertions(), Runtime, cancellationToken: Ct);
+        Assert.True(result.Passed, result.FailureSummary);
+    }
+
+    [Fact]
+    public async Task ImportRedactsNumericValuesThroughCallerPipeline()
+    {
+        var records = Records(); records[2] = Record("tool_call", 1, arguments: "{\"account\":123456}");
+        using var reader = new StringReader(string.Join('\n', records.Select(r => JsonSerializer.Serialize(r, CoreJsonContext.Default.TrajectoryExportRecord))));
+        var fixture = await TrajectoryReplayImporter.ImportAsync(reader, "private-session", 0, new RedactionPipeline([new NumericRedactor()]), Ct);
+        Assert.DoesNotContain("123456", fixture.Responses[0].ToolCalls[0].ArgumentsJson);
+    }
+    private sealed class NumericRedactor : ISensitiveDataRedactor
+    {
+        public string Name => "numeric";
+        public string Redact(string? value) => (value ?? "").Replace("123456", "[NUMBER]");
+    }
+
+    [Theory]
     [InlineData("client_secret")]
     [InlineData("private_key")]
     [InlineData("session_token")]

--- a/src/OpenClaw.Tests/TrajectoryReplayTests.cs
+++ b/src/OpenClaw.Tests/TrajectoryReplayTests.cs
@@ -33,9 +33,11 @@ public sealed class TrajectoryReplayTests
         Record("tool_result", 1, result: """{"answer":"private-person","token":"hidden-token"}""", status: "completed"),
         Record("response", 2, "Found private-person")
     ];
-    private static Task<TrajectoryReplayFixture> Import(IEnumerable<TrajectoryExportRecord> records, int turn = 0)
-        => TrajectoryReplayImporter.ImportAsync(new StringReader(string.Join('\n', records.Select(r => JsonSerializer.Serialize(r, CoreJsonContext.Default.TrajectoryExportRecord)))),
-            "private-session", turn, Redaction, Ct);
+    private static async Task<TrajectoryReplayFixture> Import(IEnumerable<TrajectoryExportRecord> records, int turn = 0)
+    {
+        using var reader = new StringReader(string.Join('\n', records.Select(r => JsonSerializer.Serialize(r, CoreJsonContext.Default.TrajectoryExportRecord))));
+        return await TrajectoryReplayImporter.ImportAsync(reader, "private-session", turn, Redaction, Ct);
+    }
     private static IAgentRuntime Runtime(IChatClient client, IReadOnlyList<ITool> tools)
         => new AgentRuntime(client, tools, Substitute.For<IMemoryStore>(), new LlmProviderConfig { Model = "offline" }, maxHistoryTurns: 20);
     private static List<ScenarioOracleDefinition> Assertions() =>
@@ -43,6 +45,28 @@ public sealed class TrajectoryReplayTests
         new() { Type = ScenarioOracleTypes.ToolCalled, Tool = "lookup" },
         new() { Type = ScenarioOracleTypes.FinalAnswerContains, Value = JsonSerializer.SerializeToElement("Found [PERSON]") }
     ];
+
+    [Theory]
+    [InlineData("client_secret")]
+    [InlineData("private_key")]
+    [InlineData("session_token")]
+    [InlineData("x-api-key")]
+    public async Task ImportMasksOpaqueCredentialFields(string field)
+    {
+        var records = Records();
+        records[2] = Record("tool_call", 1, arguments: "{\"" + field + "\":\"opaque-value\"}");
+        var fixture = await Import(records);
+        Assert.DoesNotContain("opaque-value", fixture.Responses[0].ToolCalls[0].ArgumentsJson);
+    }
+
+    [Fact]
+    public async Task UnexpectedResultIdIsRejected()
+    {
+        using var replay = new TrajectoryReplay(await Import(Records()));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replay.GetResponseAsync([
+            new ChatMessage(ChatRole.User, "Find [PERSON]"),
+            new ChatMessage(ChatRole.Tool, [new FunctionResultContent("unknown", "extra")])], cancellationToken: Ct));
+    }
 
     [Fact]
     public async Task Import_RedactsNestedValuesAndDropsSourceIdentity()

--- a/src/OpenClaw.Tests/TrajectoryReplayTests.cs
+++ b/src/OpenClaw.Tests/TrajectoryReplayTests.cs
@@ -1,0 +1,249 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using NSubstitute;
+using OpenClaw.Agent;
+using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Security;
+using OpenClaw.Testing;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class TrajectoryReplayTests
+{
+    private static readonly IRedactionPipeline Redaction = new RedactionPipeline([new BaselineSecretRedactor(), new TestRedactor()]);
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+    private sealed class TestRedactor : ISensitiveDataRedactor
+    {
+        public string Name => "test-sensitive-data";
+        public string Redact(string? value) => (value ?? "").Replace("private-person", "[PERSON]");
+    }
+    private static TrajectoryExportRecord Record(string type, int index, string? content = null, string? arguments = null,
+        string? result = null, string? status = null, string session = "private-session", int schema = 1)
+        => new() { SchemaVersion = schema, Type = type, TurnIndex = index, SessionId = session,
+            ChannelId = "private-channel", SenderId = "private-sender", Content = content,
+            Role = type == "prompt" ? "user" : "assistant", ToolName = type.StartsWith("tool_") ? "lookup" : null,
+            CallId = type.StartsWith("tool_") ? "private-call" : null, Arguments = arguments, Result = result, ResultStatus = status };
+    private static List<TrajectoryExportRecord> Records() =>
+    [
+        Record("prompt", 0, "Find private-person"),
+        Record("response", 1, "Checking"),
+        Record("tool_call", 1, arguments: """{"query":"private-person","password":"hidden-password","nested":[{"api_key":"hidden-key"}]}"""),
+        Record("tool_result", 1, result: """{"answer":"private-person","token":"hidden-token"}""", status: "completed"),
+        Record("response", 2, "Found private-person")
+    ];
+    private static Task<TrajectoryReplayFixture> Import(IEnumerable<TrajectoryExportRecord> records, int turn = 0)
+        => TrajectoryReplayImporter.ImportAsync(new StringReader(string.Join('\n', records.Select(r => JsonSerializer.Serialize(r, CoreJsonContext.Default.TrajectoryExportRecord)))),
+            "private-session", turn, Redaction, Ct);
+    private static IAgentRuntime Runtime(IChatClient client, IReadOnlyList<ITool> tools)
+        => new AgentRuntime(client, tools, Substitute.For<IMemoryStore>(), new LlmProviderConfig { Model = "offline" }, maxHistoryTurns: 20);
+    private static List<ScenarioOracleDefinition> Assertions() =>
+    [
+        new() { Type = ScenarioOracleTypes.ToolCalled, Tool = "lookup" },
+        new() { Type = ScenarioOracleTypes.FinalAnswerContains, Value = JsonSerializer.SerializeToElement("Found [PERSON]") }
+    ];
+
+    [Fact]
+    public async Task Import_RedactsNestedValuesAndDropsSourceIdentity()
+    {
+        var fixture = await Import(Records());
+        var json = JsonSerializer.Serialize(fixture, ScenarioJsonContext.Default.TrajectoryReplayFixture);
+        Assert.DoesNotContain("private-", json);
+        Assert.DoesNotContain("hidden-", json);
+        Assert.Contains("REDACTED", json);
+        Assert.Contains("[PERSON]", json);
+        var restored = JsonSerializer.Deserialize(json, ScenarioJsonContext.Default.TrajectoryReplayFixture)!;
+        Assert.Equal(fixture.Prompt, restored.Prompt);
+        Assert.Equal(2, restored.Responses.Count);
+    }
+
+    [Fact]
+    public async Task Replay_ExercisesRealRuntimeAndTools_WithIndependentAssertions()
+    {
+        var result = await RuntimeScenarioRunner.RunReplayAsync(await Import(Records()), Assertions(), Runtime, cancellationToken: Ct);
+        Assert.True(result.Passed, result.FailureSummary);
+        Assert.Contains(result.Trace.Steps, s => s.Kind == TraceStepKinds.ToolCall && s.ToolName == "lookup");
+        Assert.Contains(result.Trace.Steps, s => s.Kind == TraceStepKinds.ToolResult && s.Result!.Contains("PERSON"));
+        Assert.Contains(result.OracleResults, o => o.Name == "replay-consumed" && o.Passed);
+    }
+
+    [Fact]
+    public async Task Replay_RequiresOutcomeAssertions()
+    {
+        var result = await RuntimeScenarioRunner.RunReplayAsync(await Import(Records()), [], Runtime, cancellationToken: Ct);
+        Assert.False(result.Passed);
+        Assert.Contains(result.OracleResults, o => o.Name == "oracles-present" && !o.Passed);
+    }
+
+    [Theory]
+    [InlineData("failed")]
+    [InlineData("denied")]
+    [InlineData("unknown")]
+    public async Task Import_RejectsNonCompletedTools(string status)
+    {
+        var records = Records(); records[3] = Record("tool_result", 1, result: "outcome", status: status);
+        await Assert.ThrowsAsync<InvalidDataException>(() => Import(records));
+    }
+
+    [Fact]
+    public async Task Import_RejectsIncompleteExchange()
+    {
+        await Assert.ThrowsAsync<InvalidDataException>(() => Import(Records().Take(4)));
+        var records = Records(); records.RemoveAt(3);
+        await Assert.ThrowsAsync<InvalidDataException>(() => Import(records));
+    }
+
+    [Fact]
+    public async Task Import_RejectsMalformedArgumentsWithoutEchoingSensitiveInput()
+    {
+        var records = Records(); records[2] = Record("tool_call", 1, arguments: "private-person");
+        var ex = await Assert.ThrowsAsync<InvalidDataException>(() => Import(records));
+        Assert.DoesNotContain("private-person", ex.Message);
+    }
+
+    [Fact]
+    public async Task Import_RejectsWrongTurnResult()
+    {
+        var records = Records(); records[3] = Record("tool_result", 3, result: "wrong");
+        await Assert.ThrowsAsync<InvalidDataException>(() => Import(records));
+    }
+
+    [Fact]
+    public async Task Import_RejectsUnsupportedSchemaAndAmbiguousSelection()
+    {
+        await Assert.ThrowsAsync<InvalidDataException>(() => Import([Record("prompt", 0, "hello", schema: 2)]));
+        await Assert.ThrowsAsync<InvalidDataException>(() => Import(Records().Concat([Record("prompt", 0, "duplicate")])));
+    }
+
+    [Fact]
+    public async Task Import_SelectsOneSessionAndStopsAtNextPrompt()
+    {
+        var records = Records();
+        records.Insert(0, Record("prompt", 0, "other secret", session: "other-session"));
+        records.Add(Record("prompt", 3, "later secret"));
+        records.Add(Record("response", 4, "later answer"));
+        records.Add(Record("evidence_bundle", -1));
+        var fixture = await Import(records);
+        Assert.Equal(2, fixture.Responses.Count);
+        var later = await Import(records, 3);
+        Assert.Single(later.Responses);
+    }
+
+    [Fact]
+    public async Task Import_IgnoresEvidenceAndGovernancePayloads()
+    {
+        var fixture = await Import(Records().Concat([Record("evidence_bundle", -1), Record("governance_ledger_entry", -1)]));
+        Assert.Equal(2, fixture.Responses.Count);
+    }
+
+    [Fact]
+    public async Task Replay_RejectsSkippedToolsAndLatchesDivergence()
+    {
+        var fixture = await Import(Records());
+        using var replay = new TrajectoryReplay(fixture);
+        var messages = new[] { new ChatMessage(ChatRole.User, fixture.Prompt) };
+        await replay.GetResponseAsync(messages, cancellationToken: Ct);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replay.GetResponseAsync(messages, cancellationToken: Ct));
+        Assert.Throws<InvalidOperationException>(replay.VerifyComplete);
+    }
+
+    [Fact]
+    public async Task Replay_RejectsChangedToolArguments()
+    {
+        var fixture = await Import(Records()); using var replay = new TrajectoryReplay(fixture);
+        await replay.GetResponseAsync([new ChatMessage(ChatRole.User, fixture.Prompt)], cancellationToken: Ct);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replay.Tools[0].ExecuteAsync("{}", Ct).AsTask());
+        Assert.Throws<InvalidOperationException>(replay.VerifyComplete);
+    }
+
+    [Fact]
+    public async Task Replay_AcceptsReorderedJsonPropertiesAndRejectsDuplicateExecution()
+    {
+        var fixture = new TrajectoryReplayFixture { Prompt = "test", Responses =
+            [new() { ToolCalls = [new() { ToolName = "lookup", ArgumentsJson = "{\"a\":1,\"b\":2}", Result = "ok" }] }, new() { Text = "done" }] };
+        using var replay = new TrajectoryReplay(fixture);
+        await replay.GetResponseAsync([new ChatMessage(ChatRole.User, "test")], cancellationToken: Ct);
+        Assert.Equal("ok", await replay.Tools[0].ExecuteAsync("{\"b\":2,\"a\":1}", Ct));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replay.Tools[0].ExecuteAsync("{\"a\":1,\"b\":2}", Ct).AsTask());
+        Assert.Throws<InvalidOperationException>(replay.VerifyComplete);
+    }
+
+    [Fact]
+    public async Task Replay_RejectsChangedToolResultDeliveredToProvider()
+    {
+        var fixture = await Import(Records()); using var replay = new TrajectoryReplay(fixture);
+        var prompt = new ChatMessage(ChatRole.User, fixture.Prompt);
+        var response = await replay.GetResponseAsync([prompt], cancellationToken: Ct);
+        var call = response.Messages[0].Contents.OfType<FunctionCallContent>().Single();
+        await replay.Tools[0].ExecuteAsync(fixture.Responses[0].ToolCalls[0].ArgumentsJson, Ct);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replay.GetResponseAsync(
+            [prompt, new ChatMessage(ChatRole.Tool, [new FunctionResultContent(call.CallId, "wrong-result")])], cancellationToken: Ct));
+    }
+
+    [Fact]
+    public async Task Replay_UsesFreshStateAcrossRuns()
+    {
+        var fixture = await Import(Records());
+        for (var i = 0; i < 2; i++)
+        {
+            var result = await RuntimeScenarioRunner.RunReplayAsync(fixture, Assertions(), Runtime, cancellationToken: Ct);
+            Assert.True(result.Passed, result.FailureSummary);
+        }
+    }
+
+    [Fact]
+    public async Task Replay_HandlesParallelCallsWithDifferentArguments()
+    {
+        var fixture = new TrajectoryReplayFixture
+        {
+            Prompt = "Look up two things", Responses =
+            [
+                new() { ToolCalls = [new() { ToolName = "lookup", ArgumentsJson = "{\"id\":1}", Result = "one" }, new() { ToolName = "lookup", ArgumentsJson = "{\"id\":2}", Result = "two" }] },
+                new() { Text = "Both found" }
+            ]
+        };
+        var result = await RuntimeScenarioRunner.RunReplayAsync(fixture,
+            [new() { Type = ScenarioOracleTypes.FinalAnswerContains, Value = JsonSerializer.SerializeToElement("Both found") }], Runtime, cancellationToken: Ct);
+        Assert.True(result.Passed, result.FailureSummary);
+        Assert.Equal(2, result.Trace.Steps.Count(s => s.Kind == TraceStepKinds.ToolResult));
+    }
+
+    [Fact]
+    public async Task Replay_DeniedApprovalCannotMasqueradeAsExecutedTool()
+    {
+        var result = await RuntimeScenarioRunner.RunReplayAsync(await Import(Records()), Assertions(),
+            (provider, tools) => new AgentRuntime(provider, tools, Substitute.For<IMemoryStore>(),
+                new LlmProviderConfig { Model = "offline" }, maxHistoryTurns: 20, requireToolApproval: true,
+                approvalRequiredTools: ["lookup"]), cancellationToken: Ct);
+        Assert.False(result.Passed);
+        Assert.Contains(result.Trace.Steps, step => step.Kind == TraceStepKinds.ApprovalRequest);
+        Assert.Contains(result.OracleResults, outcome => outcome.Name == "replay-consumed" && !outcome.Passed);
+    }
+
+    [Fact]
+    public void Replay_RejectsAmbiguousParallelCalls()
+    {
+        var call = new ReplayToolCall { ToolName = "lookup", ArgumentsJson = "{}", Result = "one" };
+        var fixture = new TrajectoryReplayFixture { Prompt = "prompt", Responses = [new() { ToolCalls = [call, call] }, new() { Text = "done" }] };
+        Assert.Throws<InvalidDataException>(() => new TrajectoryReplay(fixture));
+    }
+
+    [Fact]
+    public async Task Replay_RejectsExtraProviderResponses()
+    {
+        using var replay = new TrajectoryReplay(new() { Prompt = "hello", Responses = [new() { Text = "hi" }] });
+        await replay.GetResponseAsync([new ChatMessage(ChatRole.User, "hello")], cancellationToken: Ct);
+        replay.VerifyComplete();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replay.GetResponseAsync([], cancellationToken: Ct));
+        Assert.Throws<InvalidOperationException>(replay.VerifyComplete);
+    }
+
+    [Fact]
+    public async Task Import_HonorsCancellationAndSizeLimit()
+    {
+        using var canceled = new CancellationTokenSource(); canceled.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => TrajectoryReplayImporter.ImportAsync(new StringReader("data"), "s", 0, Redaction, canceled.Token));
+        await Assert.ThrowsAsync<InvalidDataException>(() => TrajectoryReplayImporter.ImportAsync(new StringReader(new string('x', TrajectoryReplayImporter.MaxInputCharacters + 1)), "s", 0, Redaction, Ct));
+    }
+}


### PR DESCRIPTION
## Description

A trajectory export could be inspected or shared, but it could not become an offline regression exercising the real runtime. This adds a bounded, redacting importer for one complete exported text exchange, a deterministic provider/tool replay adapter, and `RuntimeScenarioRunner.RunReplayAsync`.

The runtime must actually request the recorded responses, execute the simulated tools with matching JSON arguments, and return their results to the provider. Skipped, repeated, extra, or mismatched operations fail replay even when the final text matches an assertion. Each run also requires independent outcome assertions.

## Summary

- Import v1 gateway JSONL by exported session ID and prompt turn index; discard source identities/evidence metadata, apply baseline and application redaction, and validate complete response/tool pairs.
- Replay only through recorded adapters; support sequential batches and parallel calls with distinct arguments. Tool adapters never forward to live tools.
- Preserve source-generated JSON compatibility and fresh private fixture state for each run.
- Add a runnable `samples/OpenClaw.TrajectoryReplay` entry point, usage/security guidance, and roadmap updates.

This PR is based directly on `main` and is independent of #213.

## Related Issues

Implements the roadmap's redacted trajectory import and deterministic provider/tool replay fixtures.

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation update
- [x] Tests

## Validation

- [x] `dotnet restore OpenClaw.Net.slnx`
- [x] `dotnet build OpenClaw.Net.slnx --configuration Release --no-restore` — zero warnings and errors.
- [x] `dotnet test OpenClaw.Net.slnx --configuration Release --no-restore` — 2,526 passed; zero failures/skips. Includes 23 new cases.
- [x] `dotnet run --project samples/OpenClaw.HelloAgent -c Release --no-build` — passed.
- [x] New replay sample passed a complete JSONL exchange; verified that its recorded `write_file` operation created no file.
- [x] New replay sample returned exit code 1 for an intentionally incorrect expected answer.
- [x] Authenticated gateway export → redacted import → real native runtime replay passed, including removal of the native `[tool_use]` history placeholder.

## Review Notes

- [x] NativeAOT compatibility considered: source-generated fixture serialization, no new dependencies or dynamic runtime loading.
- [x] Security posture considered: bounded import, generic parse errors, mandatory application redaction pipeline plus baseline patterns, no source IDs in fixtures, and no live tool/provider forwarding.
- [x] Docs/tests updated and scope reviewed.

Version 1 supports complete text exchanges with completed tool results. It rejects incomplete or mismatched records, unsupported schemas, failed/denied/unknown tool outcomes, and ambiguous identical calls in the same batch. It does not reconstruct prior conversation context, original tool schemas, provider reasoning, usage/timing, approval decisions, or media. Automatic production capture and structured-failure/media replay remain roadmap work.

Application-specific redaction and fixture review remain necessary before sharing: generic patterns cannot identify every private value in free text. SDK callers must build the runtime with the supplied adapters and isolated dependencies; the executable sample does this explicitly.

## Commercial or Customer-Driven Contribution Disclosure

General repository roadmap work requested by the maintainer; no customer-specific integration or downstream commercial workflow was supplied.

## Checklist

- [x] Followed CONTRIBUTING and the relevant maintainer review checklist.
- [x] Added tests for redaction, import validation, actual runtime execution, approval denial, parallel calls, argument/result divergence, repeat consumption, and gateway-export interoperability.
- [x] Updated documentation and reviewed security implications.

## Screenshots / Benchmarks

Not applicable: this adds testing SDK functionality and a console sample.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline replay for recorded gateway conversations, including provider responses and tool outputs.
  * Added redaction and validation when importing trajectory exports.
  * Added a command-line sample for running trajectory replays and reporting pass/fail results.
  * Added runtime assertions to verify complete response and tool-call consumption.

* **Documentation**
  * Added guidance for importing and replaying trajectory exports.
  * Updated the roadmap to reflect completed replay functionality.

* **Tests**
  * Added coverage for successful replay, redaction, validation, tool handling, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->