### PR TITLE
Fix MCP failure propagation and add Nacos Router PoC foundation

### DIFF
--- a/docs/SITE_MAP.md
+++ b/docs/SITE_MAP.md
@@ -26,6 +26,8 @@ Use this map when turning the Markdown docs into a documentation website. It kee
 | Guides | OpenSquilla Meta-Skill Migration | [opensquilla-meta-skill-migration.md](opensquilla-meta-skill-migration.md) |
 | Guides | OpenSquilla Dynamic Turn Routing | [opensquilla-dynamic-turn-routing.md](opensquilla-dynamic-turn-routing.md) |
 | Guides | Dynamic Routing and Model Profiles | [dynamic-turn-routing-model-profiles.md](dynamic-turn-routing-model-profiles.md) |
+| Guides | Nacos MCP Router PoC | [nacos-mcp-router.md](nacos-mcp-router.md) |
+| Guides | Nacos MCP Router PoC (zh-CN) | [zh-CN/nacos-mcp-router.md](zh-CN/nacos-mcp-router.md) |
 | Guides | External CLI Connectors | [EXTERNAL_CLI_CONNECTORS.md](EXTERNAL_CLI_CONNECTORS.md) |
 | Guides | Fractal Memory | [FRACTAL_MEMORY.md](FRACTAL_MEMORY.md) |
 | Guides | Model Profiles | [MODEL_PROFILES.md](MODEL_PROFILES.md) |

--- a/docs/nacos-mcp-router.md
+++ b/docs/nacos-mcp-router.md
@@ -1,0 +1,131 @@
+# Nacos MCP Router PoC
+
+Status: **mock-verified integration foundation; live acceptance pending** for
+[#229](https://github.com/clawdotnet/openclaw.net/issues/229). This guide does not
+claim that the Nacos deployment, discovery quality, or model-token baseline has
+been validated. The resolver/schema/cache work in #230–#234 depends on that evidence.
+
+## Contract observations
+
+The reference is the upstream Python Router at commit
+[`0ee95f4f353d6f66184dafdb3e0ffd342c4edb09`](https://github.com/nacos-group/nacos-mcp-router-python/blob/0ee95f4f353d6f66184dafdb3e0ffd342c4edb09/src/nacos_mcp_router/router.py).
+These are source observations, **not a live deployment capture**:
+
+| Tool | Arguments | Returned text |
+| --- | --- | --- |
+| `search_mcp_server` | `task_description`, `key_words` (comma-separated string) | Prose containing a JSON object keyed by server name; entries have `name` and `description`, no score |
+| `add_mcp_server` | `mcp_server_name` | Prose containing a tool list with `name`, `description`, `inputSchema` |
+| `use_tool` | `mcp_server_name`, `mcp_tool_name`, `params` | String representation of downstream MCP content |
+
+Do not substitute `tool_name` for `mcp_tool_name`, assume search is a bare JSON
+array, fabricate scores, or assume every failure sets MCP `isError`. The Python
+Router returns some initialization/install/unhealthy/use failures as ordinary
+text. Such responses cannot safely drive generic protocol-level fallback without
+a Router-specific normalization contract. The mock suite distinguishes these
+plain-text results from explicit MCP protocol failures.
+
+The server ID `nacos-mcp-router` retains its hyphens in default tool names.
+Configure `toolNamePrefix` explicitly to obtain the underscore names below.
+
+## Opt-in configuration
+
+Keep Nacos and Router on the same host when Nacos binds only to loopback. Do not
+change an existing deployment's networking or authentication for this example.
+With credentials provided by your existing secret environment, start the approved
+Router version using the upstream transport spelling:
+
+```sh
+: "${NACOS_ADDR:?Set the existing Nacos address}"
+: "${NACOS_USERNAME:?Set your Nacos username}"
+: "${NACOS_PASSWORD:?Supply through your secret environment}"
+: "${NACOS_ROUTER_VERSION:?Pin the Router version tested against your deployment}"
+export TRANSPORT_TYPE=streamable_http
+uvx "nacos-mcp-router@${NACOS_ROUTER_VERSION}"
+```
+
+Set `NACOS_ROUTER_VERSION` to an explicitly validated package version, not an
+unverified moving `latest`. Inspect startup output for the actual endpoint.
+Merge this entry into `<storagePath>/mcp/mcp.json`; preserve existing servers:
+
+```json
+{
+  "enabled": true,
+  "servers": {
+    "nacos-mcp-router": {
+      "enabled": true,
+      "transport": "http",
+      "url": "http://127.0.0.1:8000/mcp",
+      "toolNamePrefix": "nacos_mcp_router_"
+    }
+  }
+}
+```
+
+Register a test server named `weather-mcp` exposing `get_weather` with required
+string argument `city` using the deployment's supported Nacos console/API. Verify
+its registration and `add_mcp_server` output before running the static example.
+The referenced Windows compose deployment and architecture document are not in
+this repository, so this guide deliberately does not invent administrator-init
+commands or a version-specific registration payload.
+
+The examples stay under `examples/skills/` and are not bundled or enabled by
+default. Copy the two example directories into an isolated gateway workspace's
+`skills/` directory, or add their parent as an extra skills directory in that
+temporary configuration. Invoke `meta_invoke` with:
+
+```json
+{"skill":"nacos-router-weather","input":"Oslo"}
+```
+
+The static example binds on each invocation, then calls `use_tool`; it adds no
+LLM turn. Its final output is the raw tool result. The exploration example lets
+the model discover/bind/use and serves as a separate token baseline. Confirm the
+registered tool names rather than assuming the mock's weather schema exists.
+
+## Reproducible local checks
+
+From the repository root:
+
+```sh
+dotnet test src/OpenClaw.Tests -c Release --filter FullyQualifiedName~NacosRouterIntegrationTests
+```
+
+The tests start a real in-process HTTP MCP endpoint. They check exact three-tool
+registration, source-shaped discovery text, sequential bind/use execution in both
+runtimes, repeated execution without adding backend tools, and protocol-error
+fallback. They use no external credentials, model calls, Nacos server, or Docker.
+
+For a provisioned Router with a registered weather server:
+
+```sh
+export OPENCLAW_NACOS_LIVE=1
+export OPENCLAW_NACOS_ROUTER_URL=http://127.0.0.1:8000/mcp
+dotnet test src/OpenClaw.Tests -c Release --filter FullyQualifiedName~LiveRouter
+```
+
+Unset `OPENCLAW_NACOS_LIVE` for normal CI; the live check is skipped.
+
+## Remaining live acceptance and downstream decisions
+
+Before closing #229 or proceeding with the dependent runtime changes:
+
+1. Capture the real three tool schemas, success/error responses, and Router
+   package version from the intended Nacos 3.2.4 deployment. Redact credentials.
+2. Record the actual weather-server registration payload and reproducible startup
+   commands from that deployment; the issue's Windows path is not portable.
+3. Run both examples five times with the same city, model, fresh session, and
+   configuration. Read actual session input/output usage; take the median of the
+   five per-run totals. Record discovery quality separately. Do not use invented
+   fixture token counts as a model measurement.
+4. Decide how resolver results get ranking/version metadata (upstream search
+   provides neither score nor version), and how prose failures become typed
+   failures before implementing fallback, retries, caching, or replay.
+
+| Measurement | Static binding | Model-driven exploration |
+| --- | --- | --- |
+| Live recall / selected server | Not measured | Not measured |
+| Median input + output tokens (5 runs) | Not measured | Not measured |
+| Router version / deployment | Not provided | Not provided |
+
+No cache, capability slots, retry policy, or binding replay is implemented by this
+PoC. Those remain separately tracked by #230–#234.

--- a/docs/zh-CN/nacos-mcp-router.md
+++ b/docs/zh-CN/nacos-mcp-router.md
@@ -1,0 +1,45 @@
+# Nacos MCP Router 概念验证
+
+状态：**已提供可复现 mock 集成基础；真实部署验收尚未完成**。对应
+[#229](https://github.com/clawdotnet/openclaw.net/issues/229)，完整配置和命令见
+[英文指南](../nacos-mcp-router.md)。没有宣称已验证真实召回率或模型 token 基线。
+
+## 已确认的契约差异
+
+依据上游 Python Router 固定提交 `0ee95f4f353d6f66184dafdb3e0ffd342c4edb09` 的源码：
+
+- search 参数是 `task_description` 和逗号分隔字符串 `key_words`。
+- use 参数是 `mcp_server_name`、`mcp_tool_name`、`params`，不是 `tool_name`。
+- search 返回嵌有 JSON 对象的说明文字，没有 score/version 字段。
+- 部分安装、健康检查、执行错误只是普通文本，不设置 MCP `isError`。
+- server ID 中的连字符会保留。显式设置 `toolNamePrefix: nacos_mcp_router_`
+  才能保证示例中的三个下划线工具名。
+
+这些是源码观察，不是假称的真实端点抓包。协议级失败与普通错误文本必须区分；
+后续 Resolver 需要定义可靠的解析、排序、版本约束及错误归一化契约。
+
+## 验证范围
+
+`examples/skills/nacos-router-weather` 使用 bind → query 的静态 DAG，并直接返回
+工具结果。`nacos-router-weather-explore` 提供模型驱动的 search → add → use 基线。
+示例不进入生产技能索引，需在独立测试 workspace 手动启用。
+
+运行 mock 测试：
+
+```sh
+dotnet test src/OpenClaw.Tests -c Release --filter FullyQualifiedName~NacosRouterIntegrationTests
+```
+
+已有真实 Router 和 weather-mcp 注册后，可设置 `OPENCLAW_NACOS_LIVE=1`、
+`OPENCLAW_NACOS_ROUTER_URL`，运行 `FullyQualifiedName~LiveRouter` 筛选器。
+未设置时跳过 live 测试，普通 CI 不依赖外部服务。
+
+## 尚未具备的验收材料
+
+Issue 引用的 Windows compose 部署与架构文档不在仓库中。必须补充真实 Router
+版本、三个工具的参数及成功/错误响应、注册 payload 和可复制的启动命令。
+使用同一模型、输入与配置，对两个示例各执行五次，记录真实 session usage 的
+input+output 总和中位数，并单独记录召回质量。目前这两组数据均未测量。
+
+因此 #229 仍未全部完成，#230–#234 的依赖验收仍待完成；不能把 mock 数据当成
+真实 token 基线，也不能凭空补全搜索分数、版本信息或错误语义。

--- a/examples/skills/nacos-router-weather-explore/SKILL.md
+++ b/examples/skills/nacos-router-weather-explore/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: nacos-router-weather-explore
+description: "Opt-in model-driven Nacos Router weather baseline."
+kind: standard
+always: false
+triggers: ["explore nacos weather"]
+---
+For the input city, call `nacos_mcp_router_search_mcp_server` with
+`task_description` and `key_words` (a comma-separated string). Select an appropriate
+server from the actual returned text. Call `nacos_mcp_router_add_mcp_server` with
+`mcp_server_name`, inspect its actual tool list, then call
+`nacos_mcp_router_use_tool` with `mcp_server_name`, `mcp_tool_name`, and `params`.
+Treat Router initialization, missing-server, unhealthy-server, and failed-install
+messages as failures even when the MCP response is not marked as an error.
+Report a failure rather than inventing weather. Summarize successful weather data.

--- a/examples/skills/nacos-router-weather/SKILL.md
+++ b/examples/skills/nacos-router-weather/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: nacos-router-weather
+description: "Opt-in Nacos Router weather PoC; requires a registered weather-mcp server."
+kind: meta
+always: false
+final_text_mode: "step:query"
+triggers: ["nacos weather"]
+composition:
+  steps:
+    - id: bind
+      kind: tool_call
+      tool: nacos_mcp_router_add_mcp_server
+      tool_args:
+        mcp_server_name: weather-mcp
+    - id: query
+      kind: tool_call
+      tool: nacos_mcp_router_use_tool
+      depends_on: [bind]
+      tool_args:
+        mcp_server_name: weather-mcp
+        mcp_tool_name: get_weather
+        params:
+          city: "{{ input }}"
+      on_failure: fallback_notice
+    - id: fallback_notice
+      kind: tool_call
+      tool: emit_text
+      tool_args:
+        text: "weather-mcp unavailable; check Nacos registration and Router logs."
+---
+This is a static, opt-in contract fixture. Register `weather-mcp` with a
+`get_weather(city)` tool before running it. The final output is the tool result;
+no model call is needed for this deterministic path. Router prose errors are
+not MCP protocol failures: see docs/nacos-mcp-router.md before live use.

--- a/src/OpenClaw.Agent/Tools/McpNativeTool.cs
+++ b/src/OpenClaw.Agent/Tools/McpNativeTool.cs
@@ -65,7 +65,13 @@ public sealed class McpNativeTool(
 
             var text = FormatResponseContent(response, suppressStructuredContent);
             var isError = response.IsError ?? false;
+            if (isError && context is not null)
+                throw new ToolOutcomeException($"Error: {text}", "failed", "mcp_tool_error", text);
             return isError ? $"Error: {text}" : text;
+        }
+        catch (ToolOutcomeException)
+        {
+            throw;
         }
         catch (JsonException ex)
         {

--- a/src/OpenClaw.Tests/FakeNacosRouterMcpTools.cs
+++ b/src/OpenClaw.Tests/FakeNacosRouterMcpTools.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace OpenClaw.Tests;
+
+public sealed class NacosRouterFixtureState
+{
+    public List<string> Calls { get; } = [];
+    public bool FailUse { get; set; }
+    public bool PlainTextFailure { get; set; }
+}
+
+// Parameters and prose envelopes follow the pinned upstream Python Router.
+// Scores are deliberately absent: upstream search does not supply them.
+[McpServerToolType]
+public sealed class FakeNacosRouterMcpTools(NacosRouterFixtureState state)
+{
+    [McpServerTool(Name = "search_mcp_server", ReadOnly = true), Description("Search by task and comma-separated keywords.")]
+    public string Search(string task_description, string key_words)
+    {
+        state.Calls.Add("search");
+        var candidates = Enumerable.Range(0, 5).ToDictionary(
+            i => i == 0 ? "weather-mcp" : $"candidate-{i}",
+            i => new { name = i == 0 ? "weather-mcp" : $"candidate-{i}", description = "weather city" });
+        return "### 1. 当前可用的mcp server列表为：" + JsonSerializer.Serialize(candidates)
+            + "\n### 2. 从当前可用的mcp server列表中选择你需要的mcp server调add_mcp_server工具安装mcp server";
+    }
+
+    [McpServerTool(Name = "add_mcp_server"), Description("Bind a registered server.")]
+    public string Add(string mcp_server_name)
+    {
+        state.Calls.Add("add:" + mcp_server_name);
+        return "1. " + mcp_server_name + "安装完成, tool 列表为: "
+            + "[{\"name\":\"get_weather\",\"description\":\"weather city\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}]";
+    }
+
+    [McpServerTool(Name = "use_tool"), Description("Proxy an installed tool.")]
+    public CallToolResult Use(string mcp_server_name, string mcp_tool_name, Dictionary<string, JsonElement> @params)
+    {
+        state.Calls.Add("use:" + mcp_server_name + ":" + mcp_tool_name);
+        var invalid = mcp_server_name != "weather-mcp" || mcp_tool_name != "get_weather";
+        var failed = state.FailUse || invalid;
+        var text = failed ? "failed to use tool: " + mcp_tool_name : "Weather for " + @params["city"].GetString() + ": sunny";
+        return new CallToolResult { IsError = failed && !state.PlainTextFailure, Content = [new TextContentBlock { Text = text }] };
+    }
+}

--- a/src/OpenClaw.Tests/NacosRouterIntegrationTests.cs
+++ b/src/OpenClaw.Tests/NacosRouterIntegrationTests.cs
@@ -1,0 +1,151 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Server;
+using NSubstitute;
+using OpenClaw.Agent;
+using OpenClaw.Agent.Plugins;
+using OpenClaw.Agent.Tools;
+using OpenClaw.Core.Abstractions;
+using OpenClaw.Core.Memory;
+using OpenClaw.Core.Models;
+using OpenClaw.Core.Observability;
+using OpenClaw.Core.Plugins;
+using OpenClaw.Core.Skills;
+using OpenClaw.MicrosoftAgentFrameworkAdapter;
+using Xunit;
+
+namespace OpenClaw.Tests;
+
+[Collection(EnvironmentVariableCollection.Name)]
+public sealed class NacosRouterIntegrationTests
+{
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, true, false)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, true)]
+    public async Task StaticDemo_UsesOnlyThreeRouterTools_AndHandlesProtocolFailures(bool maf, bool fail, bool plainText)
+    {
+        var state = new NacosRouterFixtureState { FailUse = fail, PlainTextFailure = plainText };
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Services.AddSingleton(state);
+        builder.Services.AddMcpServer().WithHttpTransport(options => options.Stateless = true).WithTools<FakeNacosRouterMcpTools>();
+        await using var server = builder.Build();
+        server.MapMcp("/mcp");
+        await server.StartAsync(TestContext.Current.CancellationToken);
+        await using var registry = new McpServerToolRegistry(new McpPluginsConfig(), NullLogger<McpServerToolRegistry>.Instance);
+        var config = ServerConfig(server.Urls.Single() + "/mcp");
+        var reload = await registry.ReloadWorkspaceServersAsync(config, TestContext.Current.CancellationToken);
+        Assert.Equal(new[] { "nacos_mcp_router_add_mcp_server", "nacos_mcp_router_search_mcp_server", "nacos_mcp_router_use_tool" }, reload.AddedTools.Select(t => t.Name).Order().ToArray());
+        var search = await reload.AddedTools.Single(t => t.Name.EndsWith("_search_mcp_server")).ExecuteAsync("""{"task_description":"weather city","key_words":"weather,city"}""", TestContext.Current.CancellationToken);
+        Assert.Contains("weather-mcp", search);
+        Assert.DoesNotContain("score", search);
+        if (fail)
+        {
+            var direct = await reload.AddedTools.Single(t => t.Name.EndsWith("_use_tool")).ExecuteAsync(
+                """{"mcp_server_name":"weather-mcp","mcp_tool_name":"get_weather","params":{"city":"Oslo"}}""", TestContext.Current.CancellationToken);
+            Assert.Equal(plainText ? "failed to use tool: get_weather" : "Error: failed to use tool: get_weather", direct);
+        }
+        state.Calls.Clear();
+        var skill = LoadDemo();
+        var root = Path.Join(Path.GetTempPath(), "nacos-poc-tests", Guid.NewGuid().ToString("N"));
+        using var memory = new FileMemoryStore(root, 4);
+        using var services = new ServiceCollection().BuildServiceProvider();
+        var chat = Substitute.For<IChatClient>();
+        var execution = Substitute.For<ILlmExecutionService>();
+        var tools = reload.AddedTools.Append<ITool>(new EmitTextTool()).ToArray();
+        var gatewayConfig = new GatewayConfig { Memory = new MemoryConfig { StoragePath = root } };
+        object runtime;
+        if (maf)
+        {
+            var options = new MafOptions();
+            runtime = new MafAgentRuntime(new AgentRuntimeFactoryContext
+            {
+                Services = services, Config = gatewayConfig,
+                RuntimeState = new GatewayRuntimeState { RequestedMode = "jit", EffectiveMode = GatewayRuntimeMode.Jit, DynamicCodeSupported = true },
+                ChatClient = chat, Tools = tools, MemoryStore = memory,
+                RuntimeMetrics = new RuntimeMetrics(), ProviderUsage = new ProviderUsageTracker(),
+                LlmExecutionService = execution, Skills = [skill], SkillsConfig = new SkillsConfig(),
+                WorkspacePath = null, PluginSkillDirs = [], Logger = NullLogger.Instance,
+                Hooks = [], RequireToolApproval = false, ApprovalRequiredTools = []
+            }, options, new MafAgentFactory(Options.Create(options), NullLoggerFactory.Instance, services),
+                new MafSessionStateStore(gatewayConfig, Options.Create(options), NullLogger<MafSessionStateStore>.Instance),
+                new MafTelemetryAdapter(), NullLogger<MafAgentRuntime>.Instance);
+        }
+        else runtime = new AgentRuntime(chat, tools, memory, gatewayConfig.Llm, maxHistoryTurns: 5, skills: [skill]);
+        try
+        {
+            for (var i = 0; i < 2; i++)
+            {
+                var session = new Session { Id = "nacos-poc-" + i, SenderId = "test", ChannelId = "test" };
+                var method = runtime.GetType().GetMethod("ExecuteMetaSkillAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+                var result = await (Task<string>)method.Invoke(runtime, [session, skill.Name, "Oslo", TestContext.Current.CancellationToken])!;
+                Assert.Equal(fail ? (plainText ? "failed to use tool: get_weather" : "weather-mcp unavailable; check Nacos registration and Router logs.") : "Weather for Oslo: sunny", result);
+                var run = Assert.Single(session.MetaRunHistory);
+                var query = Assert.Single(run.StepResults, step => step.Id == "query");
+                if (fail && !plainText) Assert.Equal("mcp_tool_error", query.FailureCode);
+                else Assert.Equal("completed", query.Status);
+            }
+            Assert.Equal(new[] { "add:weather-mcp", "use:weather-mcp:get_weather", "add:weather-mcp", "use:weather-mcp:get_weather" }, state.Calls);
+            Assert.Empty(chat.ReceivedCalls());
+            Assert.Empty(execution.ReceivedCalls());
+            var unchanged = await registry.ReloadWorkspaceServersAsync(config, TestContext.Current.CancellationToken);
+            Assert.Empty(unchanged.AddedTools);
+            Assert.Empty(unchanged.RemovedToolNames);
+        }
+        finally
+        {
+            if (runtime is IAsyncDisposable asyncDisposable) await asyncDisposable.DisposeAsync();
+            else if (runtime is IDisposable disposable) disposable.Dispose();
+            memory.Dispose();
+            if (Directory.Exists(root)) Directory.Delete(root, true);
+        }
+    }
+
+    public static bool LiveEnabled => Environment.GetEnvironmentVariable("OPENCLAW_NACOS_LIVE") == "1";
+
+    [Fact(Skip = "Set OPENCLAW_NACOS_LIVE=1 and OPENCLAW_NACOS_ROUTER_URL for a provisioned Router.", SkipUnless = nameof(LiveEnabled))]
+    public async Task LiveRouter_SearchFindsRegisteredWeatherServer()
+    {
+        var url = Environment.GetEnvironmentVariable("OPENCLAW_NACOS_ROUTER_URL");
+        Assert.True(Uri.TryCreate(url, UriKind.Absolute, out var endpoint) && endpoint.Scheme is "http" or "https",
+            "OPENCLAW_NACOS_ROUTER_URL must be an HTTP(S) MCP endpoint.");
+        await using var registry = new McpServerToolRegistry(new McpPluginsConfig(), NullLogger<McpServerToolRegistry>.Instance);
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(30));
+        var reload = await registry.ReloadWorkspaceServersAsync(ServerConfig(url!), timeout.Token);
+        var search = Assert.Single(reload.AddedTools, tool => tool.Name == "nacos_mcp_router_search_mcp_server");
+        var result = await search.ExecuteAsync("""{"task_description":"weather city","key_words":"weather,city"}""", timeout.Token);
+        Assert.Contains("weather-mcp", result);
+        Assert.DoesNotContain("Error:", result);
+    }
+
+    private static Dictionary<string, McpServerConfig> ServerConfig(string url) => new()
+    {
+        ["nacos-mcp-router"] = new McpServerConfig { Enabled = true, Transport = "http", Url = url, ToolNamePrefix = "nacos_mcp_router_" }
+    };
+
+    private static SkillDefinition LoadDemo()
+    {
+        var root = new DirectoryInfo(AppContext.BaseDirectory);
+        while (root is not null && !File.Exists(Path.Join(root.FullName, "OpenClaw.Net.slnx"))) root = root.Parent;
+        Assert.NotNull(root);
+        var skills = SkillLoader.LoadAll(new SkillsConfig
+        {
+            Load = new SkillLoadConfig { IncludeBundled = false, IncludeManaged = false, IncludeWorkspace = false,
+                ExtraDirs = [Path.Join(root.FullName, "examples", "skills", "nacos-router-weather"),
+                    Path.Join(root.FullName, "examples", "skills", "nacos-router-weather-explore")] }
+        }, null, NullLogger.Instance);
+        Assert.Equal(SkillKind.Standard, Assert.Single(skills, skill => skill.Name == "nacos-router-weather-explore").Kind);
+        return Assert.Single(skills, skill => skill.Name == "nacos-router-weather");
+    }
+}


### PR DESCRIPTION
MCP responses with `isError=true` were returned as ordinary strings to contextual tool execution. Both MetaSkill runtimes recorded those steps as completed, so `on_failure` did not run. Propagate a structured `mcp_tool_error` outcome while preserving the existing string response for direct tool callers.

Related to #229 and #228. Adds opt-in static and model-driven Nacos Router examples, bilingual setup/contract notes, an HTTP MCP fixture covering both runtimes, and an explicitly opt-in live discovery check. The fixture follows the pinned upstream Python source's actual argument names and response shapes; it also verifies that ordinary prose errors are not misclassified as protocol errors.

Validation: 2,665 tests passed in the full local test suite; the live test was skipped. All 29 focused MCP checks also passed after the final example-loading and direct-caller compatibility assertions. The regression reproduced failures in both runtimes before the fix. After updating with merged #227, all GitHub CI checks passed on cd6dceb, including build/integration tests, compatibility smoke, JIT/NativeAOT packaging, and the macOS linker probe. The combined local desktop/MCP filter passed 33 tests with the live check skipped.

This is the mock-tested PoC foundation, not completion of #229. The referenced architecture document and Windows Nacos deployment are unavailable here. Real registration instructions, deployed tool captures, recall measurements, and five-run model token medians remain pending. #230–#234 remain open: their resolver/schema/cache/retry/replay contracts depend on that evidence; upstream search currently supplies neither score nor version.
