### PR TITLE
fix: use supported model presets in companion setup

### DIFF
--- a/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.ManagedGateway.cs
+++ b/src/OpenClaw.Companion/ViewModels/MainWindowViewModel.ManagedGateway.cs
@@ -89,20 +89,7 @@ public sealed partial class MainWindowViewModel
     ];
 
     public IReadOnlyList<string> SetupModelPresetOptions { get; } =
-    [
-        "ollama-general",
-        "ollama-llama3-8b",
-        "ollama-phi3-mini",
-        "ollama-qwen2.5",
-        "embedded-gemma-small-q4",
-        "embedded-phi3-mini-q4",
-        "openai-gpt-4o",
-        "openai-gpt-4o-mini",
-        "anthropic-claude-3.5-sonnet",
-        "anthropic-claude-3-haiku",
-        "gemini-1.5-pro",
-        "gemini-1.5-flash"
-    ];
+        LocalModelPresetCatalog.List().Select(preset => preset.Id).ToArray();
 
     public bool CanRunLocalGatewaySetup => LocalGatewayCanRunSetup && !IsManagedGatewayBusy;
 

--- a/src/OpenClaw.Tests/CompanionSetupUiTests.cs
+++ b/src/OpenClaw.Tests/CompanionSetupUiTests.cs
@@ -1,0 +1,38 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using OpenClaw.Companion.Services;
+using OpenClaw.Companion.ViewModels;
+using OpenClaw.Companion.Views;
+using OpenClaw.Core.Setup;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class CompanionSetupUiTests
+{
+    [AvaloniaFact]
+    public void SetupPresetBinding_RetainsToolCapableOllamaPreset()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "companion-setup-tests", Guid.NewGuid().ToString("N"));
+        var store = new SettingsStore(directory);
+        var viewModel = new MainWindowViewModel(store, new GatewayWebSocketClient());
+        var window = new MainWindow { DataContext = viewModel };
+        try
+        {
+            window.Show();
+            viewModel.SetupProvider = "ollama";
+            viewModel.SetupModelPreset = "ollama-agentic";
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal("ollama-agentic", viewModel.SetupModelPreset);
+            Assert.Equal("ollama-agentic", store.Load().SetupModelPreset);
+            Assert.All(viewModel.SetupModelPresetOptions, id =>
+                Assert.True(LocalModelPresetCatalog.TryGet(id, out _), $"Setup offers unknown preset '{id}'."));
+        }
+        finally
+        {
+            window.Close();
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
The companion setup dropdown used stale preset IDs and omitted `ollama-agentic`. Its two-way selection binding cleared that valid preset, causing setup to fall back to the non-tool `ollama-general` profile and leaving local chat unable to select a tool-capable model.

Populate the dropdown from the same `LocalModelPresetCatalog` used by setup. This exposes supported presets and removes IDs that the CLI cannot resolve.

Validation: a headless Avalonia regression checks that the real window binding retains and saves `ollama-agentic` and every offered ID resolves. A desktop integration smoke using the updated companion and the released NativeAOT gateway/CLI passed setup, websocket chat through a local provider fixture, stop/restart/reconnect, corrupt-config recovery, and owned-gateway shutdown on desktop exit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup model preset options now reflect the available local model presets automatically.

* **Bug Fixes**
  * Preserved the tool-capable Ollama preset during companion setup and settings persistence.

* **Tests**
  * Added coverage validating preset retention, persistence, and availability in the setup interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->