### PR TITLE
Enforce AgentQi Companion desktop release contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,20 @@ permissions:
   contents: read
 
 jobs:
+  release-documentation:
+    name: Release Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Reject stale release availability language
+        if: github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.create_release)
+        env:
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+        run: python3 eng/verify-release-docs.py "$RELEASE_TAG"
+
   public-compatibility-smoke:
     permissions:
       contents: read
@@ -86,7 +100,10 @@ jobs:
 
   build-release-assets:
     name: Build ${{ matrix.asset }} assets
-    needs: public-compatibility-smoke
+    needs:
+      - release-documentation
+      - public-compatibility-smoke
+      - desktop-first-success
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -235,6 +252,11 @@ jobs:
           & $cliBin version
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+          if ($IsLinux) {
+            python3 "$root/eng/verify-desktop-first-success.py" --cli $cliBin --gateway $gatewayBin
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+
           $desktopArchive = Join-Path $archives "openclaw-desktop-$rid.zip"
           $gatewayArchive = Join-Path $archives "openclaw-gateway-aot-$rid.zip"
           $cliArchive = Join-Path $archives "openclaw-cli-aot-$rid.zip"
@@ -282,6 +304,43 @@ jobs:
           name: release-assets-${{ matrix.rid }}
           path: artifacts/release-archives/*
 
+  desktop-first-success:
+    name: Desktop First-Success Contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('OpenClaw.Net.slnx', '**/*.csproj', '**/*.props', '**/*.targets') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Restore desktop contract tests
+        run: dotnet restore src/OpenClaw.Tests
+
+      - name: Build desktop contract tests
+        run: dotnet build --no-restore -c Release src/OpenClaw.Tests ${{ env.FAST_BUILD_PROPERTIES }}
+
+      - name: Run local-agent first-success contract
+        run: dotnet test --no-build -c Release --filter "Category=DesktopRelease" --verbosity normal --logger "trx;LogFileName=desktop-first-success.trx" src/OpenClaw.Tests
+
+      - name: Upload desktop contract results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: desktop-first-success-results
+          path: "**/desktop-first-success.trx"
+
   publish-github-release:
     name: Publish GitHub Release
     needs: build-release-assets
@@ -327,9 +386,9 @@ jobs:
           - openclaw-desktop-osx-arm64.zip
           - openclaw-desktop-linux-x64.zip
 
-          These archives bundle Companion, the NativeAOT gateway, and the NativeAOT CLI. Standalone gateway and CLI archives are also attached for operators.
+          These archives bundle AgentQi Companion, the NativeAOT gateway, and the NativeAOT CLI. Standalone gateway and CLI archives are also attached for operators.
 
-          Release verification for this exact tag includes the deterministic pinned public-plugin compatibility gate. The moving latest-package canary is reported separately and is not release-blocking.
+          Release verification for this exact tag includes the deterministic pinned public-plugin compatibility gate, the AgentQi Companion local-agent first-success contract, and the release-documentation availability check. The moving latest-package canary is reported separately and is not release-blocking.
 
           Windows and macOS assets are currently unsigned unless this workflow is extended with signing secrets. See docs/RELEASES.md for the expected first-run warnings and the signing path.
           EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,6 +307,7 @@ jobs:
   desktop-first-success:
     name: Desktop First-Success Contract
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,6 +326,9 @@ jobs:
           restore-keys: |
             nuget-${{ runner.os }}-
 
+      - name: Validate packaged smoke fixture
+        run: python3 -m unittest discover -s eng -p "test_verify_desktop_first_success.py"
+
       - name: Restore desktop contract tests
         run: dotnet restore src/OpenClaw.Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are tracked in this file.
 
 ### Release Engineering
 
+- Standardized the desktop product name as AgentQi Companion while preserving OpenClaw.NET runtime, package, protocol, and storage identities.
+- Added a release-blocking desktop first-success contract covering Companion preset persistence, shared preset capabilities, sequential multi-tool selection, and an Ollama-compatible tool round trip.
+- Added a release documentation gate that rejects tags still described as future or unavailable work, and updated v0.3.0 availability guidance.
 - Made the deterministic pinned public-plugin compatibility smoke run on pull requests and `main` pushes, while keeping the moving latest-package canary scheduled/manual and non-blocking.
 - Added the pinned public-plugin compatibility smoke as a prerequisite for release asset builds.
 - Pinned Supermemory's complete plugin/peer test set and kept a separate latest-peer canary so release verification is reproducible while upstream drift remains visible.

--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@
 
 Run an assistant locally or host a gateway for your team. Connect a hosted or local model, give it tools and memory, and work through desktop chat, the browser, messaging channels, or APIs. Developers can extend the runtime in .NET and deploy supported capabilities with NativeAOT.
 
-**OpenClaw.NET** is the runtime and repository. **AgentQi [OpenClaw.NET]** is the Avalonia desktop companion; [AgentQi.dev](https://agentqi.dev) is the documentation and ecosystem home.
+**OpenClaw.NET** is the runtime and repository. **AgentQi Companion** is the Avalonia desktop product for OpenClaw.NET; [AgentQi.dev](https://agentqi.dev) is the documentation and ecosystem home.
 
 This is an independent .NET implementation inspired by [OpenClaw](https://github.com/openclaw/openclaw), with practical ecosystem compatibility. It is not affiliated with or endorsed by the upstream project.
 
 ## Meet the desktop companion
 
-Chat is the starting point. AgentQi brings setup, connections, activity, memory, history, and settings into one desktop interface, with light and dark themes.
+Chat is the starting point. AgentQi Companion brings setup, connections, activity, memory, history, and settings into one desktop interface, with light and dark themes.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/images/companion/agentqi-dark.png" />
   <source media="(prefers-color-scheme: light)" srcset="docs/images/companion/agentqi-light.png" />
-  <img src="docs/images/companion/agentqi-light.png" alt="AgentQi Avalonia desktop companion: chat welcome screen, setup shortcuts, navigation sidebar, and Configure via chat option" width="1200" />
+  <img src="docs/images/companion/agentqi-light.png" alt="AgentQi Companion for OpenClaw.NET: chat welcome screen, setup shortcuts, navigation sidebar, and Configure via chat option" width="1200" />
 </picture>
 
 *Companion welcome screen from `main`, before connecting a gateway. Packaged releases may show an earlier interface.*
@@ -39,7 +39,7 @@ Chat configuration covers supported scalar settings, not every operation. Creden
 
 ## Download And Run Desktop
 
-Choose a desktop bundle from the [latest release](https://github.com/clawdotnet/openclaw.net/releases/latest). Each includes Companion, the NativeAOT gateway, and the NativeAOT CLI.
+Choose a desktop bundle from the [latest release](https://github.com/clawdotnet/openclaw.net/releases/latest). Each includes AgentQi Companion, the NativeAOT gateway, and the NativeAOT CLI.
 
 | Platform | Download |
 | --- | --- |
@@ -119,7 +119,7 @@ Tool: echo(hello): ok
 | Area | Capabilities |
 | --- | --- |
 | Agent runtime | Streaming, tool execution, cancellation, retries, sessions, memory, and token-usage reporting. |
-| Interfaces | AgentQi desktop companion, browser chat and admin UI, CLI, terminal UI, OpenAI-compatible HTTP endpoints, MCP, and WebSockets. |
+| Interfaces | AgentQi Companion, browser chat and admin UI, CLI, terminal UI, OpenAI-compatible HTTP endpoints, MCP, and WebSockets. |
 | Models | OpenAI, Claude, Gemini, Azure OpenAI, DeepSeek, Ollama, and OpenAI-compatible providers; named profiles and optional embedded local inference. |
 | Tools and channels | 80+ native and optional tool surfaces for files, web, sessions, databases, email, home automation, and more; adapters for Telegram, WhatsApp, Teams, Slack, Discord, and other channels. The active set depends on configuration. |
 | Extensions | MCP servers and interactive MCP Apps, reusable `SKILL.md` packages, first-party .NET integrations, and supported OpenClaw TS/JS plugins. |

--- a/docs/ARCHITECTURE_BOUNDARIES.md
+++ b/docs/ARCHITECTURE_BOUNDARIES.md
@@ -8,9 +8,19 @@ OpenClaw.NET is a NativeAOT-friendly agent runtime and gateway for local and sel
 | --- | --- | --- |
 | **OpenClaw.NET** | Repository and runtime identity | Owns runtime correctness, local/self-hosted execution, gateway and CLI primitives, durable state, recovery, replay, and plugin execution compatibility. |
 | **AgentQi** | Documentation and ecosystem umbrella | Owns the broader developer/operator experience, ecosystem discovery, trust and lifecycle UX, and future multi-instance or fleet-level management. |
+| **AgentQi Companion** | Desktop product for OpenClaw.NET | Owns the chat-first desktop experience for setup and operation of one OpenClaw.NET runtime. “For OpenClaw.NET” describes the relationship; it is not a package, protocol, or storage rename. |
 | **AgentQiX** | Reserved likely future runtime identity | No current package, repository, or runtime rename is implied. A migration requires an explicit naming decision, compatibility plan, and release boundary. |
 
-The current rule is therefore to keep runtime capabilities in OpenClaw.NET and describe cross-runtime ecosystem or managed-product work under AgentQi. Do not introduce AgentQiX naming into runtime packages or user-facing migration guidance until that separate decision is made.
+The current rule is therefore to keep runtime capabilities in OpenClaw.NET, use AgentQi Companion for the desktop application, and describe cross-runtime ecosystem or managed-product work under AgentQi. Do not introduce AgentQiX naming into runtime packages or user-facing migration guidance until that separate decision is made.
+
+### Naming surfaces
+
+| Surface | Canonical label |
+| --- | --- |
+| Repository, runtime, gateway, CLI, packages, protocols, settings, and GitHub release titles | **OpenClaw.NET** |
+| Desktop window chrome, application metadata, desktop-bundle descriptions, and desktop documentation | **AgentQi Companion**; use **AgentQi Companion for OpenClaw.NET** when the relationship needs explanation |
+| Documentation and ecosystem navigation | **AgentQi** and **AgentQi.dev** |
+| Future runtime references | Keep **AgentQiX** reserved until an explicit migration decision and compatibility plan exist |
 
 ## OpenClaw.NET Core
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -2,7 +2,7 @@
 
 OpenClaw.NET's low-friction desktop path is the **desktop bundle** published on [GitHub Releases](https://github.com/clawdotnet/openclaw.net/releases/latest). It bundles:
 
-- Companion
+- AgentQi Companion
 - the NativeAOT gateway
 - the NativeAOT CLI
 
@@ -74,7 +74,7 @@ A release is ready only when all of the following are true for the exact tag com
 
 Use **full CI** only when all required lanes above passed for that exact commit. Report the non-blocking latest-package canary separately so upstream drift is visible without making a moving dependency a release gate.
 
-> **v0.2.0 verification note:** v0.2.0 was published before the pinned public compatibility job became a release-workflow dependency. Its successful build and platform smokes did not establish public-plugin compatibility. The reliability and recovery work currently marked **main only** in the [roadmap](ROADMAP.md) also landed after the v0.2.0 tag.
+> **v0.2.0 verification note:** v0.2.0 was published before the pinned public compatibility job became a release-workflow dependency. Its successful build and platform smokes did not establish public-plugin compatibility. The reliability and recovery work documented in the [roadmap](ROADMAP.md) landed after v0.2.0 and was first released in v0.3.0.
 
 The workflow currently builds:
 
@@ -84,7 +84,7 @@ The workflow currently builds:
 
 The macOS runner label is intentionally ARM-native for the `osx-arm64` artifact. Add an Intel macOS row only if you want to support older Intel Macs and have a runner that can NativeAOT publish that RID reliably.
 
-### Companion Release Smoke
+### AgentQi Companion Release Smoke
 
 Before publishing a public desktop release, run this manual smoke on at least one desktop bundle:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,15 +2,15 @@
 
 ## Release Availability
 
-The roadmap describes the current `main` branch, not necessarily the latest published binaries. [v0.2.0](https://github.com/clawdotnet/openclaw.net/tree/v0.2.0) was cut before the reliability integration listed below. Items marked **main only** target **v0.3.0** and are not available in v0.2.0. A v0.2.1 release, if needed, is reserved for corrective release or compatibility work rather than this feature set.
+The roadmap describes the current `main` branch, which may move ahead of published binaries. The reliability, recovery, and AgentQi Companion work listed as recently completed is available in [v0.3.0](https://github.com/clawdotnet/openclaw.net/tree/v0.3.0) and later. Consult each future item for an explicit target release rather than assuming that `main` is already packaged.
 
 ## Recently Completed
 
-- **Companion token protection and migration** (**main only; target v0.3.0**): OS-backed token storage now automatically migrates legacy JSON/fallback credentials with read-back verification, preserves recoverable copies on failure, respects Remember token and plaintext opt-in, and uses atomic private file writes. See [Companion token storage](companion-token-storage.md).
+- **Companion token protection and migration** (**released in v0.3.0**): OS-backed token storage now automatically migrates legacy JSON/fallback credentials with read-back verification, preserves recoverable copies on failure, respects Remember token and plaintext opt-in, and uses atomic private file writes. See [Companion token storage](companion-token-storage.md).
 
-- **Run explanation and recovery view** (**main only; target v0.3.0**): admin console, Dashboard, and Companion session details combine recorded run/goal state, goal notes, session-scoped pending approvals, checkpoints, and recent tool failure evidence with contextual recovery guidance. Existing timelines remain available for investigation; the view does not authorize or replay actions.
+- **Run explanation and recovery view** (**released in v0.3.0**): admin console, Dashboard, and Companion session details combine recorded run/goal state, goal notes, session-scoped pending approvals, checkpoints, and recent tool failure evidence with contextual recovery guidance. Existing timelines remain available for investigation; the view does not authorize or replay actions.
 
-- **Real-run regression import and offline replay** (**main only; target v0.3.0**): import a redacted, complete text exchange from a gateway trajectory export and run recorded provider/tool fixtures through `RuntimeScenarioRunner`, with independent assertions and strict consumption checks. Includes an executable sample; see [trajectory replay](testing/trajectory-replay.md).
+- **Real-run regression import and offline replay** (**released in v0.3.0**): import a redacted, complete text exchange from a gateway trajectory export and run recorded provider/tool fixtures through `RuntimeScenarioRunner`, with independent assertions and strict consumption checks. Includes an executable sample; see [trajectory replay](testing/trajectory-replay.md).
 
 - Browser sessions invalidate after local operator account updates, deletion, or disablement.
 - Goal completion accepts completed tool work; model status updates run alone and blocked transitions require three observations. Resume resets continuation and blocker counters.
@@ -70,10 +70,10 @@ These are strong candidates for the next roadmap phases because they extend the 
 
 The runtime already includes CLI insights, URL safety validation, and trajectory export. The next additions build on those capabilities:
 
-1. **Durable action reconciliation (main only, opt-in; target v0.3.0)**: persisted dispatch journal, stable provider adapter keys, completed-result reuse, and blocking of unknown outcomes before replay. See [durable actions](durable-actions.md). Provider-specific adapters and executor-bypassing jobs need individual integration.
-2. **Expanded regression capture (main only; target v0.3.0)**: opt-in bounded automatic capture, structured failed/blocked tool replay, and offline multimodal URL-content verification. See [trajectory replay](testing/trajectory-replay.md).
-3. **Full-instance backup and restore (main only; target v0.3.0)**: offline inventory plans capture durable state and secret-reference manifests, verify checksums, and restore into a new isolated directory with SQLite validation and no dispatch. See [instance backup](instance-backup.md).
-4. **Guided recovery controls (main only; target v0.3.0)**: permission-aware goal pause/resume and evidence-backed action reconciliation with revision, approval, and budget checks. Complements the run explanation view; see [guided recovery](guided-recovery.md).
+1. **Durable action reconciliation (released in v0.3.0, opt-in)**: persisted dispatch journal, stable provider adapter keys, completed-result reuse, and blocking of unknown outcomes before replay. See [durable actions](durable-actions.md). Provider-specific adapters and executor-bypassing jobs need individual integration.
+2. **Expanded regression capture (released in v0.3.0)**: opt-in bounded automatic capture, structured failed/blocked tool replay, and offline multimodal URL-content verification. See [trajectory replay](testing/trajectory-replay.md).
+3. **Full-instance backup and restore (released in v0.3.0)**: offline inventory plans capture durable state and secret-reference manifests, verify checksums, and restore into a new isolated directory with SQLite validation and no dispatch. See [instance backup](instance-backup.md).
+4. **Guided recovery controls (released in v0.3.0)**: permission-aware goal pause/resume and evidence-backed action reconciliation with revision, approval, and budget checks. Complements the run explanation view; see [guided recovery](guided-recovery.md).
 
 ## Security Hardening (Likely Breaking)
 

--- a/docs/RUN_RECOVERY.md
+++ b/docs/RUN_RECOVERY.md
@@ -1,6 +1,6 @@
 # Run explanation and recovery
 
-> **Release availability:** Available on `main` and targeted for v0.3.0; not included in v0.2.0. See the [roadmap](ROADMAP.md).
+> **Release availability:** Included in v0.3.0 and later; not included in v0.2.0. See the [roadmap](ROADMAP.md).
 
 Open a session in the admin console, Dashboard, or Companion's Sessions tab. The **Run explanation and recovery** section shows a snapshot of the recorded state and the next steps appropriate to it. Refresh the session to see changes.
 

--- a/docs/companion-token-storage.md
+++ b/docs/companion-token-storage.md
@@ -1,6 +1,6 @@
 # Companion token storage and legacy migration
 
-> **Release availability:** Available on `main` and targeted for v0.3.0; not included in v0.2.0. See the [roadmap](ROADMAP.md).
+> **Release availability:** Included in v0.3.0 and later; not included in v0.2.0. See the [roadmap](ROADMAP.md).
 
 Companion stores remembered gateway tokens and provider API keys through the operating system:
 

--- a/docs/durable-actions.md
+++ b/docs/durable-actions.md
@@ -1,6 +1,6 @@
 # Durable action reconciliation
 
-> **Release availability:** Available on `main` and targeted for v0.3.0; not included in v0.2.0. See the [roadmap](ROADMAP.md).
+> **Release availability:** Included in v0.3.0 and later; not included in v0.2.0. See the [roadmap](ROADMAP.md).
 
 Set `OpenClaw:Tooling:DurableActionJournal` to `true` to journal native and MAF tool executor dispatches under `Memory.StoragePath/action-journal`. This is opt-in because it deliberately blocks work that older versions retried automatically.
 

--- a/docs/guided-recovery.md
+++ b/docs/guided-recovery.md
@@ -1,6 +1,6 @@
 # Guided operator recovery
 
-> **Release availability:** Available on `main` and targeted for v0.3.0; not included in v0.2.0. See the [roadmap](ROADMAP.md).
+> **Release availability:** Included in v0.3.0 and later; not included in v0.2.0. See the [roadmap](ROADMAP.md).
 
 The admin session page now includes recovery controls beside session details. The explanation view in PR #213 complements these controls; it is not required to operate them.
 

--- a/docs/instance-backup.md
+++ b/docs/instance-backup.md
@@ -1,6 +1,6 @@
 # Full-instance offline backup and restore
 
-> **Release availability:** Available on `main` and targeted for v0.3.0; not included in v0.2.0. See the [roadmap](ROADMAP.md).
+> **Release availability:** Included in v0.3.0 and later; not included in v0.2.0. See the [roadmap](ROADMAP.md).
 
 `openclaw backup` snapshots a declared inventory of instance directories, including file and SQLite state. It never starts a gateway, scheduler, plugin, model, or tool. Restoration always targets a new isolated directory and never replaces an existing deployment.
 

--- a/docs/testing/trajectory-replay.md
+++ b/docs/testing/trajectory-replay.md
@@ -1,6 +1,6 @@
 # Turn a captured exchange into an offline regression
 
-> **Release availability:** Available on `main` and targeted for v0.3.0; not included in v0.2.0. See the [roadmap](../ROADMAP.md).
+> **Release availability:** Included in v0.3.0 and later; not included in v0.2.0. See the [roadmap](../ROADMAP.md).
 
 `OpenClaw.Testing` can import one user exchange from the gateway's version 1 JSONL trajectory export and replay its provider responses and tool outputs through the real runtime. This tests orchestration, tool dispatch, approval behavior, and output assertions without repeating external actions.
 

--- a/eng/test_verify_desktop_first_success.py
+++ b/eng/test_verify_desktop_first_success.py
@@ -1,0 +1,33 @@
+"""The packaged gate must reject error responses masquerading as a tool round trip."""
+import importlib.util
+from pathlib import Path
+import threading
+import unittest
+from http.server import ThreadingHTTPServer
+
+spec = importlib.util.spec_from_file_location("desktop_smoke", Path(__file__).with_name("verify-desktop-first-success.py"))
+smoke = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(smoke)
+
+
+class ToolResultContractTests(unittest.TestCase):
+    def test_only_known_memory_result_completes_turn(self):
+        server = ThreadingHTTPServer(("127.0.0.1", 0), smoke.OllamaFixtureHandler)
+        worker = threading.Thread(target=server.serve_forever, daemon=True)
+        worker.start()
+        try:
+            for content in ("Error: tool denied", "Note 'desktop-release-contract' not found.", smoke.NOTE_TEXT):
+                with self.subTest(content=content):
+                    response = smoke.read_json(
+                        f"http://127.0.0.1:{server.server_port}/api/chat",
+                        payload={"messages": [{"role": "tool", "content": content}]},
+                    )
+                    self.assertEqual(response["message"]["content"] == smoke.FINAL_TEXT, content == smoke.NOTE_TEXT)
+        finally:
+            server.shutdown()
+            server.server_close()
+            worker.join(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eng/verify-desktop-first-success.py
+++ b/eng/verify-desktop-first-success.py
@@ -2,6 +2,7 @@
 """Exercise packaged CLI/setup and gateway through an Ollama-compatible tool round trip."""
 
 import argparse
+import base64
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 from pathlib import Path
@@ -15,6 +16,8 @@ from urllib.request import Request, urlopen
 
 
 FINAL_TEXT = "desktop packaged first success complete"
+NOTE_KEY = "desktop-release-contract"
+NOTE_TEXT = "verified desktop release memory sentinel"
 
 
 def free_port() -> int:
@@ -39,15 +42,16 @@ class OllamaFixtureHandler(BaseHTTPRequestHandler):
         length = int(self.headers.get("Content-Length", "0"))
         payload = json.loads(self.rfile.read(length).decode("utf-8"))
         self.requests.append(payload)
-        has_tool_result = any(message.get("role") == "tool" for message in payload.get("messages", []))
-        if has_tool_result:
-            message = {"role": "assistant", "content": FINAL_TEXT}
+        tool_results = [message for message in payload.get("messages", []) if message.get("role") == "tool"]
+        if tool_results:
+            valid = any(message.get("content") == NOTE_TEXT for message in tool_results)
+            message = {"role": "assistant", "content": FINAL_TEXT if valid else "unexpected tool result"}
         else:
             message = {
                 "role": "assistant",
                 "content": "",
                 "tool_calls": [
-                    {"function": {"name": "memory_get", "arguments": {"key": "desktop-release-contract"}}}
+                    {"function": {"name": "memory_get", "arguments": {"key": NOTE_KEY}}}
                 ],
             }
         self.send_json({"message": message, "done": True, "done_reason": "stop", "prompt_eval_count": 12, "eval_count": 4})
@@ -107,10 +111,10 @@ def main() -> int:
 
     cli = str(Path(args.cli).resolve(strict=True))
     gateway = str(Path(args.gateway).resolve(strict=True))
-    provider_port = free_port()
-    gateway_port = free_port()
     OllamaFixtureHandler.requests = []
-    provider = ThreadingHTTPServer(("127.0.0.1", provider_port), OllamaFixtureHandler)
+    provider = ThreadingHTTPServer(("127.0.0.1", 0), OllamaFixtureHandler)
+    provider_port = provider.server_port
+    gateway_port = free_port()
     provider_thread = threading.Thread(target=provider.serve_forever, daemon=True)
     provider_thread.start()
 
@@ -150,6 +154,11 @@ def main() -> int:
             if capabilities["supportsTools"] is not True or capabilities["supportsParallelToolCalls"] is not False:
                 raise AssertionError("Packaged CLI did not persist sequential tool capabilities.")
             config_path.write_text(json.dumps(config), encoding="utf-8")
+            # Seed the file-memory store so errors or missing notes cannot satisfy the gate.
+            notes = Path(openclaw["memory"]["storagePath"]) / "notes"
+            notes.mkdir(parents=True, exist_ok=True)
+            encoded_key = base64.urlsafe_b64encode(NOTE_KEY.encode()).decode().rstrip("=")
+            (notes / f"{encoded_key}.md").write_text(NOTE_TEXT, encoding="utf-8")
 
             gateway_log_path = root / "gateway.log"
             with gateway_log_path.open("w", encoding="utf-8") as gateway_log:
@@ -158,6 +167,7 @@ def main() -> int:
                     stdout=gateway_log,
                     stderr=subprocess.STDOUT,
                     text=True,
+                    cwd=root,
                 )
                 try:
                     base_url = f"http://127.0.0.1:{gateway_port}"
@@ -190,9 +200,11 @@ def main() -> int:
             if len(OllamaFixtureHandler.requests) != 2:
                 raise AssertionError(f"Expected two sequential provider requests, got {len(OllamaFixtureHandler.requests)}.")
             first, second = OllamaFixtureHandler.requests
+            if any(request.get("model") != "fixture-model" for request in (first, second)):
+                raise AssertionError("Gateway did not use the configured model.")
             if len(first.get("tools", [])) < 2:
                 raise AssertionError("Gateway did not advertise multiple tools to the sequential-tool model.")
-            if not any(message.get("role") == "tool" for message in second.get("messages", [])):
+            if not any(message.get("role") == "tool" and message.get("content") == NOTE_TEXT for message in second.get("messages", [])):
                 raise AssertionError("Gateway did not return the tool result before requesting the final response.")
     finally:
         provider.shutdown()

--- a/eng/verify-desktop-first-success.py
+++ b/eng/verify-desktop-first-success.py
@@ -64,22 +64,32 @@ class OllamaFixtureHandler(BaseHTTPRequestHandler):
         del format, args
 
 
-def read_json(url: str, token: str | None = None, payload: dict | None = None) -> dict:
+def read_json(
+    url: str,
+    token: str | None = None,
+    payload: dict | None = None,
+    timeout: float = 5,
+) -> dict:
     data = None if payload is None else json.dumps(payload).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
     request = Request(url, data=data, headers=headers, method="POST" if payload is not None else "GET")
-    with urlopen(request, timeout=5) as response:
+    with urlopen(request, timeout=timeout) as response:
         return json.loads(response.read().decode("utf-8"))
 
 
-def wait_for_health(url: str, process: subprocess.Popen[str]) -> None:
+def read_gateway_log(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace") if path.exists() else ""
+
+
+def wait_for_health(url: str, process: subprocess.Popen[str], log_path: Path) -> None:
     deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
         if process.poll() is not None:
-            stdout, stderr = process.communicate()
-            raise RuntimeError(f"Packaged gateway exited before readiness.\n{stdout}\n{stderr}")
+            raise RuntimeError(
+                f"Packaged gateway exited before readiness.\n{read_gateway_log(log_path)}"
+            )
         try:
             with urlopen(url, timeout=5) as response:
                 response.read()
@@ -141,33 +151,41 @@ def main() -> int:
                 raise AssertionError("Packaged CLI did not persist sequential tool capabilities.")
             config_path.write_text(json.dumps(config), encoding="utf-8")
 
-            process = subprocess.Popen(
-                [gateway, "--config", str(config_path)],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
-            try:
-                base_url = f"http://127.0.0.1:{gateway_port}"
-                wait_for_health(f"{base_url}/health", process)
-                response = read_json(
-                    f"{base_url}/v1/chat/completions",
-                    openclaw.get("authToken"),
-                    {
-                        "model": "local-primary",
-                        "messages": [{"role": "user", "content": "Read the desktop release contract memory note."}],
-                    },
+            gateway_log_path = root / "gateway.log"
+            with gateway_log_path.open("w", encoding="utf-8") as gateway_log:
+                process = subprocess.Popen(
+                    [gateway, "--config", str(config_path)],
+                    stdout=gateway_log,
+                    stderr=subprocess.STDOUT,
+                    text=True,
                 )
-                rendered = json.dumps(response)
-                if FINAL_TEXT not in rendered:
-                    raise AssertionError(f"Gateway response did not contain the fixture completion: {rendered}")
-            finally:
-                process.terminate()
                 try:
-                    process.wait(timeout=10)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                    process.wait(timeout=5)
+                    base_url = f"http://127.0.0.1:{gateway_port}"
+                    wait_for_health(f"{base_url}/health", process, gateway_log_path)
+                    response = read_json(
+                        f"{base_url}/v1/chat/completions",
+                        openclaw.get("authToken"),
+                        {
+                            "model": "local-primary",
+                            "messages": [{"role": "user", "content": "Read the desktop release contract memory note."}],
+                        },
+                        timeout=60,
+                    )
+                    rendered = json.dumps(response)
+                    if FINAL_TEXT not in rendered:
+                        raise AssertionError(f"Gateway response did not contain the fixture completion: {rendered}")
+                except Exception as error:
+                    gateway_log.flush()
+                    raise RuntimeError(
+                        f"{error}\nPackaged gateway log:\n{read_gateway_log(gateway_log_path)}"
+                    ) from error
+                finally:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=5)
 
             if len(OllamaFixtureHandler.requests) != 2:
                 raise AssertionError(f"Expected two sequential provider requests, got {len(OllamaFixtureHandler.requests)}.")

--- a/eng/verify-desktop-first-success.py
+++ b/eng/verify-desktop-first-success.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Exercise packaged CLI/setup and gateway through an Ollama-compatible tool round trip."""
+
+import argparse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+from pathlib import Path
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+FINAL_TEXT = "desktop packaged first success complete"
+
+
+def free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return listener.getsockname()[1]
+
+
+class OllamaFixtureHandler(BaseHTTPRequestHandler):
+    requests: list[dict] = []
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            self.send_json({"status": "ok"})
+        else:
+            self.send_error(404)
+
+    def do_POST(self) -> None:
+        if self.path != "/api/chat":
+            self.send_error(404)
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        self.requests.append(payload)
+        has_tool_result = any(message.get("role") == "tool" for message in payload.get("messages", []))
+        if has_tool_result:
+            message = {"role": "assistant", "content": FINAL_TEXT}
+        else:
+            message = {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"function": {"name": "memory_get", "arguments": {"key": "desktop-release-contract"}}}
+                ],
+            }
+        self.send_json({"message": message, "done": True, "done_reason": "stop", "prompt_eval_count": 12, "eval_count": 4})
+
+    def send_json(self, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        del format, args
+
+
+def read_json(url: str, token: str | None = None, payload: dict | None = None) -> dict:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = Request(url, data=data, headers=headers, method="POST" if payload is not None else "GET")
+    with urlopen(request, timeout=5) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def wait_for_health(url: str, process: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            stdout, stderr = process.communicate()
+            raise RuntimeError(f"Packaged gateway exited before readiness.\n{stdout}\n{stderr}")
+        try:
+            with urlopen(url, timeout=5) as response:
+                response.read()
+            return
+        except (HTTPError, URLError, TimeoutError):
+            time.sleep(0.25)
+    raise TimeoutError("Packaged gateway did not become healthy within 30 seconds.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cli", required=True)
+    parser.add_argument("--gateway", required=True)
+    args = parser.parse_args()
+
+    cli = str(Path(args.cli).resolve(strict=True))
+    gateway = str(Path(args.gateway).resolve(strict=True))
+    provider_port = free_port()
+    gateway_port = free_port()
+    OllamaFixtureHandler.requests = []
+    provider = ThreadingHTTPServer(("127.0.0.1", provider_port), OllamaFixtureHandler)
+    provider_thread = threading.Thread(target=provider.serve_forever, daemon=True)
+    provider_thread.start()
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="openclaw-desktop-first-success-") as temporary:
+            root = Path(temporary)
+            config_path = root / "config" / "openclaw.settings.json"
+            workspace = root / "workspace"
+            setup = subprocess.run(
+                [
+                    cli,
+                    "setup",
+                    "--non-interactive",
+                    "--profile", "local",
+                    "--workspace", str(workspace),
+                    "--provider", "ollama",
+                    "--model", "fixture-model",
+                    "--model-preset", "ollama-agentic",
+                    "--config", str(config_path),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if setup.returncode:
+                raise RuntimeError(f"Packaged CLI setup failed.\n{setup.stdout}\n{setup.stderr}")
+
+            config = json.loads(config_path.read_text(encoding="utf-8-sig"))
+            openclaw = config["OpenClaw"]
+            openclaw["port"] = gateway_port
+            openclaw["llm"]["endpoint"] = f"http://127.0.0.1:{provider_port}"
+            profile = openclaw["models"]["profiles"][0]
+            profile["baseUrl"] = f"http://127.0.0.1:{provider_port}"
+            if profile["presetId"] != "ollama-agentic":
+                raise AssertionError("Packaged CLI did not persist the ollama-agentic preset.")
+            capabilities = profile["capabilities"]
+            if capabilities["supportsTools"] is not True or capabilities["supportsParallelToolCalls"] is not False:
+                raise AssertionError("Packaged CLI did not persist sequential tool capabilities.")
+            config_path.write_text(json.dumps(config), encoding="utf-8")
+
+            process = subprocess.Popen(
+                [gateway, "--config", str(config_path)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                base_url = f"http://127.0.0.1:{gateway_port}"
+                wait_for_health(f"{base_url}/health", process)
+                response = read_json(
+                    f"{base_url}/v1/chat/completions",
+                    openclaw.get("authToken"),
+                    {
+                        "model": "local-primary",
+                        "messages": [{"role": "user", "content": "Read the desktop release contract memory note."}],
+                    },
+                )
+                rendered = json.dumps(response)
+                if FINAL_TEXT not in rendered:
+                    raise AssertionError(f"Gateway response did not contain the fixture completion: {rendered}")
+            finally:
+                process.terminate()
+                try:
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+
+            if len(OllamaFixtureHandler.requests) != 2:
+                raise AssertionError(f"Expected two sequential provider requests, got {len(OllamaFixtureHandler.requests)}.")
+            first, second = OllamaFixtureHandler.requests
+            if len(first.get("tools", [])) < 2:
+                raise AssertionError("Gateway did not advertise multiple tools to the sequential-tool model.")
+            if not any(message.get("role") == "tool" for message in second.get("messages", [])):
+                raise AssertionError("Gateway did not return the tool result before requesting the final response.")
+    finally:
+        provider.shutdown()
+        provider.server_close()
+        provider_thread.join(timeout=5)
+
+    print("Packaged Ollama Agentic setup, gateway start, and sequential tool round trip passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eng/verify-release-docs.py
+++ b/eng/verify-release-docs.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Reject release documentation that still describes the release tag as future work."""
+
+from pathlib import Path
+import re
+import sys
+
+
+def normalize_tag(value: str) -> tuple[str, str]:
+    tag = value.strip()
+    match = re.fullmatch(r"v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)", tag)
+    if match is None:
+        raise ValueError(f"Expected a semantic release tag such as v0.3.0, got {value!r}.")
+    version = match.group(1)
+    return f"v{version}", version
+
+
+def markdown_files(root: Path) -> list[Path]:
+    candidates = [root / "README.md", root / "CHANGELOG.md"]
+    candidates.extend((root / "docs").rglob("*.md"))
+    return sorted(path for path in candidates if path.is_file())
+
+
+def find_stale_references(root: Path, tag: str, version: str) -> list[str]:
+    escaped_tag = re.escape(tag)
+    escaped_version = re.escape(version)
+    patterns = [
+        re.compile(rf"\btarget(?:ed)?(?:\s+for)?\s+\*{{0,2}}{escaped_tag}\*{{0,2}}", re.IGNORECASE),
+        re.compile(rf"\bmain[ -]only\b[^\n]{{0,120}}\b{escaped_tag}\b", re.IGNORECASE),
+        re.compile(rf"\bnot (?:available|included) in\s+\*{{0,2}}{escaped_tag}\*{{0,2}}", re.IGNORECASE),
+        re.compile(rf"\bplanned for\s+\*{{0,2}}v?{escaped_version}\*{{0,2}}", re.IGNORECASE),
+    ]
+    failures: list[str] = []
+    for path in markdown_files(root):
+        for line_number, line in enumerate(path.read_text(encoding="utf-8-sig").splitlines(), start=1):
+            if any(pattern.search(line) for pattern in patterns):
+                failures.append(f"{path.relative_to(root)}:{line_number}: {line.strip()}")
+    return failures
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: verify-release-docs.py <release-tag>", file=sys.stderr)
+        return 2
+
+    try:
+        tag, version = normalize_tag(sys.argv[1])
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 2
+
+    root = Path(__file__).resolve().parent.parent
+    failures = find_stale_references(root, tag, version)
+    if failures:
+        print(f"Release documentation still describes {tag} as future or unavailable:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        print("Update roadmap and availability banners before publishing the tag.", file=sys.stderr)
+        return 1
+
+    print(f"Release documentation contains no stale future-work markers for {tag}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/OpenClaw.Companion/App.axaml
+++ b/src/OpenClaw.Companion/App.axaml
@@ -3,7 +3,7 @@
              x:Class="OpenClaw.Companion.App"
              xmlns:local="using:OpenClaw.Companion"
              xmlns:conv="using:OpenClaw.Companion.Converters"
-             Name="AgentQi [OpenClaw.NET]"
+             Name="AgentQi Companion"
              RequestedThemeVariant="Default">
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
 

--- a/src/OpenClaw.Companion/Assets/BRANDING.md
+++ b/src/OpenClaw.Companion/Assets/BRANDING.md
@@ -1,6 +1,10 @@
 # AgentQi Companion branding
 
-Display name: **AgentQi [OpenClaw.NET]**. Assembly names, protocol identifiers, settings paths, and credential-store identifiers remain compatible with existing installations.
+Canonical desktop product name: **AgentQi Companion**.
+
+Relationship descriptor: **AgentQi Companion for OpenClaw.NET**. Use this in explanatory copy where the runtime relationship needs to be explicit; do not treat the descriptor as an executable, package, protocol, or storage identity.
+
+Assembly names, protocol identifiers, settings paths, and credential-store identifiers remain compatible with existing installations.
 
 - `agentqi-wordmark.png`: supplied light wordmark, copied unchanged.
 - `agentqi-artwork.png`: supplied dark artwork, copied unchanged.

--- a/src/OpenClaw.Companion/OpenClaw.Companion.csproj
+++ b/src/OpenClaw.Companion/OpenClaw.Companion.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <Title>AgentQi [OpenClaw.NET]</Title>
-    <Product>AgentQi [OpenClaw.NET]</Product>
+    <Title>AgentQi Companion</Title>
+    <Product>AgentQi Companion</Product>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/OpenClaw.Companion/Services/DesktopNotifier.cs
+++ b/src/OpenClaw.Companion/Services/DesktopNotifier.cs
@@ -109,7 +109,7 @@ public sealed class DesktopNotifier : IDesktopNotifier
     }
 
     private static Task NotifyLinuxAsync(string title, string body, CancellationToken ct)
-        => RunProcessAsync("notify-send", ["--app-name=AgentQi [OpenClaw.NET]", "--", title, body], ct);
+        => RunProcessAsync("notify-send", ["--app-name=AgentQi Companion", "--", title, body], ct);
 
     private static async Task RunProcessAsync(string fileName, string[] arguments, CancellationToken ct)
     {

--- a/src/OpenClaw.Companion/Views/MainWindow.axaml
+++ b/src/OpenClaw.Companion/Views/MainWindow.axaml
@@ -9,7 +9,7 @@
         x:DataType="vm:MainWindowViewModel"
         Icon="/Assets/agentqi-icon.png"
 		Width="1440" Height="960" MinWidth="1000" MinHeight="700" WindowStartupLocation="CenterScreen" WindowState="Maximized"
-        Title="AgentQi [OpenClaw.NET]" Classes="companion-window">
+        Title="AgentQi Companion" Classes="companion-window">
 
 	<Design.DataContext>
 		<vm:MainWindowViewModel/>
@@ -269,7 +269,7 @@
                     <Grid Grid.Row="1">
                         <ScrollViewer IsVisible="{Binding ShowChatWelcome}" HorizontalScrollBarVisibility="Disabled">
                             <StackPanel Classes="welcome" MaxWidth="640" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                <Grid Height="128" HorizontalAlignment="Stretch" AutomationProperties.Name="AgentQi [OpenClaw.NET]">
+                                <Grid Height="128" HorizontalAlignment="Stretch" AutomationProperties.Name="AgentQi Companion">
                                     <Border CornerRadius="16" ClipToBounds="True" Background="Transparent" IsVisible="{Binding IsDarkTheme, Converter={StaticResource InverseBool}}">
                                         <Image Source="/Assets/agentqi-wordmark-transparent.png" Stretch="Uniform" />
                                     </Border>

--- a/src/OpenClaw.Companion/Views/MainWindow.axaml
+++ b/src/OpenClaw.Companion/Views/MainWindow.axaml
@@ -19,8 +19,8 @@
         <Border Background="{DynamicResource CompanionSidebar}" BorderBrush="{DynamicResource CompanionBorder}" BorderThickness="0,0,1,0">
             <Grid RowDefinitions="Auto,*,Auto">
                 <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12" Margin="20,26,16,28">
-                    <Image Source="/Assets/agentqi-icon.png" Width="38" Height="38" Stretch="Uniform" AutomationProperties.Name="AgentQi logo" />
-                    <StackPanel Grid.Column="1" Spacing="3"><TextBlock Text="AgentQi" FontWeight="SemiBold" FontSize="19" /><TextBlock Text="[OpenClaw.NET]" Classes="muted" FontSize="11" /></StackPanel>
+                    <Image Source="/Assets/agentqi-icon.png" Width="38" Height="38" Stretch="Uniform" AutomationProperties.Name="AgentQi Companion logo" />
+                    <StackPanel Grid.Column="1" Spacing="3"><TextBlock Text="AgentQi Companion" FontWeight="SemiBold" FontSize="19" /><TextBlock Text="for OpenClaw.NET" Classes="muted" FontSize="11" /></StackPanel>
                 </Grid>
                 <ListBox x:Name="PrimaryNavigation" Grid.Row="1" Classes="navigation" Margin="10,0" ItemsSource="{Binding NavigationGroups}" SelectedItem="{Binding SelectedNavigationGroup}" AutomationProperties.Name="Main navigation">
                     <ListBox.ItemTemplate><DataTemplate DataType="vm:CompanionNavigationGroup">
@@ -276,11 +276,11 @@
                                     <Border CornerRadius="16" ClipToBounds="True" Background="#030B10" IsVisible="{Binding IsDarkTheme}">
                                         <Grid ColumnDefinitions="*,*">
                                             <Image Source="/Assets/agentqi-artwork.png" Stretch="Uniform" />
-                                            <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="6" Margin="12,0"><TextBlock Text="AgentQi" FontSize="40" FontWeight="SemiBold" Foreground="#BAF4EF" /><TextBlock Text="[OpenClaw.NET]" Foreground="#CBB99B" FontSize="14" /></StackPanel>
+                                            <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="6" Margin="12,0"><TextBlock Text="AgentQi Companion" FontSize="40" FontWeight="SemiBold" Foreground="#BAF4EF" /><TextBlock Text="for OpenClaw.NET" Foreground="#CBB99B" FontSize="14" /></StackPanel>
                                         </Grid>
                                     </Border>
                                 </Grid>
-                                <TextBlock Text="[OpenClaw.NET]" Classes="muted" FontSize="12" IsVisible="{Binding IsDarkTheme, Converter={StaticResource InverseBool}}" />
+                                <TextBlock Text="AgentQi Companion for OpenClaw.NET" Classes="muted" FontSize="12" IsVisible="{Binding IsDarkTheme, Converter={StaticResource InverseBool}}" />
                                 <TextBlock Classes="welcome-title" Text="A little help. A lot of possibility." FontWeight="SemiBold" TextWrapping="Wrap" />
                                 <TextBlock Text="Bring a question, work through an idea, or put your assistant to work. Everything you need is close by." Classes="muted" FontSize="15" TextWrapping="Wrap" LineHeight="24" />
                                 <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12" Margin="0,12,0,0">
@@ -300,7 +300,7 @@
                                                 <StackPanel Spacing="6"><TextBlock Text="You" FontWeight="SemiBold" FontSize="12" Foreground="{DynamicResource CompanionAccent}" /><SelectableTextBlock Text="{Binding Text}" TextWrapping="Wrap" /></StackPanel>
                                             </Border>
                                             <StackPanel IsVisible="{Binding IsAssistant}" Spacing="10" Margin="0,0,20,0">
-                                                <TextBlock Text="AgentQi" FontWeight="SemiBold" Foreground="{DynamicResource CompanionAccent}" />
+                                                <TextBlock Text="AgentQi Companion" FontWeight="SemiBold" Foreground="{DynamicResource CompanionAccent}" />
                                                 <SelectableTextBlock Text="{Binding Text}" TextWrapping="Wrap" />
                                                 <TextBlock Text="Working on it…" Classes="muted" IsVisible="{Binding IsStreamingPlaceholder}" />
                                             </StackPanel>

--- a/src/OpenClaw.Tests/CompanionCanvasUiTests.cs
+++ b/src/OpenClaw.Tests/CompanionCanvasUiTests.cs
@@ -103,7 +103,7 @@ public sealed class CompanionCanvasUiTests : IDisposable
 
             var tabControl = window.GetVisualDescendants().OfType<TabControl>().Single();
             Assert.Equal(Dock.Left, tabControl.TabStripPlacement);
-            Assert.Contains(window.GetVisualDescendants().OfType<TextBlock>(), text => string.Equals(text.Text, "AgentQi", StringComparison.Ordinal));
+            Assert.Contains(window.GetVisualDescendants().OfType<TextBlock>(), text => string.Equals(text.Text, "AgentQi Companion", StringComparison.Ordinal));
 
             var headers = tabControl.Items.OfType<TabItem>().Select(static item => item.Header?.ToString()).ToArray();
             Assert.Contains("Home", headers);

--- a/src/OpenClaw.Tests/DesktopFirstSuccessContractTests.cs
+++ b/src/OpenClaw.Tests/DesktopFirstSuccessContractTests.cs
@@ -33,11 +33,12 @@ public sealed class DesktopFirstSuccessContractTests
         {
             window.Show();
             viewModel.SetupProvider = "ollama";
-            viewModel.SetupModel = "fixture-model";
+            viewModel.SetupModel = "llama3.2";
             viewModel.SetupModelPreset = "ollama-agentic";
             Dispatcher.UIThread.RunJobs();
 
             var settings = store.Load();
+            Assert.Equal("llama3.2", settings.SetupModel);
             Assert.Equal("ollama-agentic", settings.SetupModelPreset);
             Assert.All(viewModel.SetupModelPresetOptions, id =>
                 Assert.True(LocalModelPresetCatalog.TryGet(id, out _), $"Setup offers unknown preset '{id}'."));

--- a/src/OpenClaw.Tests/DesktopFirstSuccessContractTests.cs
+++ b/src/OpenClaw.Tests/DesktopFirstSuccessContractTests.cs
@@ -1,0 +1,159 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using OpenClaw.Agent;
+using OpenClaw.Companion.Services;
+using OpenClaw.Companion.ViewModels;
+using OpenClaw.Companion.Views;
+using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Setup;
+using OpenClaw.Gateway.Extensions;
+using OpenClaw.Gateway.Models;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+public sealed class DesktopFirstSuccessContractTests
+{
+    [AvaloniaFact]
+    [Trait("Category", "DesktopRelease")]
+    public async Task OllamaAgentic_FromCompanionBinding_SelectsSequentialModelAndCompletesToolCall()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "desktop-first-success", Guid.NewGuid().ToString("N"));
+        var store = new SettingsStore(directory);
+        var viewModel = new MainWindowViewModel(store, new GatewayWebSocketClient());
+        var window = new MainWindow { DataContext = viewModel };
+        try
+        {
+            window.Show();
+            viewModel.SetupProvider = "ollama";
+            viewModel.SetupModel = "fixture-model";
+            viewModel.SetupModelPreset = "ollama-agentic";
+            Dispatcher.UIThread.RunJobs();
+
+            var settings = store.Load();
+            Assert.Equal("ollama-agentic", settings.SetupModelPreset);
+            Assert.All(viewModel.SetupModelPresetOptions, id =>
+                Assert.True(LocalModelPresetCatalog.TryGet(id, out _), $"Setup offers unknown preset '{id}'."));
+
+            var config = GatewaySetupProfileFactory.CreateProfileConfig(
+                "local",
+                "127.0.0.1",
+                18789,
+                "test-token",
+                directory,
+                Path.Combine(directory, "memory"),
+                settings.SetupProvider!,
+                settings.SetupModel,
+                "",
+                settings.SetupModelPreset);
+            var profile = Assert.Single(config.Models.Profiles);
+            Assert.Equal("ollama-agentic", profile.PresetId);
+            Assert.True(profile.Capabilities.SupportsTools);
+            Assert.False(profile.Capabilities.SupportsParallelToolCalls);
+
+            using var registry = new ConfiguredModelProfileRegistry(config, NullLogger<ConfiguredModelProfileRegistry>.Instance);
+            registry.SetDefaultProfileId();
+            var selectionPolicy = new DefaultModelSelectionPolicy(registry);
+            using var schema = JsonDocument.Parse("""{"type":"object","properties":{"value":{"type":"string"}}}""");
+            var selection = selectionPolicy.Resolve(new ModelSelectionRequest
+            {
+                Session = new Session
+                {
+                    Id = "desktop-first-success",
+                    ChannelId = "desktop",
+                    SenderId = "operator",
+                    ModelProfileId = "local-primary"
+                },
+                Messages = [new ChatMessage(ChatRole.User, "Record the first successful tool call.")],
+                Options = new ChatOptions
+                {
+                    Tools =
+                    [
+                        AIFunctionFactory.CreateDeclaration("record_observation", "Record an observation", schema.RootElement.Clone(), returnJsonSchema: null),
+                        AIFunctionFactory.CreateDeclaration("read_observation", "Read an observation", schema.RootElement.Clone(), returnJsonSchema: null)
+                    ]
+                }
+            });
+
+            Assert.Equal("local-primary", selection.SelectedProfileId);
+            Assert.True(selection.Requirements.SupportsTools);
+            Assert.Null(selection.Requirements.SupportsParallelToolCalls);
+
+            var handler = new SequentialOllamaHandler();
+            using var httpClient = new HttpClient(handler);
+            using var ollama = new OllamaChatClient(config.Llm, httpClient);
+            var tool = new RecordingTool();
+            var runtime = new AgentRuntime(
+                ollama,
+                [tool, new NoOpTool()],
+                Substitute.For<IMemoryStore>(),
+                config.Llm,
+                maxHistoryTurns: 10);
+            var result = await runtime.RunAsync(
+                new Session { Id = "tool-round-trip", ChannelId = "desktop", SenderId = "operator" },
+                "Record the first successful tool call.",
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal("desktop first success complete", result);
+            Assert.Equal(1, tool.CallCount);
+            Assert.Equal(2, handler.RequestBodies.Count);
+            Assert.Contains("\"record_observation\"", handler.RequestBodies[0], StringComparison.Ordinal);
+            Assert.Contains("\"read_observation\"", handler.RequestBodies[0], StringComparison.Ordinal);
+            Assert.Contains("\"role\":\"tool\"", handler.RequestBodies[1], StringComparison.Ordinal);
+        }
+        finally
+        {
+            window.Close();
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private sealed class SequentialOllamaHandler : HttpMessageHandler
+    {
+        public List<string> RequestBodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Assert.Equal("/api/chat", request.RequestUri!.AbsolutePath);
+            RequestBodies.Add(await request.Content!.ReadAsStringAsync(cancellationToken));
+            var body = RequestBodies.Count == 1
+                ? """{"message":{"content":"","tool_calls":[{"function":{"name":"record_observation","arguments":{"value":"ready"}}}]},"done_reason":"stop","prompt_eval_count":12,"eval_count":4}"""
+                : """{"message":{"content":"desktop first success complete"},"done_reason":"stop","prompt_eval_count":18,"eval_count":5}""";
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            };
+        }
+    }
+
+    private sealed class RecordingTool : ITool
+    {
+        private int _callCount;
+
+        public int CallCount => Volatile.Read(ref _callCount);
+        public string Name => "record_observation";
+        public string Description => "Record an observation.";
+        public string ParameterSchema => """{"type":"object","properties":{"value":{"type":"string"}},"required":["value"]}""";
+
+        public ValueTask<string> ExecuteAsync(string argumentsJson, CancellationToken ct)
+        {
+            Interlocked.Increment(ref _callCount);
+            return ValueTask.FromResult("recorded");
+        }
+    }
+
+    private sealed class NoOpTool : ITool
+    {
+        public string Name => "read_observation";
+        public string Description => "Read an observation.";
+        public string ParameterSchema => """{"type":"object","properties":{"value":{"type":"string"}}}""";
+        public ValueTask<string> ExecuteAsync(string argumentsJson, CancellationToken ct) => ValueTask.FromResult("none");
+    }
+}

--- a/src/OpenClaw.Tests/DesktopFirstSuccessContractTests.cs
+++ b/src/OpenClaw.Tests/DesktopFirstSuccessContractTests.cs
@@ -107,6 +107,8 @@ public sealed class DesktopFirstSuccessContractTests
             Assert.Equal("desktop first success complete", result);
             Assert.Equal(1, tool.CallCount);
             Assert.Equal(2, handler.RequestBodies.Count);
+            using var firstRequest = JsonDocument.Parse(handler.RequestBodies[0]);
+            Assert.Equal("llama3.2", firstRequest.RootElement.GetProperty("model").GetString());
             Assert.Contains("\"record_observation\"", handler.RequestBodies[0], StringComparison.Ordinal);
             Assert.Contains("\"read_observation\"", handler.RequestBodies[0], StringComparison.Ordinal);
             Assert.Contains("\"role\":\"tool\"", handler.RequestBodies[1], StringComparison.Ordinal);

--- a/src/OpenClaw.Tests/DesktopFirstSuccessContractTests.cs
+++ b/src/OpenClaw.Tests/DesktopFirstSuccessContractTests.cs
@@ -55,7 +55,8 @@ public sealed class DesktopFirstSuccessContractTests
                 settings.SetupModelPreset);
             var profile = Assert.Single(config.Models.Profiles);
             Assert.Equal("ollama-agentic", profile.PresetId);
-            var capabilities = Assert.NotNull(profile.Capabilities);
+            Assert.NotNull(profile.Capabilities);
+            var capabilities = profile.Capabilities!;
             Assert.True(capabilities.SupportsTools);
             Assert.False(capabilities.SupportsParallelToolCalls);
 

--- a/src/OpenClaw.Tests/DesktopFirstSuccessContractTests.cs
+++ b/src/OpenClaw.Tests/DesktopFirstSuccessContractTests.cs
@@ -55,8 +55,9 @@ public sealed class DesktopFirstSuccessContractTests
                 settings.SetupModelPreset);
             var profile = Assert.Single(config.Models.Profiles);
             Assert.Equal("ollama-agentic", profile.PresetId);
-            Assert.True(profile.Capabilities.SupportsTools);
-            Assert.False(profile.Capabilities.SupportsParallelToolCalls);
+            var capabilities = Assert.NotNull(profile.Capabilities);
+            Assert.True(capabilities.SupportsTools);
+            Assert.False(capabilities.SupportsParallelToolCalls);
 
             using var registry = new ConfiguredModelProfileRegistry(config, NullLogger<ConfiguredModelProfileRegistry>.Instance);
             registry.SetDefaultProfileId();

--- a/src/OpenClaw.Tests/DocsConsistencyTests.cs
+++ b/src/OpenClaw.Tests/DocsConsistencyTests.cs
@@ -93,6 +93,38 @@ public sealed class DocsConsistencyTests
         Assert.Contains("## Known Limitations", compatibility, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void BrandingSurfaces_DefineAgentQiCompanionWithoutRenamingRuntimeIdentity()
+    {
+        var root = FindRepositoryRoot();
+        var paths = new[]
+        {
+            "README.md",
+            "docs/ARCHITECTURE_BOUNDARIES.md",
+            "src/OpenClaw.Companion/Assets/BRANDING.md",
+            "src/OpenClaw.Companion/OpenClaw.Companion.csproj",
+            "src/OpenClaw.Companion/App.axaml",
+            "src/OpenClaw.Companion/Views/MainWindow.axaml",
+            "src/OpenClaw.Companion/Services/DesktopNotifier.cs"
+        };
+        var surfaces = paths.ToDictionary(
+            path => path,
+            path => File.ReadAllText(Path.Combine(root, path)),
+            StringComparer.Ordinal);
+
+        Assert.All(surfaces, surface =>
+        {
+            Assert.Contains("AgentQi Companion", surface.Value, StringComparison.Ordinal);
+            Assert.DoesNotContain("AgentQi [OpenClaw.NET]", surface.Value, StringComparison.Ordinal);
+        });
+        Assert.Contains("OpenClaw.NET** | Repository and runtime identity", surfaces["docs/ARCHITECTURE_BOUNDARIES.md"], StringComparison.Ordinal);
+        Assert.Contains("AgentQi** | Documentation and ecosystem umbrella", surfaces["docs/ARCHITECTURE_BOUNDARIES.md"], StringComparison.Ordinal);
+        Assert.Contains("AgentQiX** | Reserved likely future runtime identity", surfaces["docs/ARCHITECTURE_BOUNDARIES.md"], StringComparison.Ordinal);
+        Assert.Contains("GitHub release titles | **OpenClaw.NET**", surfaces["docs/ARCHITECTURE_BOUNDARIES.md"], StringComparison.Ordinal);
+        Assert.Contains("Desktop window chrome", surfaces["docs/ARCHITECTURE_BOUNDARIES.md"], StringComparison.Ordinal);
+        Assert.Contains("<Product>AgentQi Companion</Product>", surfaces["src/OpenClaw.Companion/OpenClaw.Companion.csproj"], StringComparison.Ordinal);
+    }
+
     private static string FindRepositoryRoot()
     {
         var current = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
## Summary

- standardize the desktop product name as **AgentQi Companion** while retaining **OpenClaw.NET** for the repository, runtime, packages, protocols, settings, and mixed-artifact GitHub releases
- keep **AgentQi** as the documentation/ecosystem umbrella and **AgentQiX** reserved
- add a release-blocking cross-layer contract covering the real Companion preset binding, shared preset catalog, sequential multi-tool selection, and an Ollama-compatible tool round trip
- exercise the same first-success path against the packaged CLI and gateway during the Linux release build
- reject a release tag when documentation still describes that version as future or unavailable, and correct the v0.3.0 availability notes

## Validation

- `python3 eng/verify-release-docs.py v0.3.0`
- `python3 -m py_compile eng/verify-release-docs.py eng/verify-desktop-first-success.py`
- release workflow parsed successfully as YAML
- `git diff --check`

The workspace does not include the .NET SDK or packaged binaries, so the new .NET contract test and packaged-runtime smoke are intentionally left to repository CI/release runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Branding**
  - The desktop app is now consistently branded as **AgentQi Companion** across the application, notifications, documentation, and release materials.

- **Documentation**
  - Documentation now identifies reliability, recovery, backup, token storage, and trajectory replay features as available in v0.3.0 and later.

- **Release Engineering**
  - Release validation now checks documentation for outdated availability or future-work descriptions before publishing.

- **Tests**
  - Added release checks covering Companion setup, preset persistence, sequential tool use, and Ollama-compatible agent interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->