### PR TITLE
Complete safe Companion token migration and recovery

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,8 @@
 
 ## Recently Completed
 
+- **Companion token protection and migration**: OS-backed token storage now automatically migrates legacy JSON/fallback credentials with read-back verification, preserves recoverable copies on failure, respects Remember token and plaintext opt-in, and uses atomic private file writes. See [Companion token storage](companion-token-storage.md).
+
 - Browser sessions invalidate after local operator account updates, deletion, or disablement.
 - Goal completion accepts completed tool work; model status updates run alone and blocked transitions require three observations. Resume resets continuation and blocker counters.
 - Goal state is persisted atomically under the configured memory storage directory and restored lazily after restart.
@@ -78,11 +80,7 @@ Recommend implementing behind flags first, then enabling by default in a major r
    - Current: `legacy` makes empty allowlist behave as allow-all for some channels.
    - Target: `strict` should be the default for safer out-of-the-box behavior.
 
-3. **Encrypt Companion token storage**
-   - Store the auth token using OS-provided secure storage (Keychain/DPAPI/etc).
-   - Include migration from existing plaintext settings.
-
-4. **Default Telegram webhook signature validation to `true`**
+3. **Default Telegram webhook signature validation to `true`**
    - Requires `WebhookSecretToken`/`WebhookSecretTokenRef` to be configured.
    - Improves default webhook authenticity guarantees.
 

--- a/docs/companion-token-storage.md
+++ b/docs/companion-token-storage.md
@@ -1,0 +1,35 @@
+# Companion token storage and legacy migration
+
+Companion stores remembered gateway tokens and provider API keys through the operating system:
+
+- macOS: Keychain.
+- Windows: DPAPI scoped to the current user.
+- Linux: Secret Service through `secret-tool`, when available.
+
+Plaintext fallback remains disabled by default and requires the existing explicit setting. Gateway tokens are not written into new `settings.json` files.
+
+## Existing profiles
+
+When Remember token is enabled, loading a profile automatically attempts to move a legacy `authToken`/`AuthToken` field or `token.txt` fallback into protected storage. This also supports old PascalCase settings. Provider-key fallback files use the same migration logic when the stored key is loaded.
+
+Migration reads the protected token back and compares it before removing any plaintext copy. JSON cleanup preserves unrelated settings, including unknown fields. Settings, fallback token, and DPAPI ciphertext writes use a temporary file, flush it, and replace the destination atomically; newly written files have owner-only read/write permissions on Unix. Windows DPAPI ciphertext writes also use atomic replacement.
+
+If secure storage is unavailable, locked, fails verification, or contains a different credential, existing copies remain available for recovery and Companion displays a warning. Conflicting legacy fields are not guessed at or deleted. If settings change during migration, cleanup is deferred and retried on the next load.
+
+**Compatibility change:** legacy plaintext fields now obey the plaintext fallback setting. If protected storage is unavailable and fallback is disabled, the legacy token remains on disk but is not used to authenticate. Unlock/enable the OS store and reload Companion, re-enter the token once protected storage is available, or explicitly enable plaintext fallback if that is your intended policy.
+
+A failed secure save no longer deletes an existing fallback token. Failed provider-key replacements retain the previous key's marker. When credentials cannot be loaded, saving other settings will not silently strip the only legacy copy; Companion reports that the settings update was deferred.
+
+## Remembering and forgetting
+
+With Remember token off, Companion does not load or migrate a saved gateway token. Saving with Remember token off removes the legacy JSON field and attempts to clear both protected and fallback gateway-token storage. A failure to clear or verify storage is reported.
+
+An empty token field with Remember token still enabled retains existing stored credentials and defers settings changes. This prevents a temporarily locked store from turning an unrelated settings save into credential deletion. Turn Remember token off and save to explicitly forget the gateway token. Provider API keys have their existing separate clear action.
+
+## Limits
+
+Migration does not rotate tokens, alter gateway accounts, or move credentials between profiles or machines. It does not change existing OS store names or account scoping. Protected storage availability depends on the operating system and an unlocked user session. A preserved conflicting plaintext copy requires operator review; it is never silently preferred over an existing protected credential.
+
+A `token-update.pending` marker is written before replacing a remembered credential. It is cleared only after credential verification and the settings write succeed. If an update is interrupted or fails, Companion does not load saved gateway tokens until the intended token is re-entered and saved, or Remember token is turned off. This prevents pairing a changed credential with an old server URL. The marker contains no secret.
+
+Atomic file replacement protects individual writes; settings files and OS credential stores are not a cross-store transaction. Use one Companion writer per profile. If the process stops between a verified protected save and JSON cleanup, the next load can finish cleanup without needing to recover a lost token.

--- a/docs/companion-token-storage.md
+++ b/docs/companion-token-storage.md
@@ -33,3 +33,5 @@ Migration does not rotate tokens, alter gateway accounts, or move credentials be
 A `token-update.pending` marker is written before replacing a remembered credential. It is cleared only after credential verification and the settings write succeed. If an update is interrupted or fails, Companion does not load saved gateway tokens until the intended token is re-entered and saved, or Remember token is turned off. This prevents pairing a changed credential with an old server URL. The marker contains no secret.
 
 Atomic file replacement protects individual writes; settings files and OS credential stores are not a cross-store transaction. Use one Companion writer per profile. If the process stops between a verified protected save and JSON cleanup, the next load can finish cleanup without needing to recover a lost token.
+
+Native migration has been smoke-tested on macOS. Windows DPAPI and Linux Secret Service behavior have deterministic fake-store coverage; native end-to-end migration on those platforms remains unverified.

--- a/src/OpenClaw.Companion/CompanionJsonContext.cs
+++ b/src/OpenClaw.Companion/CompanionJsonContext.cs
@@ -3,7 +3,7 @@ using OpenClaw.Companion.Models;
 
 namespace OpenClaw.Companion;
 
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true, PropertyNameCaseInsensitive = true)]
 [JsonSerializable(typeof(CompanionSettings))]
 internal partial class CompanionJsonContext : JsonSerializerContext
 {

--- a/src/OpenClaw.Companion/Services/CompanionFilePersistence.cs
+++ b/src/OpenClaw.Companion/Services/CompanionFilePersistence.cs
@@ -1,0 +1,26 @@
+namespace OpenClaw.Companion.Services;
+
+internal static class CompanionFilePersistence
+{
+    public static void WriteAtomically(string path, ReadOnlySpan<byte> content)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var temporary = path + ".tmp-" + Guid.NewGuid().ToString("N");
+        try
+        {
+            var options = new FileStreamOptions { Mode = FileMode.CreateNew, Access = FileAccess.Write, Share = FileShare.None };
+            if (!OperatingSystem.IsWindows())
+                options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+            using (var stream = new FileStream(temporary, options))
+            {
+                stream.Write(content);
+                stream.Flush(flushToDisk: true);
+            }
+            File.Move(temporary, path, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(temporary)) File.Delete(temporary);
+        }
+    }
+}

--- a/src/OpenClaw.Companion/Services/CompanionFilePersistence.cs
+++ b/src/OpenClaw.Companion/Services/CompanionFilePersistence.cs
@@ -20,7 +20,9 @@ internal static class CompanionFilePersistence
         }
         finally
         {
-            if (File.Exists(temporary)) File.Delete(temporary);
+            try { if (File.Exists(temporary)) File.Delete(temporary); }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            { System.Diagnostics.Trace.TraceWarning("Temporary credential file cleanup failed: {0}", ex.GetType().Name); }
         }
     }
 }

--- a/src/OpenClaw.Companion/Services/ProtectedTokenStore.cs
+++ b/src/OpenClaw.Companion/Services/ProtectedTokenStore.cs
@@ -26,6 +26,8 @@ public sealed class ProtectedTokenStore
 
     public string? LastWarning { get; private set; }
 
+    public bool LastLoadWasProtected { get; private set; }
+
     public string ProtectedPath => _secureStore.StorageDescription;
 
     public string FallbackPath => _fallbackPath;
@@ -45,77 +47,138 @@ public sealed class ProtectedTokenStore
     public string? LoadToken(bool allowPlaintextFallback)
     {
         LastWarning = null;
-
-        if (_secureStore.IsAvailable)
+        LastLoadWasProtected = false;
+        var secureAvailable = _secureStore.IsAvailable;
+        if (secureAvailable)
         {
             var token = _secureStore.LoadSecret(out var warning);
             LastWarning = warning;
             if (!string.IsNullOrWhiteSpace(token))
+            {
+                LastLoadWasProtected = warning is null;
+                if (warning is null && File.Exists(_fallbackPath))
+                {
+                    if (string.Equals(File.ReadAllText(_fallbackPath), token, StringComparison.Ordinal))
+                        LastWarning = JoinWarning(LastWarning, DeleteFallback());
+                    else
+                        LastWarning = JoinWarning(LastWarning, "A different plaintext token was preserved for recovery; the protected token is being used.");
+                }
                 return token;
+            }
         }
         else
-        {
             LastWarning = "Secure token storage is unavailable on this system.";
+
+        if (!File.Exists(_fallbackPath)) return null;
+        var fallback = File.ReadAllText(_fallbackPath);
+        if (secureAvailable && LastWarning is null && !string.IsNullOrWhiteSpace(fallback))
+        {
+            if (TryMigrateToken(fallback, out var migrationWarning))
+            {
+                LastLoadWasProtected = true;
+                return fallback;
+            }
+            LastWarning = migrationWarning;
         }
-
-        if (!File.Exists(_fallbackPath))
-            return null;
-
         if (!allowPlaintextFallback)
         {
-            LastWarning = LastWarning is null
-                ? "A plaintext companion token exists, but plaintext fallback is disabled."
-                : $"{LastWarning} Plaintext fallback is disabled.";
+            LastWarning = JoinWarning(LastWarning, "A plaintext token was preserved, but it was not loaded because plaintext fallback is disabled.");
             return null;
         }
+        LastWarning = JoinWarning(LastWarning, "Using plaintext companion token fallback storage.");
+        return fallback;
+    }
 
-        LastWarning = LastWarning is null
-            ? "Using plaintext companion token fallback storage."
-            : $"{LastWarning} Plaintext fallback was used.";
-        return File.ReadAllText(_fallbackPath);
+    /// <summary>Migrates an existing token without replacing a different or unreadable protected credential.</summary>
+    public bool TryMigrateToken(string token, out string? warning)
+    {
+        warning = null;
+        if (!_secureStore.IsAvailable)
+            warning = "Secure token storage is unavailable on this system.";
+        else
+        {
+            var existing = _secureStore.LoadSecret(out warning);
+            if (warning is null && !string.IsNullOrWhiteSpace(existing) && !string.Equals(existing, token, StringComparison.Ordinal))
+                warning = "A different protected token already exists; the legacy token was preserved for recovery.";
+            if (warning is null) return SaveToken(token, allowPlaintextFallback: false, out warning);
+        }
+        LastWarning = warning;
+        return false;
     }
 
     public bool SaveToken(string token, bool allowPlaintextFallback, out string? warning)
     {
         warning = null;
         Directory.CreateDirectory(Path.GetDirectoryName(_fallbackPath)!);
-
-        if (_secureStore.IsAvailable && _secureStore.SaveSecret(token, out warning))
+        try
         {
-            TryDelete(_fallbackPath);
-            LastWarning = warning;
-            return true;
+            if (_secureStore.IsAvailable && _secureStore.SaveSecret(token, out warning))
+            {
+                var verified = _secureStore.LoadSecret(out var readWarning);
+                if (readWarning is null && string.Equals(verified, token, StringComparison.Ordinal))
+                {
+                    warning = JoinWarning(warning, DeleteFallback());
+                    LastWarning = warning;
+                    return true;
+                }
+                warning = JoinWarning(readWarning, "Protected token storage could not be verified.");
+            }
         }
-
-        warning ??= _secureStore.IsAvailable
-            ? "Secure token storage failed."
-            : "Secure token storage is unavailable on this system.";
-
+        catch (Exception ex) when (IsStorageFailure(ex))
+        {
+            warning = "Protected token storage could not be written and verified.";
+        }
+        warning ??= _secureStore.IsAvailable ? "Secure token storage failed." : "Secure token storage is unavailable on this system.";
         if (!allowPlaintextFallback)
         {
-            TryDelete(_fallbackPath);
-            warning = $"{warning} Token was not saved because plaintext fallback is disabled.";
+            // Never destroy the only recoverable credential after an unsuccessful secure save.
+            warning = JoinWarning(warning, "Token was not saved because plaintext fallback is disabled. Existing plaintext storage, if any, was preserved.");
             LastWarning = warning;
             return false;
         }
-
-        File.WriteAllText(_fallbackPath, token);
-        warning = $"{warning} Plaintext fallback was used.";
+        CompanionFilePersistence.WriteAtomically(_fallbackPath, Encoding.UTF8.GetBytes(token));
+        warning = JoinWarning(warning, "Plaintext fallback was used.");
         LastWarning = warning;
         return false;
     }
 
-    public void ClearToken()
+    private string? DeleteFallback()
     {
-        _secureStore.ClearSecret();
-        TryDelete(_fallbackPath);
-        LastWarning = null;
+        try { File.Delete(_fallbackPath); return null; }
+        catch (IOException) { return "Plaintext token storage could not be removed."; }
+        catch (UnauthorizedAccessException) { return "Plaintext token storage could not be removed."; }
     }
 
-    private static void TryDelete(string path)
+    private static string? JoinWarning(string? first, string? second)
+        => first is null ? second : second is null ? first : $"{first} {second}";
+
+    public void ClearToken()
     {
-        try { File.Delete(path); } catch { }
+        LastLoadWasProtected = false;
+        LastWarning = DeleteFallback();
+        try
+        {
+            _secureStore.ClearSecret();
+            if (_secureStore.IsAvailable)
+            {
+                var remaining = _secureStore.LoadSecret(out var warning);
+                LastWarning = JoinWarning(LastWarning, warning);
+                if (!string.IsNullOrWhiteSpace(remaining))
+                    LastWarning = JoinWarning(LastWarning, "Protected token storage could not be cleared.");
+            }
+            else
+                LastWarning = JoinWarning(LastWarning, "Secure token storage is unavailable; any previous protected credential could not be checked or cleared.");
+        }
+        catch (Exception ex) when (IsStorageFailure(ex))
+        {
+            LastWarning = JoinWarning(LastWarning, "Protected token storage could not be cleared or verified.");
+        }
     }
+
+    private static bool IsStorageFailure(Exception ex)
+        => ex is IOException or UnauthorizedAccessException or InvalidOperationException or CryptographicException
+            or System.ComponentModel.Win32Exception or NotSupportedException;
+
 }
 
 internal static class CompanionSecretStoreFactory
@@ -406,7 +469,7 @@ internal sealed class WindowsDpapiSecretStore : ICompanionSecretStore
             }
 
             var protectedBytes = Protect(Encoding.UTF8.GetBytes(secret));
-            File.WriteAllBytes(_ciphertextPath, protectedBytes);
+            CompanionFilePersistence.WriteAtomically(_ciphertextPath, protectedBytes);
             return true;
         }
         catch (Exception ex)

--- a/src/OpenClaw.Companion/Services/ProtectedTokenStore.cs
+++ b/src/OpenClaw.Companion/Services/ProtectedTokenStore.cs
@@ -106,6 +106,18 @@ public sealed class ProtectedTokenStore
         return false;
     }
 
+    internal bool TryReadProtected(out string? token)
+    {
+        token = null;
+        try
+        {
+            if (!_secureStore.IsAvailable) return false;
+            token = _secureStore.LoadSecret(out var warning);
+            return warning is null;
+        }
+        catch (Exception ex) when (IsStorageFailure(ex)) { return false; }
+    }
+
     public bool SaveToken(string token, bool allowPlaintextFallback, out string? warning)
     {
         warning = null;
@@ -117,7 +129,9 @@ public sealed class ProtectedTokenStore
                 var verified = _secureStore.LoadSecret(out var readWarning);
                 if (readWarning is null && string.Equals(verified, token, StringComparison.Ordinal))
                 {
-                    warning = JoinWarning(warning, DeleteFallback());
+                    if (File.Exists(_fallbackPath))
+                        warning = JoinWarning(warning, string.Equals(File.ReadAllText(_fallbackPath), token, StringComparison.Ordinal)
+                            ? DeleteFallback() : "A different plaintext token was preserved for recovery.");
                     LastWarning = warning;
                     return true;
                 }

--- a/src/OpenClaw.Companion/Services/SettingsStore.cs
+++ b/src/OpenClaw.Companion/Services/SettingsStore.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text;
 using OpenClaw.Companion.Models;
 
 namespace OpenClaw.Companion.Services;
@@ -9,6 +10,7 @@ public sealed class SettingsStore
     private readonly ProtectedTokenStore _tokenStore;
     private readonly ProtectedTokenStore _providerKeyStore;
     private readonly string _providerKeyMarkerPath;
+    private readonly string _tokenUpdateMarkerPath;
 
     public string SettingsPath { get; }
     public string? LastWarning { get; private set; }
@@ -23,6 +25,7 @@ public sealed class SettingsStore
             "Companion");
         var dir = baseDir ?? defaultDir;
         SettingsPath = Path.Join(dir, "settings.json");
+        _tokenUpdateMarkerPath = Path.Join(dir, "token-update.pending");
         _tokenStore = tokenStore ?? new ProtectedTokenStore(dir);
         var providerKeyDir = Path.Join(dir, "provider-key");
         _providerKeyStore = providerKeyStore ?? new ProtectedTokenStore(providerKeyDir);
@@ -40,9 +43,24 @@ public sealed class SettingsStore
 
             var json = File.ReadAllText(SettingsPath);
             var settings = JsonSerializer.Deserialize(json, CompanionJsonContext.Default.CompanionSettings) ?? new CompanionSettings();
-            settings.AuthToken = _tokenStore.LoadToken(settings.AllowPlaintextTokenFallback)
-                ?? TryReadLegacyAuthToken(json, settings.RememberToken);
-            LastWarning = _tokenStore.LastWarning;
+            if (!settings.RememberToken)
+                return settings;
+            if (File.Exists(_tokenUpdateMarkerPath))
+            {
+                LastWarning = "A previous token update is incomplete. No saved token was loaded; re-enter the intended token and save, or turn off Remember token.";
+                return settings;
+            }
+            try
+            {
+                settings.AuthToken = _tokenStore.LoadToken(settings.AllowPlaintextTokenFallback);
+                LastWarning = _tokenStore.LastWarning;
+                MigrateLegacyToken(settings, json);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException
+                or System.Security.Cryptography.CryptographicException or System.ComponentModel.Win32Exception or NotSupportedException)
+            {
+                LastWarning = "Credentials could not be loaded or migrated. Existing storage was preserved; unlock secure storage and retry.";
+            }
             return settings;
         }
         catch (JsonException ex)
@@ -95,22 +113,57 @@ public sealed class SettingsStore
             SetupLocalModelPath = settings.SetupLocalModelPath
         };
 
-        var json = JsonSerializer.Serialize(toSave, CompanionJsonContext.Default.CompanionSettings);
-        var tmp = SettingsPath + ".tmp";
-        File.WriteAllText(tmp, json);
-        File.Move(tmp, SettingsPath, overwrite: true);
-
-        if (!settings.RememberToken || string.IsNullOrWhiteSpace(settings.AuthToken))
+        if (settings.RememberToken && string.IsNullOrWhiteSpace(settings.AuthToken))
         {
-            _tokenStore.ClearToken();
+            LastWarning = "No token was supplied; existing credentials and settings were retained. Re-enter the intended token or turn off Remember token. Token migration is still pending if secure storage is unavailable.";
             return;
         }
+        var persisted = false;
 
-        _tokenStore.SaveToken(
-            settings.AuthToken,
-            settings.AllowPlaintextTokenFallback,
-            out var warning);
-        LastWarning = warning;
+        if (settings.RememberToken && !string.IsNullOrWhiteSpace(settings.AuthToken))
+        {
+            // A crash or failed settings write must not pair a changed credential with an old server URL.
+            CompanionFilePersistence.WriteAtomically(_tokenUpdateMarkerPath, "pending"u8);
+            var protectedSave = _tokenStore.SaveToken(settings.AuthToken, settings.AllowPlaintextTokenFallback, out var warning);
+            LastWarning = warning;
+            persisted = protectedSave;
+            if (!persisted && settings.AllowPlaintextTokenFallback)
+            {
+                try { persisted = string.Equals(_tokenStore.LoadToken(true), settings.AuthToken, StringComparison.Ordinal); }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException
+                    or System.Security.Cryptography.CryptographicException or System.ComponentModel.Win32Exception or NotSupportedException)
+                {
+                    persisted = false;
+                }
+                if (!persisted)
+                    LastWarning = $"{LastWarning} The new token could not be reloaded; existing credential copies were retained.".Trim();
+            }
+            if (!persisted && File.Exists(SettingsPath) && HasLegacyToken(File.ReadAllText(SettingsPath)))
+            {
+                LastWarning = $"{LastWarning} Settings were not changed because the legacy token could not be stored safely.".Trim();
+                return;
+            }
+        }
+
+        var json = JsonSerializer.Serialize(toSave, CompanionJsonContext.Default.CompanionSettings);
+        CompanionFilePersistence.WriteAtomically(SettingsPath, Encoding.UTF8.GetBytes(json));
+        if (!settings.RememberToken)
+        {
+            _tokenStore.ClearToken();
+            LastWarning = _tokenStore.LastWarning;
+            ClearTokenUpdateMarker();
+        }
+        else if (persisted)
+            ClearTokenUpdateMarker();
+    }
+
+    private void ClearTokenUpdateMarker()
+    {
+        try { File.Delete(_tokenUpdateMarkerPath); }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            LastWarning = "Credentials were stored, but the incomplete-update marker could not be removed. Saved-token loading remains disabled until a successful save.";
+        }
     }
 
     public string? LoadProviderApiKey(bool allowPlaintextFallback)
@@ -133,7 +186,7 @@ public sealed class SettingsStore
         LastWarning ??= _providerKeyStore.LastWarning;
         if (!string.Equals(loadedProviderApiKey, providerApiKey, StringComparison.Ordinal))
         {
-            TryDelete(_providerKeyMarkerPath);
+            // A failed replacement must not hide a previously stored provider key.
             return false;
         }
 
@@ -147,30 +200,65 @@ public sealed class SettingsStore
         TryDelete(_providerKeyMarkerPath);
     }
 
-    private static string? TryReadLegacyAuthToken(string json, bool rememberToken)
+    private void MigrateLegacyToken(CompanionSettings settings, string originalJson)
     {
-        if (!rememberToken)
-            return null;
-
+        using var document = JsonDocument.Parse(originalJson);
+        var properties = document.RootElement.EnumerateObject()
+            .Where(property => property.Name.Equals("authToken", StringComparison.OrdinalIgnoreCase)).ToArray();
+        if (properties.Length == 0) return;
+        var tokens = properties.Where(p => p.Value.ValueKind == JsonValueKind.String)
+            .Select(p => p.Value.GetString()).Where(value => !string.IsNullOrWhiteSpace(value)).Distinct(StringComparer.Ordinal).ToArray();
+        if (tokens.Length != 1 || properties.Any(p => p.Value.ValueKind != JsonValueKind.String))
+        {
+            LastWarning = "Legacy token fields are empty, conflicting, or invalid; they were preserved for manual review.";
+            return;
+        }
+        var legacy = tokens[0]!;
+        var protectedCopy = _tokenStore.LastLoadWasProtected && string.Equals(settings.AuthToken, legacy, StringComparison.Ordinal);
+        if (!protectedCopy)
+        {
+            if (!string.IsNullOrWhiteSpace(settings.AuthToken) && !string.Equals(settings.AuthToken, legacy, StringComparison.Ordinal))
+            {
+                LastWarning = "A different stored token is in use; the legacy token was preserved for recovery.";
+                return;
+            }
+            if (!_tokenStore.TryMigrateToken(legacy, out var warning))
+            {
+                LastWarning = $"{warning} Legacy token remains in settings."
+                    + (settings.AllowPlaintextTokenFallback ? " Plaintext fallback is enabled." : " It was not loaded because plaintext fallback is disabled.");
+                if (settings.AllowPlaintextTokenFallback) settings.AuthToken = legacy;
+                return;
+            }
+            LastWarning = warning;
+            settings.AuthToken = legacy;
+        }
         try
         {
-            using var document = JsonDocument.Parse(json);
-            var root = document.RootElement;
-            if (root.TryGetProperty("AuthToken", out var authToken) && authToken.ValueKind == JsonValueKind.String)
-                return authToken.GetString();
-            if (root.TryGetProperty("authToken", out authToken) && authToken.ValueKind == JsonValueKind.String)
-                return authToken.GetString();
+            if (!string.Equals(File.ReadAllText(SettingsPath), originalJson, StringComparison.Ordinal))
+            {
+                LastWarning = "Token is protected, but settings changed during migration; plaintext cleanup was deferred.";
+                return;
+            }
+            using var content = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(content, new JsonWriterOptions { Indented = true }))
+            {
+                writer.WriteStartObject();
+                foreach (var property in document.RootElement.EnumerateObject())
+                    if (!property.Name.Equals("authToken", StringComparison.OrdinalIgnoreCase)) property.WriteTo(writer);
+                writer.WriteEndObject();
+            }
+            CompanionFilePersistence.WriteAtomically(SettingsPath, content.ToArray());
         }
-        catch (JsonException ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            Trace.TraceWarning("Settings store ignored legacy token JSON error: {0}", ex.Message);
+            LastWarning = "Token is protected, but the legacy plaintext field could not be removed. Migration will retry on next load.";
         }
-        catch (InvalidOperationException ex)
-        {
-            Trace.TraceWarning("Settings store ignored legacy token invalid state: {0}", ex.Message);
-        }
+    }
 
-        return null;
+    private static bool HasLegacyToken(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.EnumerateObject().Any(p => p.Name.Equals("authToken", StringComparison.OrdinalIgnoreCase));
     }
 
     private static void TraceSettingsLoadFailure(Exception ex)

--- a/src/OpenClaw.Companion/Services/SettingsStore.cs
+++ b/src/OpenClaw.Companion/Services/SettingsStore.cs
@@ -162,9 +162,9 @@ public sealed class SettingsStore
                 if (!persisted)
                     LastWarning = $"{LastWarning} The new token could not be reloaded; existing credential copies were retained.".Trim();
             }
-            if (!persisted && legacy.Length > 0)
+            if (!persisted)
             {
-                LastWarning = $"{LastWarning} Settings were not changed because the legacy token could not be stored safely.".Trim();
+                LastWarning = $"{LastWarning} Settings were not changed because the intended token could not be stored safely.".Trim();
                 return;
             }
         }

--- a/src/OpenClaw.Companion/Services/SettingsStore.cs
+++ b/src/OpenClaw.Companion/Services/SettingsStore.cs
@@ -118,15 +118,39 @@ public sealed class SettingsStore
             LastWarning = "No token was supplied; existing credentials and settings were retained. Re-enter the intended token or turn off Remember token. Token migration is still pending if secure storage is unavailable.";
             return;
         }
+        string? originalJson;
+        KeyValuePair<string, JsonElement>[] legacy;
+        try
+        {
+            originalJson = File.Exists(SettingsPath) ? File.ReadAllText(SettingsPath) : null;
+            using var original = originalJson is null ? null : JsonDocument.Parse(originalJson);
+            legacy = original?.RootElement.EnumerateObject()
+                .Where(p => p.Name.Equals("authToken", StringComparison.OrdinalIgnoreCase))
+                .Select(p => new KeyValuePair<string, JsonElement>(p.Name, p.Value.Clone()))
+                .ToArray() ?? [];
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            LastWarning = "Existing settings could not be read; settings and credentials were retained for recovery.";
+            return;
+        }
         var persisted = false;
 
         if (settings.RememberToken && !string.IsNullOrWhiteSpace(settings.AuthToken))
         {
-            // A crash or failed settings write must not pair a changed credential with an old server URL.
-            CompanionFilePersistence.WriteAtomically(_tokenUpdateMarkerPath, "pending"u8);
-            var protectedSave = _tokenStore.SaveToken(settings.AuthToken, settings.AllowPlaintextTokenFallback, out var warning);
-            LastWarning = warning;
-            persisted = protectedSave;
+            var hadMarker = File.Exists(_tokenUpdateMarkerPath);
+            var readableBefore = _tokenStore.TryReadProtected(out var before);
+            persisted = readableBefore && string.Equals(before, settings.AuthToken, StringComparison.Ordinal);
+            if (!persisted)
+            {
+                // Only a credential change needs an incomplete-update marker.
+                CompanionFilePersistence.WriteAtomically(_tokenUpdateMarkerPath, "pending"u8);
+                persisted = _tokenStore.SaveToken(settings.AuthToken, settings.AllowPlaintextTokenFallback, out var warning);
+                LastWarning = warning;
+                if (!persisted && !hadMarker && readableBefore && !settings.AllowPlaintextTokenFallback
+                    && _tokenStore.TryReadProtected(out var after) && string.Equals(before, after, StringComparison.Ordinal))
+                    ClearTokenUpdateMarker();
+            }
             if (!persisted && settings.AllowPlaintextTokenFallback)
             {
                 try { persisted = string.Equals(_tokenStore.LoadToken(true), settings.AuthToken, StringComparison.Ordinal); }
@@ -138,7 +162,7 @@ public sealed class SettingsStore
                 if (!persisted)
                     LastWarning = $"{LastWarning} The new token could not be reloaded; existing credential copies were retained.".Trim();
             }
-            if (!persisted && File.Exists(SettingsPath) && HasLegacyToken(File.ReadAllText(SettingsPath)))
+            if (!persisted && legacy.Length > 0)
             {
                 LastWarning = $"{LastWarning} Settings were not changed because the legacy token could not be stored safely.".Trim();
                 return;
@@ -146,6 +170,27 @@ public sealed class SettingsStore
         }
 
         var json = JsonSerializer.Serialize(toSave, CompanionJsonContext.Default.CompanionSettings);
+        if (settings.RememberToken && legacy.Length > 0)
+        {
+            using var content = new MemoryStream();
+            using var current = JsonDocument.Parse(json);
+            using (var writer = new Utf8JsonWriter(content))
+            {
+                writer.WriteStartObject();
+                foreach (var property in current.RootElement.EnumerateObject()) property.WriteTo(writer);
+                foreach (var property in legacy)
+                        if (property.Value.ValueKind != JsonValueKind.Null
+                            && !(persisted && property.Value.ValueKind == JsonValueKind.String
+                                && string.Equals(property.Value.GetString(), settings.AuthToken, StringComparison.Ordinal)))
+                        {
+                            writer.WritePropertyName(property.Key);
+                            property.Value.WriteTo(writer);
+                            LastWarning = $"{LastWarning} A legacy token field was preserved for recovery.".Trim();
+                        }
+                writer.WriteEndObject();
+            }
+            json = Encoding.UTF8.GetString(content.ToArray());
+        }
         CompanionFilePersistence.WriteAtomically(SettingsPath, Encoding.UTF8.GetBytes(json));
         if (!settings.RememberToken)
         {
@@ -162,7 +207,7 @@ public sealed class SettingsStore
         try { File.Delete(_tokenUpdateMarkerPath); }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            LastWarning = "Credentials were stored, but the incomplete-update marker could not be removed. Saved-token loading remains disabled until a successful save.";
+            LastWarning = $"{LastWarning} The incomplete-update marker could not be removed. Saved-token loading remains disabled until a successful save.".Trim();
         }
     }
 
@@ -206,9 +251,23 @@ public sealed class SettingsStore
         var properties = document.RootElement.EnumerateObject()
             .Where(property => property.Name.Equals("authToken", StringComparison.OrdinalIgnoreCase)).ToArray();
         if (properties.Length == 0) return;
+        if (properties.All(p => p.Value.ValueKind == JsonValueKind.Null))
+        {
+            using var content = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(content))
+            {
+                writer.WriteStartObject();
+                foreach (var property in document.RootElement.EnumerateObject()
+                    .Where(p => !p.Name.Equals("authToken", StringComparison.OrdinalIgnoreCase))) property.WriteTo(writer);
+                writer.WriteEndObject();
+            }
+            if (File.ReadAllText(SettingsPath) == originalJson)
+                CompanionFilePersistence.WriteAtomically(SettingsPath, content.ToArray());
+            return;
+        }
         var tokens = properties.Where(p => p.Value.ValueKind == JsonValueKind.String)
             .Select(p => p.Value.GetString()).Where(value => !string.IsNullOrWhiteSpace(value)).Distinct(StringComparer.Ordinal).ToArray();
-        if (tokens.Length != 1 || properties.Any(p => p.Value.ValueKind != JsonValueKind.String))
+        if (tokens.Length != 1 || properties.Any(p => p.Value.ValueKind is not (JsonValueKind.String or JsonValueKind.Null)))
         {
             LastWarning = "Legacy token fields are empty, conflicting, or invalid; they were preserved for manual review.";
             return;
@@ -253,12 +312,6 @@ public sealed class SettingsStore
         {
             LastWarning = "Token is protected, but the legacy plaintext field could not be removed. Migration will retry on next load.";
         }
-    }
-
-    private static bool HasLegacyToken(string json)
-    {
-        using var document = JsonDocument.Parse(json);
-        return document.RootElement.EnumerateObject().Any(p => p.Name.Equals("authToken", StringComparison.OrdinalIgnoreCase));
     }
 
     private static void TraceSettingsLoadFailure(Exception ex)

--- a/src/OpenClaw.Tests/CompanionSettingsStoreTests.cs
+++ b/src/OpenClaw.Tests/CompanionSettingsStoreTests.cs
@@ -55,7 +55,8 @@ public sealed class CompanionSettingsStoreTests
             Assert.Contains("not saved", store.LastWarning, StringComparison.OrdinalIgnoreCase);
 
             var loaded = store.Load();
-            Assert.True(loaded.RememberToken);
+            Assert.False(loaded.RememberToken);
+            Assert.False(File.Exists(store.SettingsPath));
             Assert.Null(loaded.AuthToken);
         }
         finally

--- a/src/OpenClaw.Tests/CompanionTokenMigrationTests.cs
+++ b/src/OpenClaw.Tests/CompanionTokenMigrationTests.cs
@@ -1,0 +1,345 @@
+using System.Text;
+using System.Text.Json;
+using OpenClaw.Companion.Models;
+using OpenClaw.Companion.Services;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class CompanionTokenMigrationTests : IDisposable
+{
+    private readonly string _directory = Path.Join(Path.GetTempPath(), "openclaw-token-migration-" + Guid.NewGuid().ToString("N"));
+    private readonly FakeSecretStore _secure = new();
+    private SettingsStore Store() => new(_directory, new ProtectedTokenStore(_directory, _secure),
+        new ProtectedTokenStore(Path.Join(_directory, "provider"), new FakeSecretStore()));
+    private string SettingsPath => Path.Join(_directory, "settings.json");
+    private string FallbackPath => Path.Join(_directory, "token.txt");
+
+    private void Legacy(bool allowFallback = false, bool remember = true, string property = "authToken")
+    {
+        Directory.CreateDirectory(_directory);
+        File.WriteAllText(SettingsPath, JsonSerializer.Serialize(new Dictionary<string, object?>
+        {
+            ["rememberToken"] = remember, ["allowPlaintextTokenFallback"] = allowFallback,
+            [property] = "legacy-secret", ["serverUrl"] = "ws://example.invalid/ws",
+            ["futureSetting"] = new { keep = 42 }
+        }));
+    }
+
+    [Theory]
+    [InlineData("authToken")]
+    [InlineData("AuthToken")]
+    [InlineData("AUTHTOKEN")]
+    public void Load_MigratesLegacyTokenAndPreservesUnrelatedSettings(string property)
+    {
+        Legacy(property: property);
+        var store = Store(); var loaded = store.Load();
+        Assert.Equal("legacy-secret", loaded.AuthToken);
+        Assert.Equal("legacy-secret", _secure.Secret);
+        Assert.DoesNotContain("legacy-secret", File.ReadAllText(SettingsPath));
+        using var json = JsonDocument.Parse(File.ReadAllText(SettingsPath));
+        Assert.Equal(42, json.RootElement.GetProperty("futureSetting").GetProperty("keep").GetInt32());
+        Assert.Equal("ws://example.invalid/ws", loaded.ServerUrl);
+        Assert.Null(store.LastWarning);
+        var saves = _secure.SaveCount;
+        Assert.Equal("legacy-secret", store.Load().AuthToken);
+        Assert.Equal(saves, _secure.SaveCount);
+    }
+
+    [Fact]
+    public void Load_MigratesPascalCaseLegacySettings()
+    {
+        Legacy(); File.WriteAllText(SettingsPath, """{"RememberToken":true,"AuthToken":"legacy-secret","ServerUrl":"ws://example.invalid/ws"}""");
+        var loaded = Store().Load();
+        Assert.Equal("legacy-secret", loaded.AuthToken);
+        Assert.Equal("ws://example.invalid/ws", loaded.ServerUrl);
+        Assert.DoesNotContain("legacy-secret", File.ReadAllText(SettingsPath));
+    }
+
+    [Fact]
+    public void Load_UnexpectedStorageErrorRetainsSettingsAndLegacyToken()
+    {
+        Legacy(); _secure.ThrowLoad = true;
+        var store = Store(); var loaded = store.Load();
+        Assert.True(loaded.RememberToken);
+        Assert.Equal("ws://example.invalid/ws", loaded.ServerUrl);
+        Assert.Null(loaded.AuthToken);
+        Assert.Contains("legacy-secret", File.ReadAllText(SettingsPath));
+        Assert.Contains("preserved", store.LastWarning);
+    }
+
+    [Fact]
+    public void Load_DoesNotOverwriteSettingsChangedDuringMigration()
+    {
+        Legacy();
+        _secure.AfterSave = () => File.WriteAllText(SettingsPath, """{"rememberToken":true,"authToken":"legacy-secret","futureSetting":"changed"}""");
+        var store = Store();
+        Assert.Equal("legacy-secret", store.Load().AuthToken);
+        Assert.Contains("changed", File.ReadAllText(SettingsPath));
+        Assert.Contains("deferred", store.LastWarning);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Load_UnavailableSecureStorePreservesLegacyAndHonorsPlaintextOptIn(bool allow)
+    {
+        Legacy(allow); _secure.IsAvailable = false;
+        var original = File.ReadAllText(SettingsPath); var store = Store();
+        var loaded = store.Load();
+        Assert.Equal(allow ? "legacy-secret" : null, loaded.AuthToken);
+        Assert.Equal(original, File.ReadAllText(SettingsPath));
+        Assert.NotNull(store.LastWarning);
+        Assert.DoesNotContain("legacy-secret", store.LastWarning);
+    }
+
+    [Fact]
+    public void Load_DoesNotLoadOrMigrateWhenRememberTokenIsFalse()
+    {
+        Legacy(remember: false); _secure.Secret = "protected-secret";
+        var original = File.ReadAllText(SettingsPath);
+        Assert.Null(Store().Load().AuthToken);
+        Assert.Equal(0, _secure.LoadCount);
+        Assert.Equal(0, _secure.SaveCount);
+        Assert.Equal(original, File.ReadAllText(SettingsPath));
+    }
+
+    [Fact]
+    public void Load_FailedReadbackPreservesLegacyForRetry()
+    {
+        Legacy(); _secure.FailReadAfterSave = true; var original = File.ReadAllText(SettingsPath); var store = Store();
+        Assert.Null(store.Load().AuthToken);
+        Assert.Equal(original, File.ReadAllText(SettingsPath));
+        Assert.Contains("verified", store.LastWarning);
+        _secure.FailReadAfterSave = false;
+        Assert.Equal("legacy-secret", store.Load().AuthToken);
+        Assert.DoesNotContain("legacy-secret", File.ReadAllText(SettingsPath));
+    }
+
+    [Fact]
+    public void Load_LockedStoreIsNotOverwrittenDuringMigration()
+    {
+        Legacy(); _secure.Secret = "protected-secret"; _secure.Locked = true;
+        var store = Store(); Assert.Null(store.Load().AuthToken);
+        Assert.Equal(0, _secure.SaveCount);
+        Assert.Equal("protected-secret", _secure.Secret);
+        Assert.Contains("legacy-secret", File.ReadAllText(SettingsPath));
+    }
+
+    [Fact]
+    public void Load_ConflictingProtectedAndLegacyTokensArePreserved()
+    {
+        Legacy(); _secure.Secret = "protected-secret";
+        var store = Store(); Assert.Equal("protected-secret", store.Load().AuthToken);
+        Assert.Contains("legacy-secret", File.ReadAllText(SettingsPath));
+        Assert.Equal(0, _secure.SaveCount);
+        Assert.Contains("different", store.LastWarning);
+    }
+
+    [Fact]
+    public void Load_ConflictingLegacyFieldsAreNotSilentlyDeleted()
+    {
+        Legacy(); File.WriteAllText(SettingsPath, """{"rememberToken":true,"authToken":"one","AuthToken":"two"}""");
+        var store = Store(); Assert.Null(store.Load().AuthToken);
+        Assert.Contains("conflicting", store.LastWarning);
+        Assert.Equal(0, _secure.SaveCount);
+        Assert.Contains("two", File.ReadAllText(SettingsPath));
+    }
+
+    [Fact]
+    public void Load_MigratesFallbackEvenWhenPlaintextUseIsDisabled()
+    {
+        var protectedStore = new ProtectedTokenStore(_directory, _secure);
+        File.WriteAllText(FallbackPath, "fallback-secret");
+        Assert.Equal("fallback-secret", protectedStore.LoadToken(false));
+        Assert.True(protectedStore.LastLoadWasProtected);
+        Assert.Equal("fallback-secret", _secure.Secret);
+        Assert.False(File.Exists(FallbackPath));
+    }
+
+    [Fact]
+    public void Load_FailedFallbackMigrationKeepsOriginalFile()
+    {
+        var store = new ProtectedTokenStore(_directory, _secure); _secure.FailReadAfterSave = true;
+        File.WriteAllText(FallbackPath, "fallback-secret");
+        Assert.Null(store.LoadToken(false));
+        Assert.Equal("fallback-secret", File.ReadAllText(FallbackPath));
+        Assert.False(store.LastLoadWasProtected);
+    }
+
+    [Fact]
+    public void Load_DifferentFallbackIsNotDeletedWhenProtectedTokenExists()
+    {
+        var store = new ProtectedTokenStore(_directory, _secure); _secure.Secret = "protected-secret";
+        File.WriteAllText(FallbackPath, "different-secret");
+        Assert.Equal("protected-secret", store.LoadToken(false));
+        Assert.Equal("different-secret", File.ReadAllText(FallbackPath));
+        Assert.Contains("different", store.LastWarning);
+    }
+
+    [Fact]
+    public void Save_FailureDoesNotDeleteExistingFallback()
+    {
+        var store = new ProtectedTokenStore(_directory, _secure); _secure.IsAvailable = false;
+        File.WriteAllText(FallbackPath, "old-secret");
+        Assert.False(store.SaveToken("new-secret", false, out _));
+        Assert.Equal("old-secret", File.ReadAllText(FallbackPath));
+    }
+
+    [Fact]
+    public void Save_FailureDoesNotStripOnlyLegacyCopy()
+    {
+        Legacy(); _secure.FailSave = true; var original = File.ReadAllText(SettingsPath); var store = Store();
+        store.Save(new CompanionSettings { RememberToken = true, AuthToken = "new-secret", DebugMode = true });
+        Assert.Equal(original, File.ReadAllText(SettingsPath));
+        Assert.Contains("not changed", store.LastWarning);
+    }
+
+    [Fact]
+    public void Save_AfterBlockedLoadDoesNotForgetCredentials()
+    {
+        Legacy(); _secure.IsAvailable = false; var original = File.ReadAllText(SettingsPath); var store = Store();
+        var loaded = store.Load(); loaded.DebugMode = true; store.Save(loaded);
+        Assert.Equal(original, File.ReadAllText(SettingsPath));
+        Assert.Contains("migration is still pending", store.LastWarning);
+    }
+
+    [Fact]
+    public void Save_EmptyInMemoryTokenDoesNotClearProtectedStorage()
+    {
+        var store = Store(); _secure.Secret = "protected-secret";
+        store.Save(new CompanionSettings { RememberToken = true });
+        Assert.Equal("protected-secret", _secure.Secret);
+        Assert.Equal(0, _secure.ClearCount);
+    }
+
+    [Fact]
+    public void Save_ExplicitForgetClearsProtectedFallbackAndLegacyCopies()
+    {
+        Legacy(); var store = Store(); _secure.Secret = "protected-secret";
+        File.WriteAllText(FallbackPath, "fallback-secret");
+        store.Save(new CompanionSettings { RememberToken = false });
+        Assert.Null(_secure.Secret);
+        Assert.False(File.Exists(FallbackPath));
+        Assert.DoesNotContain("legacy-secret", File.ReadAllText(SettingsPath));
+        Assert.Null(store.LastWarning);
+    }
+
+    [Fact]
+    public void ProviderKey_FailedReplacementKeepsExistingMarkerAndKey()
+    {
+        var provider = new FakeSecretStore();
+        var store = new SettingsStore(_directory, new ProtectedTokenStore(_directory, _secure),
+            new ProtectedTokenStore(Path.Join(_directory, "provider"), provider));
+        Assert.True(store.SaveProviderApiKey("old-key", false));
+        provider.FailSave = true;
+        Assert.False(store.SaveProviderApiKey("new-key", false));
+        Assert.Equal("old-key", store.LoadProviderApiKey(false));
+    }
+
+    [Fact]
+    public void AtomicFilesHavePrivatePermissionsAndLeaveNoTemporaryCopies()
+    {
+        var path = Path.Join(_directory, "private.txt");
+        CompanionFilePersistence.WriteAtomically(path, Encoding.UTF8.GetBytes("secret"));
+        Assert.Equal("secret", File.ReadAllText(path));
+        Assert.Empty(Directory.GetFiles(_directory, "*.tmp-*"));
+        if (!OperatingSystem.IsWindows())
+            Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(path));
+        CompanionFilePersistence.WriteAtomically(path, Encoding.UTF8.GetBytes("replacement"));
+        Assert.Equal("replacement", File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void AtomicWriteFailurePreservesDestinationAndCleansTemporaryFile()
+    {
+        var destination = Path.Join(_directory, "existing-directory");
+        Directory.CreateDirectory(destination);
+        File.WriteAllText(Path.Join(destination, "keep"), "original");
+        var error = Record.Exception(() => CompanionFilePersistence.WriteAtomically(destination, Encoding.UTF8.GetBytes("secret")));
+        Assert.True(error is IOException or UnauthorizedAccessException);
+        Assert.Equal("original", File.ReadAllText(Path.Join(destination, "keep")));
+        Assert.Empty(Directory.GetFiles(_directory, "*.tmp-*"));
+    }
+
+    [Fact]
+    public void Save_ThrowingReadbackPreservesFallback()
+    {
+        var store = new ProtectedTokenStore(_directory, _secure);
+        File.WriteAllText(FallbackPath, "original"); _secure.ThrowLoad = true;
+        Assert.False(store.SaveToken("new-secret", false, out var warning));
+        Assert.Equal("original", File.ReadAllText(FallbackPath));
+        Assert.Contains("verified", warning);
+    }
+
+    [Fact]
+    public void Clear_ReportsProtectedStoreVerificationFailure()
+    {
+        var store = new ProtectedTokenStore(_directory, _secure); _secure.ThrowLoad = true;
+        store.ClearToken();
+        Assert.Contains("could not be cleared or verified", store.LastWarning);
+    }
+
+    [Fact]
+    public void Save_SettingsFailureBlocksAutomaticUseUntilSuccessfulRetry()
+    {
+        var store = Store();
+        Directory.CreateDirectory(SettingsPath);
+        var update = new CompanionSettings { RememberToken = true, AuthToken = "new-server-secret", ServerUrl = "ws://new.invalid/ws" };
+        var error = Record.Exception(() => store.Save(update));
+        Assert.True(error is IOException or UnauthorizedAccessException);
+        Assert.Equal("new-server-secret", _secure.Secret);
+        Assert.True(File.Exists(Path.Join(_directory, "token-update.pending")));
+        Directory.Delete(SettingsPath);
+        File.WriteAllText(SettingsPath, """{"rememberToken":true,"serverUrl":"ws://old.invalid/ws"}""");
+        var loaded = store.Load();
+        Assert.Null(loaded.AuthToken);
+        Assert.Contains("incomplete", store.LastWarning);
+        store.Save(update);
+        Assert.False(File.Exists(Path.Join(_directory, "token-update.pending")));
+        loaded = store.Load();
+        Assert.Equal("new-server-secret", loaded.AuthToken);
+        Assert.Equal("ws://new.invalid/ws", loaded.ServerUrl);
+    }
+
+    [Fact]
+    public void Save_EmptyTokenCannotPairOldCredentialWithNewServer()
+    {
+        var store = Store();
+        store.Save(new CompanionSettings { RememberToken = true, AuthToken = "old-secret", ServerUrl = "ws://old.invalid/ws" });
+        store.Save(new CompanionSettings { RememberToken = true, ServerUrl = "ws://new.invalid/ws" });
+        Assert.Equal("ws://old.invalid/ws", store.Load().ServerUrl);
+    }
+
+    public void Dispose() { if (Directory.Exists(_directory)) Directory.Delete(_directory, true); }
+
+    private sealed class FakeSecretStore : ICompanionSecretStore
+    {
+        public string? Secret { get; set; }
+        public bool IsAvailable { get; set; } = true;
+        public bool FailSave { get; set; }
+        public bool FailReadAfterSave { get; set; }
+        public bool Locked { get; set; }
+        public bool ThrowLoad { get; set; }
+        public Action? AfterSave { get; set; }
+        public int SaveCount { get; private set; }
+        public int LoadCount { get; private set; }
+        public int ClearCount { get; private set; }
+        public string StorageDescription => "test-secret-store";
+        public string? LoadSecret(out string? warning)
+        {
+            LoadCount++;
+            if (ThrowLoad) throw new IOException("Test store unavailable");
+            warning = Locked || (FailReadAfterSave && SaveCount > 0) ? "Secure store is locked." : null;
+            return warning is null ? Secret : null;
+        }
+        public bool SaveSecret(string secret, out string? warning)
+        {
+            SaveCount++;
+            warning = FailSave ? "Secure save failed." : null;
+            if (!FailSave) { Secret = secret; AfterSave?.Invoke(); }
+            return !FailSave;
+        }
+        public void ClearSecret() { ClearCount++; Secret = null; }
+    }
+}

--- a/src/OpenClaw.Tests/CompanionTokenMigrationTests.cs
+++ b/src/OpenClaw.Tests/CompanionTokenMigrationTests.cs
@@ -47,6 +47,60 @@ public sealed class CompanionTokenMigrationTests : IDisposable
     }
 
     [Fact]
+    public void OrdinarySavePreservesConflictingRecoveryCopiesWithoutSecureRewrite()
+    {
+        Legacy(); _secure.Secret = "protected-secret";
+        File.WriteAllText(FallbackPath, "different-fallback");
+        var store = Store(); var settings = store.Load();
+        settings.DebugMode = true; _secure.FailSave = true;
+        store.Save(settings);
+        Assert.Equal(0, _secure.SaveCount);
+        Assert.Contains("legacy-secret", File.ReadAllText(SettingsPath));
+        Assert.Equal("different-fallback", File.ReadAllText(FallbackPath));
+        Assert.False(File.Exists(Path.Join(_directory, "token-update.pending")));
+        Assert.Equal("protected-secret", store.Load().AuthToken);
+    }
+
+    [Fact]
+    public void SuccessfulSavePreservesDifferentFallback()
+    {
+        var store = new ProtectedTokenStore(_directory, _secure);
+        File.WriteAllText(FallbackPath, "recovery-copy");
+        Assert.True(store.SaveToken("new-secret", false, out var warning));
+        Assert.Equal("recovery-copy", File.ReadAllText(FallbackPath));
+        Assert.Contains("preserved", warning);
+    }
+
+    [Fact]
+    public void MalformedSettingsSaveDoesNotChangeCredentials()
+    {
+        Legacy(); File.WriteAllText(SettingsPath, "{");
+        var store = Store(); store.Save(new CompanionSettings { RememberToken = true, AuthToken = "new" });
+        Assert.Equal("{", File.ReadAllText(SettingsPath));
+        Assert.Equal(0, _secure.SaveCount);
+        Assert.NotNull(store.LastWarning);
+    }
+
+    [Fact]
+    public void NullLegacyFieldDoesNotPreventMigrationOrWarnForever()
+    {
+        Legacy(); File.WriteAllText(SettingsPath, """{"rememberToken":true,"authToken":null}""");
+        var store = Store(); store.Load();
+        Assert.DoesNotContain("authToken", File.ReadAllText(SettingsPath));
+        Assert.Null(store.LastWarning);
+    }
+
+    [Fact]
+    public void FailedUnchangedWriteDoesNotStrandMigrationMarker()
+    {
+        Legacy(); _secure.FailSave = true;
+        var store = Store(); store.Save(new CompanionSettings { RememberToken = true, AuthToken = "new" });
+        Assert.False(File.Exists(Path.Join(_directory, "token-update.pending")));
+        _secure.FailSave = false;
+        Assert.Equal("legacy-secret", store.Load().AuthToken);
+    }
+
+    [Fact]
     public void Load_MigratesPascalCaseLegacySettings()
     {
         Legacy(); File.WriteAllText(SettingsPath, """{"RememberToken":true,"AuthToken":"legacy-secret","ServerUrl":"ws://example.invalid/ws"}""");

--- a/src/OpenClaw.Tests/CompanionTokenMigrationTests.cs
+++ b/src/OpenClaw.Tests/CompanionTokenMigrationTests.cs
@@ -47,6 +47,18 @@ public sealed class CompanionTokenMigrationTests : IDisposable
     }
 
     [Fact]
+    public void FailedTokenReplacementCannotPairOldSecretWithNewServer()
+    {
+        var store = Store();
+        store.Save(new CompanionSettings { RememberToken = true, AuthToken = "old", ServerUrl = "ws://old.invalid/ws" });
+        _secure.FailSave = true;
+        store.Save(new CompanionSettings { RememberToken = true, AuthToken = "new", ServerUrl = "ws://new.invalid/ws" });
+        var loaded = store.Load();
+        Assert.Equal("old", loaded.AuthToken);
+        Assert.Equal("ws://old.invalid/ws", loaded.ServerUrl);
+    }
+
+    [Fact]
     public void OrdinarySavePreservesConflictingRecoveryCopiesWithoutSecureRewrite()
     {
         Legacy(); _secure.Secret = "protected-secret";


### PR DESCRIPTION
## Description

Companion already had OS-backed token stores, but older plaintext credentials were not migrated automatically. Failed saves could delete a fallback or strip the only legacy JSON copy, and loading settings could restore a token even with Remember token disabled.

This completes the roadmap's Companion token-protection work: migrate legacy credentials only after a verified protected read-back, preserve recoverable copies on failure, and make remembered-token policy consistent.

## Summary

- Automatically migrate legacy JSON tokens and fallback files to existing macOS Keychain, Windows DPAPI, or Linux Secret Service stores. Preserve unknown settings during JSON cleanup and support PascalCase legacy settings.
- Do not overwrite conflicting or unreadable protected credentials during migration. Report unavailable/locked storage and retry cleanup after recovery.
- Verify protected saves before deleting plaintext; use atomic private file writes for settings, fallback credentials, and DPAPI ciphertext.
- Preserve existing provider-key markers after unsuccessful replacements.
- Respect Remember token on load. Defer settings changes when a remembered token is unavailable instead of silently clearing it; explicit Forget still clears saved gateway credentials.
- Write a non-secret pending-update marker before replacing a remembered credential. Incomplete updates block automatic token loading, preventing a changed credential from being paired with stale connection settings after a write failure.

Based directly on `main`; independent of #213 and #214.

## Related Issues

Completes **Encrypt Companion token storage**, including migration, in `docs/ROADMAP.md`.

## Type of Change

- [x] Bug fix
- [x] Security hardening / compatibility change
- [x] Documentation update
- [x] Tests

## Validation

- [x] `dotnet restore OpenClaw.Net.slnx`
- [x] Release solution build — zero warnings and errors.
- [x] `dotnet test OpenClaw.Net.slnx --configuration Release --no-restore` — **2,531 passed**, zero failures/skips; 28 new regression cases.
- [x] Deterministic HelloAgent smoke passed.
- [x] Native macOS Keychain smoke with a disposable credential: migration, read-back verification, plaintext cleanup, remembered save/reload, and explicit forget.

Failure coverage includes locked/unavailable stores, unverifiable/throwing read-back, conflicting credentials, settings changing during migration, failed atomic replacement, explicit opt-in, and interrupted token/settings updates. Windows and Linux behavior is covered through the shared-store contract tests; native OS execution was performed on macOS only.

## Compatibility and Review Notes

Legacy plaintext fields now obey `AllowPlaintextTokenFallback`. If protected storage is unavailable and fallback is disabled, the original remains on disk but is not used for authentication. Unlock the OS store and reload, re-enter the intended token once storage is available, or explicitly opt into plaintext fallback.

An empty token with Remember token enabled no longer implicitly forgets credentials or saves a potentially different server URL. Re-enter the intended token to save, or turn Remember token off to forget it. An incomplete-update marker requires a successful intended-token save or explicit forget before saved-token loading resumes.

- [x] NativeAOT/source-generation compatibility considered; no new dependencies.
- [x] Existing OS store names/profile scoping retained; no token rotation or account changes.
- [x] Docs/tests updated; security and maintainer checklist reviewed.

Individual files are replaced atomically; OS storage and settings are not a cross-store transaction. The pending marker fails closed across that boundary. One writer per Companion profile is still required.

## Commercial or Customer-Driven Contribution Disclosure

General roadmap work requested by the maintainer; no customer-specific integration or downstream commercial workflow was supplied.

## Checklist

- [x] Followed CONTRIBUTING and the relevant maintainer review checklist.
- [x] Added meaningful regression coverage and ran the full suite.
- [x] Documented migration, failure recovery, and policy changes.
- [x] Preserved unrelated working files.

## Screenshots / Benchmarks

Not applicable: storage and migration behavior; existing Companion warning surfaces are reused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Companion tokens and provider keys can migrate from legacy plaintext storage to OS-protected storage.
  - Secure storage supports macOS Keychain, Windows DPAPI, and Linux Secret Service.
  - Remember, forget, and plaintext fallback settings are handled consistently.

- **Bug Fixes**
  - Improved recovery when credential updates or secure storage operations fail.
  - Atomic file updates help prevent partial or corrupted settings.
  - Credential loading now handles property-name casing more flexibly.

- **Documentation**
  - Added guidance on token storage, migration, fallback behavior, and operational safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->