### PR TITLE
fix: allow sequential tool models with multiple tool definitions

### DIFF
--- a/src/OpenClaw.Gateway/Models/DefaultModelSelectionPolicy.cs
+++ b/src/OpenClaw.Gateway/Models/DefaultModelSelectionPolicy.cs
@@ -148,12 +148,10 @@ internal sealed class DefaultModelSelectionPolicy : IModelSelectionPolicy
 
         if (request.Streaming)
             combined.SupportsStreaming = true;
+        // Offering several tools does not require parallel calls in one response.
+        // Explicit session requirements for parallel calling remain in the clone.
         if (request.Options?.Tools is { Count: > 0 })
-        {
             combined.SupportsTools = true;
-            if (request.Options.Tools.Count > 1)
-                combined.SupportsParallelToolCalls ??= true;
-        }
 
         if (request.Options?.ResponseFormat is not null)
         {

--- a/src/OpenClaw.Tests/ModelProfileSelectionTests.cs
+++ b/src/OpenClaw.Tests/ModelProfileSelectionTests.cs
@@ -89,6 +89,48 @@ public sealed class ModelProfileSelectionTests
         Assert.Contains("Falling back from 'gemma4-local'", selection.Explanation, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(false, "mini-readonly")]
+    [InlineData(true, "frontier-tools")]
+    public void SelectionPolicy_MultipleToolDefinitions_RequireParallelSupportOnlyWhenExplicit(bool requireParallel, string expectedProfile)
+    {
+        LlmClientFactory.ResetDynamicProviders();
+        LlmClientFactory.RegisterProvider("fake-profile-tests", new EvaluationChatClient());
+        using var registry = new ConfiguredModelProfileRegistry(BuildProfileConfig(), NullLogger<ConfiguredModelProfileRegistry>.Instance);
+        registry.SetDefaultProfileId();
+        var policy = new DefaultModelSelectionPolicy(registry);
+        using var schema = JsonDocument.Parse("""{"type":"object","properties":{}}""");
+        var selection = policy.Resolve(new OpenClaw.Core.Abstractions.ModelSelectionRequest
+        {
+            Session = new Session
+            {
+                Id = "multiple-tools",
+                ChannelId = "test",
+                SenderId = "user",
+                ModelProfileId = "mini-readonly",
+                FallbackModelProfileIds = ["frontier-tools"],
+                ModelRequirements = new ModelSelectionRequirements
+                {
+                    SupportsParallelToolCalls = requireParallel ? true : null
+                }
+            },
+            Messages = [new ChatMessage(ChatRole.User, "Choose an appropriate tool")],
+            Options = new ChatOptions
+            {
+                Tools =
+                [
+                    AIFunctionFactory.CreateDeclaration("first", "First tool", schema.RootElement.Clone(), returnJsonSchema: null),
+                    AIFunctionFactory.CreateDeclaration("second", "Second tool", schema.RootElement.Clone(), returnJsonSchema: null)
+                ]
+            },
+            Streaming = false
+        });
+
+        Assert.Equal(expectedProfile, selection.SelectedProfileId);
+        Assert.True(selection.Requirements.SupportsTools);
+        Assert.Equal(requireParallel ? true : (bool?)null, selection.Requirements.SupportsParallelToolCalls);
+    }
+
     [Fact]
     public void SelectionPolicy_PrefersTaggedProfileWhenRequirementsAreEqual()
     {


### PR DESCRIPTION
A request advertising more than one tool incorrectly required parallel tool-call support. This rejected the Ollama Agentic preset and other sequential tool models before any provider request, even when a response would use one tool at a time.

Infer tool-call support from the available tools, but preserve parallel-call requirements only when explicitly requested by the session. Regression tests cover selection of a sequential tool model and fallback when parallel calls are explicitly required.

Validation: 25 model-selection tests and the full 2,658-test local suite pass. An isolated gateway chat request with the Ollama Agentic preset and a local deterministic provider fixture reproduced the rejection before this change and succeeds after it. This was found during v0.3.0 release validation; the release remains a draft pending rebuilt packages and checks.
